### PR TITLE
refactor: hierarchical react-query key factory + global fetching indicator

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Navigate,
   Outlet,
@@ -7,11 +7,14 @@ import {
   useNavigate,
   useParams,
 } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { ClusterRail } from "./components/shell/ClusterRail";
 import { Brand } from "./components/shell/Brand";
+import { GlobalFetchingBar } from "./components/shell/GlobalFetchingBar";
 import { Sidebar } from "./components/shell/Sidebar";
 import { ErrorState, NoClustersState } from "./components/table/states";
 import { useClusters } from "./hooks/useClusters";
+import { queryKeys } from "./lib/queryKeys";
 import { useTheme } from "./hooks/useTheme";
 import { OverviewPage } from "./pages/OverviewPage";
 import { ConfigMapsPage } from "./pages/ConfigMapsPage";
@@ -164,6 +167,7 @@ function AppShell() {
         </div>
       </div>
       <main className="flex min-w-0 flex-1 flex-col bg-bg">
+        <GlobalFetchingBar />
         <Outlet />
       </main>
     </div>
@@ -176,6 +180,21 @@ function WithCluster<P extends { cluster: string }>({
   Page: React.ComponentType<P>;
 }) {
   const { cluster } = useParams<{ cluster: string }>();
+  const qc = useQueryClient();
+  const prevCluster = useRef<string | undefined>(undefined);
+
+  // Single-cluster-at-a-time UX: when the route's cluster id changes,
+  // evict the prior cluster's subtree so its stale entries don't sit
+  // in the cache (and don't trigger ghost background refetches).
+  useEffect(() => {
+    if (cluster && prevCluster.current && prevCluster.current !== cluster) {
+      qc.removeQueries({
+        queryKey: queryKeys.cluster(prevCluster.current).all,
+      });
+    }
+    prevCluster.current = cluster;
+  }, [cluster, qc]);
+
   if (!cluster) return null;
   return <Page {...({ cluster } as unknown as P)} />;
 }

--- a/web/src/components/detail/yaml/DriftDiffOverlay.tsx
+++ b/web/src/components/detail/yaml/DriftDiffOverlay.tsx
@@ -8,13 +8,13 @@
 // via a one-shot useQuery with its own key so we don't disturb the
 // editor's cached pristine flow.
 
-import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api, type YamlKind, type ClusterScopedKind } from "../../../lib/api";
 import { cn } from "../../../lib/cn";
 import { queryKeys } from "../../../lib/queryKeys";
 import { stripForEdit } from "../../../lib/stripForEdit";
 import { DetailLoading, DetailError } from "../states";
+import { Modal } from "../../ui/Modal";
 import { InlineDiff } from "./InlineDiff";
 
 const CLUSTER_SCOPED_KINDS = new Set<ClusterScopedKind>([
@@ -47,18 +47,6 @@ export function DriftDiffOverlay({
   onClose,
   onReload,
 }: DriftDiffOverlayProps) {
-  // Esc to close.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
   // Independent fetch — separate cache key so we don't compete with
   // the editor's pristine-flowing yamlQuery. staleTime: 0 + a fresh
   // mount on every open guarantees we see latest server state.
@@ -76,16 +64,15 @@ export function DriftDiffOverlay({
   const freshStripped = freshQuery.data ? stripForEdit(freshQuery.data) : null;
 
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4 py-6"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="drift-diff-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="drift-diff-title"
+      size="lg"
+      z={60}
+      panelClassName="flex h-full max-h-[820px] flex-col overflow-hidden"
     >
-      <div className="flex h-full max-h-[820px] w-full max-w-[1100px] flex-col overflow-hidden rounded-md border border-border-strong bg-surface shadow-2xl">
+      <>
         {/* Header */}
         <header className="shrink-0 border-b border-border bg-surface px-5 py-3">
           <div className="font-mono text-[10px] uppercase tracking-[0.10em] text-yellow-700 dark:text-yellow-300">
@@ -143,7 +130,7 @@ export function DriftDiffOverlay({
             reload from cluster
           </button>
         </footer>
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }

--- a/web/src/components/detail/yaml/DriftDiffOverlay.tsx
+++ b/web/src/components/detail/yaml/DriftDiffOverlay.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api, type YamlKind, type ClusterScopedKind } from "../../../lib/api";
 import { cn } from "../../../lib/cn";
+import { queryKeys } from "../../../lib/queryKeys";
 import { stripForEdit } from "../../../lib/stripForEdit";
 import { DetailLoading, DetailError } from "../states";
 import { InlineDiff } from "./InlineDiff";
@@ -62,7 +63,7 @@ export function DriftDiffOverlay({
   // the editor's pristine-flowing yamlQuery. staleTime: 0 + a fresh
   // mount on every open guarantees we see latest server state.
   const freshQuery = useQuery<string>({
-    queryKey: ["yaml-drift-overlay", cluster, yamlKind, namespace ?? "", name],
+    queryKey: queryKeys.cluster(cluster).kind(yamlKind).yamlDrift(namespace ?? "", name),
     queryFn: ({ signal }) =>
       CLUSTER_SCOPED_KINDS.has(yamlKind as ClusterScopedKind)
         ? api.clusterScopedYaml(cluster, yamlKind as ClusterScopedKind, name, signal)

--- a/web/src/components/detail/yaml/TakeoverDialog.tsx
+++ b/web/src/components/detail/yaml/TakeoverDialog.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "../../../lib/cn";
 import { classifyManager } from "../../../lib/managers";
+import { Modal } from "../../ui/Modal";
 
 interface TakeoverDialogProps {
   fields: Array<{ path: string; manager: string }>;
@@ -34,18 +35,6 @@ export function TakeoverDialog({ fields, onCancel, onConfirm }: TakeoverDialogPr
     const t = setTimeout(() => inputRef.current?.focus(), 50);
     return () => clearTimeout(t);
   }, []);
-
-  // Esc to cancel. Doesn't catch when typing — typing flows through.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
 
   // Decide whether to require the typing gate. Skip if every field
   // being seized is owned by a HUMAN-category manager (kubectl-edit,
@@ -67,16 +56,8 @@ export function TakeoverDialog({ fields, onCancel, onConfirm }: TakeoverDialogPr
   const ok = !requireGate || typed.trim().toLowerCase() === "force";
 
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="takeover-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
-      }}
-    >
-      <div className="w-full max-w-[560px] rounded-md border border-border-strong bg-surface px-6 py-5 shadow-2xl">
+    <Modal open onClose={onCancel} labelledBy="takeover-title" size="md" z={60}>
+      <div className="px-6 py-5">
         <div className="font-mono text-[10px] uppercase tracking-[0.10em] text-red">
           take ownership · deliberate action
         </div>
@@ -179,6 +160,6 @@ export function TakeoverDialog({ fields, onCancel, onConfirm }: TakeoverDialogPr
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/web/src/components/detail/yaml/YamlEditor.tsx
+++ b/web/src/components/detail/yaml/YamlEditor.tsx
@@ -57,6 +57,7 @@ import {
 } from "../../../lib/monacoSetup";
 import { useOpenAPISchema, useResourceMeta, useYaml } from "../../../hooks/useResource";
 import { usePublishEditorDirty } from "../../../hooks/useEditorDirty";
+import { queryKeys } from "../../../lib/queryKeys";
 import {
   buildMinimalSSA,
   computeOps,
@@ -220,6 +221,7 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
   // (configured in useResourceMeta).
   const metaQuery = useResourceMeta(
     cluster,
+    yamlKind,
     {
       group: resource.group,
       version: resource.version,
@@ -286,7 +288,10 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPristineMeta(metaQuery.data);
     qc.invalidateQueries({
-      queryKey: ["yaml", cluster, yamlKind, resource.namespace ?? "", resource.name],
+      queryKey: queryKeys
+        .cluster(cluster)
+        .kind(yamlKind)
+        .yaml(resource.namespace ?? "", resource.name),
     });
   }, [drift, dirty, metaQuery.data, qc, cluster, yamlKind, resource.namespace, resource.name]);
 
@@ -310,7 +315,10 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
     if (metaQuery.data) setPristineMeta(metaQuery.data);
     setDismissedAtRV(null);
     qc.invalidateQueries({
-      queryKey: ["yaml", cluster, yamlKind, resource.namespace ?? "", resource.name],
+      queryKey: queryKeys
+        .cluster(cluster)
+        .kind(yamlKind)
+        .yaml(resource.namespace ?? "", resource.name),
     });
   }, [
     dirty,
@@ -683,29 +691,19 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
         await api.applyResource({ ...args, dryRun: false, force }, ac.signal);
         setApplyState({ kind: "success" });
 
-        // Invalidate caches so list/detail/events/yaml/meta all refetch.
-        qc.invalidateQueries({ queryKey: [yamlKind] });
-        qc.invalidateQueries({
-          queryKey: ["yaml", cluster, yamlKind, resource.namespace ?? "", resource.name],
+        // Single hierarchical prefix sweeps list + detail + yaml +
+        // events + meta + metrics for this kind. Awaited so the
+        // post-apply refetch lands before the editor unmounts —
+        // YamlReadView then opens to fresh data without the prior
+        // 400ms race-mitigation timeout.
+        await qc.invalidateQueries({
+          queryKey: queryKeys.cluster(cluster).kind(yamlKind).all,
         });
-        qc.invalidateQueries({
-          queryKey: [`${singularize(yamlKind)}-detail`, cluster, resource.namespace ?? "", resource.name],
-        });
-        qc.invalidateQueries({
-          queryKey: ["events", cluster, yamlKind, resource.namespace ?? "", resource.name],
-        });
-        qc.invalidateQueries({
-          queryKey: ["meta", cluster, resource.group, resource.version, resource.resource, resource.namespace ?? "", resource.name],
-        });
-
-        // Drop ?edit=1 → unmount → YamlReadView takes over
-        setTimeout(() => {
-          setParams((prev) => {
-            const next = new URLSearchParams(prev);
-            next.delete("edit");
-            return next;
-          }, { replace: true });
-        }, 400);
+        setParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("edit");
+          return next;
+        }, { replace: true });
       } catch (e) {
         if (ac.signal.aborted) return;
         const apiErr = e instanceof ApiError ? e : null;
@@ -795,29 +793,17 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
       setApplyState({ kind: "applying" });
       await api.applyResource({ ...args, dryRun: false, force }, ac.signal);
       setApplyState({ kind: "success" });
-      qc.invalidateQueries({ queryKey: [yamlKind] });
-      qc.invalidateQueries({
-        queryKey: ["yaml", cluster, yamlKind, resource.namespace ?? "", resource.name],
-      });
-      qc.invalidateQueries({
-        queryKey: [`${singularize(yamlKind)}-detail`, cluster, resource.namespace ?? "", resource.name],
-      });
-      qc.invalidateQueries({
-        queryKey: ["events", cluster, yamlKind, resource.namespace ?? "", resource.name],
-      });
-      qc.invalidateQueries({
-        queryKey: ["meta", cluster, resource.group, resource.version, resource.resource, resource.namespace ?? "", resource.name],
+      await qc.invalidateQueries({
+        queryKey: queryKeys.cluster(cluster).kind(yamlKind).all,
       });
       setShowTakeover(false);
       setConflicts([]);
       setResolutions(new Map());
-      setTimeout(() => {
-        setParams((prev) => {
-          const next = new URLSearchParams(prev);
-          next.delete("edit");
-          return next;
-        }, { replace: true });
-      }, 400);
+      setParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("edit");
+        return next;
+      }, { replace: true });
     } catch (e) {
       if (ac.signal.aborted) return;
       const apiErr = e instanceof ApiError ? e : null;
@@ -1095,9 +1081,3 @@ function Editor({ cluster, yamlKind, resource, pristine }: EditorProps) {
   );
 }
 
-// Map plural → singular for invalidating *-detail cache keys on apply
-// success. Mirrors the convention in useResource.ts.
-function singularize(kind: string): string {
-  if (kind.endsWith("s")) return kind.slice(0, -1);
-  return kind;
-}

--- a/web/src/components/edit/DeleteResourceModal.tsx
+++ b/web/src/components/edit/DeleteResourceModal.tsx
@@ -1,5 +1,11 @@
 // DeleteResourceModal — type-the-name confirmation for destructive deletes.
 //
+// Presentational only as of Lane 2: the mutation lives in
+// useDeleteResource (web/src/hooks/mutations/useDeleteResource.ts), which
+// optimistically removes the row from the list cache before the DELETE
+// fires. This modal owns confirmation UX (type-the-name + cancel/run
+// buttons) and surfaces the hook's pending/error state.
+//
 // kubectl delete is a one-step verb; for a UI, type-the-name is the
 // industry-standard friction (GitHub repo delete, Stripe API key
 // revoke, etc.). It prevents the muscle-memory delete that operators
@@ -9,143 +15,103 @@
 // default. Foreground / Orphan are different verbs operationally and
 // will get their own UI when actually needed.
 
-import { useEffect, useState } from "react";
-import { ApiError, api } from "../../lib/api";
+import { useState } from "react";
 import type { ResourceRef } from "../../lib/api";
+import { Modal } from "../ui/Modal";
 
 interface DeleteResourceModalProps {
   resourceRef: ResourceRef;
+  pending: boolean;
+  error?: { status?: number; message: string } | null;
   onClose: () => void;
-  onDeleted?: () => void;
+  onConfirm: () => void;
 }
-
-type DeleteState =
-  | { kind: "idle" }
-  | { kind: "running" }
-  | { kind: "error"; message: string; status?: number };
 
 export function DeleteResourceModal({
   resourceRef,
+  pending,
+  error,
   onClose,
-  onDeleted,
+  onConfirm,
 }: DeleteResourceModalProps) {
   const [confirm, setConfirm] = useState("");
-  const [state, setState] = useState<DeleteState>({ kind: "idle" });
-
   const matches = confirm === resourceRef.name;
   const kindLabel = (resourceRef.kind ?? resourceRef.resource).toLowerCase();
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && state.kind !== "running") onClose();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose, state.kind]);
-
-  async function run() {
-    setState({ kind: "running" });
-    try {
-      await api.deleteResource({
-        cluster: resourceRef.cluster,
-        group: resourceRef.group,
-        version: resourceRef.version,
-        resource: resourceRef.resource,
-        namespace: resourceRef.namespace,
-        name: resourceRef.name,
-      });
-      onDeleted?.();
-      onClose();
-    } catch (err) {
-      const apiErr = err instanceof ApiError ? err : null;
-      setState({
-        kind: "error",
-        status: apiErr?.status,
-        message:
-          apiErr?.bodyText?.trim() ||
-          (err as Error)?.message ||
-          "delete failed",
-      });
-    }
-  }
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="delete-resource-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget && state.kind !== "running") onClose();
-      }}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="delete-resource-title"
+      size="sm"
+      dismissOnEsc={!pending}
+      dismissOnBackdrop={!pending}
     >
-      <div className="w-full max-w-md rounded-md border border-border-strong bg-surface shadow-2xl">
-        <div className="border-b border-border px-5 py-3 font-mono text-sm">
-          <span className="text-red">delete</span>{" "}
-          <span id="delete-resource-title" className="text-ink">
-            {kindLabel} {resourceRef.name}
-          </span>
-        </div>
-
-        <div className="space-y-4 px-5 py-4">
-          <p className="text-sm text-ink-muted">
-            this will delete{" "}
-            <span className="font-mono text-ink">{kindLabel}/{resourceRef.name}</span>
-            {resourceRef.namespace && (
-              <>
-                {" "}in namespace{" "}
-                <span className="font-mono text-ink">{resourceRef.namespace}</span>
-              </>
-            )}
-            . propagation is <span className="font-mono">background</span> —
-            owned objects will be deleted asynchronously.
-          </p>
-          <p className="text-sm text-ink-muted">
-            type{" "}
-            <span className="font-mono text-ink">{resourceRef.name}</span> to
-            confirm:
-          </p>
-          <input
-            type="text"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            disabled={state.kind === "running"}
-            autoFocus
-            className="w-full rounded-sm border border-border bg-bg px-3 py-2 font-mono text-sm text-ink outline-none focus:border-ink-muted"
-            placeholder={resourceRef.name}
-            spellCheck={false}
-            aria-label={`Type ${resourceRef.name} to confirm deletion`}
-          />
-
-          {state.kind === "error" && (
-            <div className="rounded-sm border border-red bg-red-soft px-3 py-2 font-mono text-xs text-red">
-              <div className="mb-1 font-semibold">
-                {state.status ? `error ${state.status}` : "error"}
-              </div>
-              <pre className="whitespace-pre-wrap">{state.message}</pre>
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={state.kind === "running"}
-            className="rounded-sm border border-border-strong px-3 py-1.5 font-mono text-sm text-ink-muted transition-colors hover:border-ink-muted hover:text-ink disabled:opacity-50"
-          >
-            cancel
-          </button>
-          <button
-            type="button"
-            onClick={run}
-            disabled={!matches || state.kind === "running"}
-            className="rounded-sm bg-red px-3 py-1.5 font-mono text-sm text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            {state.kind === "running" ? "deleting…" : "delete"}
-          </button>
-        </div>
+      <div className="border-b border-border px-5 py-3 font-mono text-sm">
+        <span className="text-red">delete</span>{" "}
+        <span id="delete-resource-title" className="text-ink">
+          {kindLabel} {resourceRef.name}
+        </span>
       </div>
-    </div>
+
+      <div className="space-y-4 px-5 py-4">
+        <p className="text-sm text-ink-muted">
+          this will delete{" "}
+          <span className="font-mono text-ink">{kindLabel}/{resourceRef.name}</span>
+          {resourceRef.namespace && (
+            <>
+              {" "}in namespace{" "}
+              <span className="font-mono text-ink">{resourceRef.namespace}</span>
+            </>
+          )}
+          . propagation is <span className="font-mono">background</span> —
+          owned objects will be deleted asynchronously.
+        </p>
+        <p className="text-sm text-ink-muted">
+          type{" "}
+          <span className="font-mono text-ink">{resourceRef.name}</span> to
+          confirm:
+        </p>
+        <input
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          disabled={pending}
+          autoFocus
+          className="w-full rounded-sm border border-border bg-bg px-3 py-2 font-mono text-sm text-ink outline-none focus:border-ink-muted"
+          placeholder={resourceRef.name}
+          spellCheck={false}
+          aria-label={`Type ${resourceRef.name} to confirm deletion`}
+        />
+
+        {error && (
+          <div className="rounded-sm border border-red bg-red-soft px-3 py-2 font-mono text-xs text-red">
+            <div className="mb-1 font-semibold">
+              {error.status ? `error ${error.status}` : "error"}
+            </div>
+            <pre className="whitespace-pre-wrap">{error.message}</pre>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={pending}
+          className="rounded-sm border border-border-strong px-3 py-1.5 font-mono text-sm text-ink-muted transition-colors hover:border-ink-muted hover:text-ink disabled:opacity-50"
+        >
+          cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={!matches || pending}
+          className="rounded-sm bg-red px-3 py-1.5 font-mono text-sm text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {pending ? "deleting…" : "delete"}
+        </button>
+      </div>
+    </Modal>
   );
 }

--- a/web/src/components/edit/EditLabelsModal.tsx
+++ b/web/src/components/edit/EditLabelsModal.tsx
@@ -1,0 +1,232 @@
+// EditLabelsModal — structured key/value editor for metadata.labels.
+// Replaces "drop into YAML to edit one label" with the primary
+// interaction Headlamp / Rancher operators expect. Validation is
+// inline (red border + chip) so a typo doesn't make a round trip.
+//
+// On submit we fire useEditLabels which optimistically writes the new
+// labels into the detail cache; MetaPills updates pre-roundtrip.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "../../lib/cn";
+import {
+  findDuplicateKeys,
+  validateLabelKey,
+  validateLabelValue,
+  type LabelRow,
+} from "../../lib/labels";
+import { Modal } from "../ui/Modal";
+
+interface EditLabelsModalProps {
+  title: string;
+  initialLabels: Record<string, string>;
+  onClose: () => void;
+  onSubmit: (labels: Record<string, string>) => void;
+}
+
+let rowIdCounter = 0;
+
+interface KeyedRow extends LabelRow {
+  id: number;
+}
+
+function fromMap(map: Record<string, string>): KeyedRow[] {
+  const entries = Object.entries(map);
+  if (entries.length === 0) {
+    return [{ id: ++rowIdCounter, key: "", value: "" }];
+  }
+  return entries.map(([key, value]) => ({
+    id: ++rowIdCounter,
+    key,
+    value,
+  }));
+}
+
+export function EditLabelsModal({
+  title,
+  initialLabels,
+  onClose,
+  onSubmit,
+}: EditLabelsModalProps) {
+  const [rows, setRows] = useState<KeyedRow[]>(() => fromMap(initialLabels));
+  const firstInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => firstInputRef.current?.focus(), 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  const dups = useMemo(() => findDuplicateKeys(rows), [rows]);
+
+  const errorsByRow = useMemo(() => {
+    return rows.map((r) => ({
+      key: validateLabelKey(r.key),
+      value: validateLabelValue(r.value),
+      duplicate: dups.has(r.key) && r.key.length > 0,
+    }));
+  }, [rows, dups]);
+
+  const hasErrors = errorsByRow.some(
+    (e) => e.key !== null || e.value !== null || e.duplicate,
+  );
+  const initialMap = useMemo(() => normalize(initialLabels), [initialLabels]);
+  const currentMap = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const r of rows) {
+      if (r.key.length > 0) out[r.key] = r.value;
+    }
+    return normalize(out);
+  }, [rows]);
+  const unchanged = currentMap === initialMap;
+
+  const submitDisabled = hasErrors || unchanged;
+
+  function update(id: number, patch: Partial<LabelRow>) {
+    setRows((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+    );
+  }
+
+  function remove(id: number) {
+    setRows((prev) => {
+      const next = prev.filter((r) => r.id !== id);
+      // Always keep at least one row visible so the affordance to add
+      // a label is consistent.
+      return next.length === 0
+        ? [{ id: ++rowIdCounter, key: "", value: "" }]
+        : next;
+    });
+  }
+
+  function add() {
+    setRows((prev) => [...prev, { id: ++rowIdCounter, key: "", value: "" }]);
+  }
+
+  function submit() {
+    if (submitDisabled) return;
+    const out: Record<string, string> = {};
+    for (const r of rows) {
+      if (r.key.length > 0) out[r.key] = r.value;
+    }
+    onSubmit(out);
+    onClose();
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} labelledBy="edit-labels-title" size="md">
+      <div className="border-b border-border px-5 py-3 font-mono text-sm">
+        <span className="text-ink-muted">edit labels</span>{" "}
+        <span id="edit-labels-title" className="text-ink">
+          {title}
+        </span>
+      </div>
+
+      <div
+        className="space-y-2 px-5 py-4"
+        onKeyDown={onKeyDown}
+      >
+        <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_28px] gap-2 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+          <div>key</div>
+          <div>value</div>
+          <div />
+        </div>
+        {rows.map((row, i) => {
+          const errs = errorsByRow[i];
+          const keyMsg = errs.key ?? (errs.duplicate ? "duplicate key" : null);
+          const valueMsg = errs.value;
+          return (
+            <div key={row.id}>
+              <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_28px] items-center gap-2">
+                <input
+                  ref={i === 0 ? firstInputRef : undefined}
+                  type="text"
+                  value={row.key}
+                  onChange={(e) => update(row.id, { key: e.target.value })}
+                  placeholder="app.kubernetes.io/name"
+                  spellCheck={false}
+                  autoComplete="off"
+                  className={cn(
+                    "min-w-0 rounded-sm border bg-bg px-2 py-1.5 font-mono text-[12.5px] text-ink outline-none",
+                    keyMsg ? "border-red" : "border-border",
+                    "focus:border-ink-muted",
+                  )}
+                  aria-invalid={Boolean(keyMsg)}
+                />
+                <input
+                  type="text"
+                  value={row.value}
+                  onChange={(e) => update(row.id, { value: e.target.value })}
+                  placeholder="value"
+                  spellCheck={false}
+                  autoComplete="off"
+                  className={cn(
+                    "min-w-0 rounded-sm border bg-bg px-2 py-1.5 font-mono text-[12.5px] text-ink outline-none",
+                    valueMsg ? "border-red" : "border-border",
+                    "focus:border-ink-muted",
+                  )}
+                  aria-invalid={Boolean(valueMsg)}
+                />
+                <button
+                  type="button"
+                  onClick={() => remove(row.id)}
+                  aria-label="remove label"
+                  className="rounded-sm border border-border-strong bg-surface px-2 py-1 font-mono text-[12px] text-ink-muted hover:text-ink"
+                >
+                  ×
+                </button>
+              </div>
+              {(keyMsg || valueMsg) && (
+                <div className="mt-1 grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_28px] gap-2 font-mono text-[10.5px] text-red">
+                  <div>{keyMsg ?? ""}</div>
+                  <div>{valueMsg ?? ""}</div>
+                  <div />
+                </div>
+              )}
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          onClick={add}
+          className="mt-1 rounded-sm border border-border-strong bg-surface px-2 py-1 font-mono text-[11.5px] text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
+        >
+          + add label
+        </button>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-sm border border-border-strong px-3 py-1.5 font-mono text-sm text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
+        >
+          cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitDisabled}
+          className="rounded-sm bg-accent px-3 py-1.5 font-mono text-sm text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          title="⌘/Ctrl+Enter to submit"
+        >
+          save
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+// Sort + serialize a labels map so equality checks (initial vs. current)
+// don't false-positive on key-order differences.
+function normalize(map: Record<string, string>): string {
+  return Object.keys(map)
+    .sort()
+    .map((k) => `${k}=${map[k]}`)
+    .join("\n");
+}

--- a/web/src/components/edit/ResourceActions.tsx
+++ b/web/src/components/edit/ResourceActions.tsx
@@ -1,12 +1,13 @@
-// ResourceActions — the "edit yaml" + "delete" pair shown in detail
-// panel tab strips. Centralises styling + RBAC gating so the
-// Pods/Deployments/Secrets detail components stay declarative.
+// ResourceActions — the action bar shown in detail panel tab strips.
+// Centralises styling + RBAC gating + mutation wiring so the
+// per-kind detail components stay declarative.
 //
-// As of PR5 the edit flow is the inline YamlEditor (not a modal):
-// `<EditButton />` navigates the URL to `?tab=yaml&edit=1`, and
-// YamlView dispatches to the editor. ResourceActions retains the
-// delete modal — that's still a confirm-and-go interaction that
-// doesn't benefit from being inline.
+// Lane 2 expanded the surface from {Edit YAML, Delete} to
+// {Edit YAML, Edit labels, Scale (scalable kinds only), Delete}.
+// Each destructive / write action has its own dedicated mutation
+// hook (useEditLabels, useScaleResource, useDeleteResource) that
+// optimistically updates the React Query cache before the network
+// call lands, so the UI feels instant on slow links.
 //
 // Actions are shown unconditionally in v1 — the backend is the
 // authoritative gate (impersonated K8s RBAC). useCanI() is called
@@ -14,12 +15,18 @@
 // free. See useCanI for the rationale.
 
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useCanI } from "../../hooks/useCanI";
+import { ApiError } from "../../lib/api";
 import type { ResourceRef, YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import { useCanI } from "../../hooks/useCanI";
+import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/queryKeys";
+import { useScaleResource, isScalable } from "../../hooks/mutations/useScaleResource";
+import { useEditLabels } from "../../hooks/mutations/useEditLabels";
+import { useDeleteResource } from "../../hooks/mutations/useDeleteResource";
 import { DeleteResourceModal } from "./DeleteResourceModal";
+import { ScaleModal } from "./ScaleModal";
+import { EditLabelsModal } from "./EditLabelsModal";
 import { EditButton } from "../detail/yaml/EditButton";
 
 interface ResourceActionsProps {
@@ -38,6 +45,11 @@ interface ResourceActionsProps {
   onDeleted?: () => void;
 }
 
+interface DetailLike {
+  replicas?: number;
+  labels?: Record<string, string>;
+}
+
 export function ResourceActions({
   cluster,
   yamlKind,
@@ -47,6 +59,8 @@ export function ResourceActions({
   onDeleted,
 }: ResourceActionsProps) {
   const [showDelete, setShowDelete] = useState(false);
+  const [showScale, setShowScale] = useState(false);
+  const [showLabels, setShowLabels] = useState(false);
   const meta = KIND_REGISTRY[yamlKind];
   const ns = namespace ?? undefined;
   const resource: ResourceRef = {
@@ -60,12 +74,70 @@ export function ResourceActions({
   };
   const canEdit = useCanI({ verb: "patch", resource: meta.resource, namespace: ns });
   const canDelete = useCanI({ verb: "delete", resource: meta.resource, namespace: ns });
+  const canScale = useCanI({
+    verb: "patch",
+    resource: `${meta.resource}/scale`,
+    namespace: ns,
+  });
+  const showScaleButton = canScale && isScalable(yamlKind);
 
   const qc = useQueryClient();
+  const detailKey = queryKeys
+    .cluster(cluster)
+    .kind(yamlKind)
+    .detail(ns ?? "", name);
+  const cachedDetail = qc.getQueryData<DetailLike>(detailKey);
+
+  const scaleMutation = useScaleResource({
+    cluster,
+    kind: yamlKind,
+    namespace: ns ?? "",
+    name,
+  });
+  const labelsMutation = useEditLabels({
+    cluster,
+    kind: yamlKind,
+    namespace: ns ?? "",
+    name,
+  });
+  const deleteMutation = useDeleteResource({
+    cluster,
+    kind: yamlKind,
+    namespace: ns ?? "",
+    name,
+  });
+
+  const deleteError = deleteMutation.error
+    ? deleteErrorShape(deleteMutation.error)
+    : null;
 
   return (
     <div className="flex items-center gap-1.5">
       {canEdit && <EditButton />}
+      {canEdit && (
+        <button
+          type="button"
+          onClick={() => setShowLabels(true)}
+          className="rounded-sm border border-border-strong px-2.5 py-1 font-mono text-[12px] text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink"
+        >
+          labels
+        </button>
+      )}
+      {showScaleButton && (
+        <button
+          type="button"
+          onClick={() => setShowScale(true)}
+          disabled={cachedDetail?.replicas === undefined}
+          className="rounded-sm border border-border-strong px-2.5 py-1 font-mono text-[12px] text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            cachedDetail?.replicas === undefined
+              ? "loading current replica count…"
+              : `current replicas: ${cachedDetail.replicas}`
+          }
+        >
+          scale
+        </button>
+      )}
       {canDelete && (
         <button
           type="button"
@@ -80,18 +152,54 @@ export function ResourceActions({
       {showDelete && (
         <DeleteResourceModal
           resourceRef={resource}
-          onClose={() => setShowDelete(false)}
-          onDeleted={async () => {
-            // Await before calling onDeleted: the parent typically
-            // navigates away, and the new route's queries must see
-            // the post-delete cache to render fresh data.
-            await qc.invalidateQueries({
-              queryKey: queryKeys.cluster(cluster).kind(yamlKind).all,
-            });
-            onDeleted?.();
+          pending={deleteMutation.isPending}
+          error={deleteError}
+          onClose={() => {
+            if (deleteMutation.isPending) return;
+            deleteMutation.reset();
+            setShowDelete(false);
           }}
+          onConfirm={() => {
+            deleteMutation.mutate(undefined, {
+              onSuccess: () => {
+                setShowDelete(false);
+                onDeleted?.();
+              },
+            });
+          }}
+        />
+      )}
+
+      {showScale && showScaleButton && cachedDetail?.replicas !== undefined && (
+        <ScaleModal
+          cluster={cluster}
+          kind={yamlKind}
+          namespace={ns ?? ""}
+          name={name}
+          currentReplicas={cachedDetail.replicas}
+          onClose={() => setShowScale(false)}
+          onSubmit={(replicas) => scaleMutation.mutate({ replicas })}
+        />
+      )}
+
+      {showLabels && (
+        <EditLabelsModal
+          title={`${meta.kind} ${name}`}
+          initialLabels={cachedDetail?.labels ?? {}}
+          onClose={() => setShowLabels(false)}
+          onSubmit={(labels) => labelsMutation.mutate({ labels })}
         />
       )}
     </div>
   );
+}
+
+function deleteErrorShape(err: Error): { status?: number; message: string } {
+  if (err instanceof ApiError) {
+    return {
+      status: err.status,
+      message: err.bodyText?.trim() || err.message,
+    };
+  }
+  return { message: err.message || "delete failed" };
 }

--- a/web/src/components/edit/ResourceActions.tsx
+++ b/web/src/components/edit/ResourceActions.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCanI } from "../../hooks/useCanI";
 import type { ResourceRef, YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import { queryKeys } from "../../lib/queryKeys";
 import { DeleteResourceModal } from "./DeleteResourceModal";
 import { EditButton } from "../detail/yaml/EditButton";
 
@@ -80,8 +81,13 @@ export function ResourceActions({
         <DeleteResourceModal
           resourceRef={resource}
           onClose={() => setShowDelete(false)}
-          onDeleted={() => {
-            qc.invalidateQueries({ queryKey: [yamlKind] });
+          onDeleted={async () => {
+            // Await before calling onDeleted: the parent typically
+            // navigates away, and the new route's queries must see
+            // the post-delete cache to render fresh data.
+            await qc.invalidateQueries({
+              queryKey: queryKeys.cluster(cluster).kind(yamlKind).all,
+            });
             onDeleted?.();
           }}
         />

--- a/web/src/components/edit/ScaleModal.tsx
+++ b/web/src/components/edit/ScaleModal.tsx
@@ -1,0 +1,215 @@
+// ScaleModal — set spec.replicas for a Deployment / StatefulSet /
+// ReplicaSet. The mutation lives in useScaleResource and is optimistic
+// — by the time this modal closes the StatStrip already shows the new
+// value, so the modal itself does not render a spinner.
+//
+// HPA awareness: if managedFields shows a CONTROLLER-category manager
+// (notably horizontal-pod-autoscaler) owns spec.replicas, render an
+// amber chip warning the user that the HPA will likely overwrite their
+// scale within a control-loop interval. Non-blocking — operators
+// sometimes deliberately bump replicas to clear a backlog quickly and
+// accept that the HPA will normalize back.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "../../lib/cn";
+import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import {
+  parseManagedFields,
+  pathToManager,
+} from "../../lib/managedFields";
+import { classifyManager } from "../../lib/managers";
+import { useResourceMeta } from "../../hooks/useResource";
+import { Modal } from "../ui/Modal";
+import type { YamlKind } from "../../lib/api";
+
+interface ScaleModalProps {
+  cluster: string;
+  kind: YamlKind;
+  namespace: string;
+  name: string;
+  currentReplicas: number;
+  onClose: () => void;
+  onSubmit: (replicas: number) => void;
+}
+
+export function ScaleModal({
+  cluster,
+  kind,
+  namespace,
+  name,
+  currentReplicas,
+  onClose,
+  onSubmit,
+}: ScaleModalProps) {
+  const [value, setValue] = useState<string>(String(currentReplicas));
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const meta = KIND_REGISTRY[kind];
+
+  // Auto-focus & select on mount so the most common interaction
+  // (overwrite the current value) is one keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  // Pull managedFields to spot HPA ownership of spec.replicas.
+  const metaQuery = useResourceMeta(
+    cluster,
+    kind,
+    {
+      group: meta.group,
+      version: meta.version,
+      resource: meta.resource,
+      namespace,
+      name,
+    },
+    true,
+  );
+
+  const replicasOwner = useMemo(() => {
+    const owners = parseManagedFields(metaQuery.data?.managedFields);
+    const map = pathToManager(owners);
+    const manager = map.get("spec.replicas");
+    if (!manager) return null;
+    const info = classifyManager(manager);
+    return info;
+  }, [metaQuery.data]);
+
+  const showHpaWarning =
+    replicasOwner !== null && replicasOwner.category === "CONTROLLER";
+
+  // Validation: non-negative integer.
+  const parsed = Number(value);
+  const valid =
+    value.trim() !== "" &&
+    Number.isInteger(parsed) &&
+    parsed >= 0;
+  const unchanged = valid && parsed === currentReplicas;
+  const submitDisabled = !valid || unchanged;
+
+  function bump(delta: number) {
+    const n = Math.max(0, (Number.isInteger(parsed) ? parsed : 0) + delta);
+    setValue(String(n));
+  }
+
+  function submit() {
+    if (submitDisabled) return;
+    onSubmit(parsed);
+    onClose();
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      bump(1);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      bump(-1);
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} labelledBy="scale-title" size="sm">
+      <div className="border-b border-border px-5 py-3 font-mono text-sm">
+        <span className="text-ink-muted">scale</span>{" "}
+        <span id="scale-title" className="text-ink">
+          {meta.kind} {name}
+        </span>
+      </div>
+
+      <div className="space-y-4 px-5 py-4">
+        <div>
+          <label
+            htmlFor="scale-replicas"
+            className="mb-1.5 block font-mono text-[11px] text-ink-muted"
+          >
+            replicas (current: {currentReplicas})
+          </label>
+          <div className="flex items-stretch gap-1">
+            <button
+              type="button"
+              onClick={() => bump(-1)}
+              disabled={!valid || parsed <= 0}
+              aria-label="decrease replicas"
+              className="rounded-sm border border-border-strong bg-surface px-3 font-mono text-sm text-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              −
+            </button>
+            <input
+              ref={inputRef}
+              id="scale-replicas"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={onKeyDown}
+              className={cn(
+                "min-w-0 flex-1 rounded-sm border bg-bg px-3 py-2 text-center font-mono text-sm text-ink outline-none",
+                valid ? "border-border" : "border-red",
+                "focus:border-ink-muted",
+              )}
+              aria-invalid={!valid}
+              aria-describedby={valid ? undefined : "scale-error"}
+            />
+            <button
+              type="button"
+              onClick={() => bump(1)}
+              disabled={!valid && value.trim() !== ""}
+              aria-label="increase replicas"
+              className="rounded-sm border border-border-strong bg-surface px-3 font-mono text-sm text-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              +
+            </button>
+          </div>
+          {!valid && (
+            <p
+              id="scale-error"
+              className="mt-1.5 font-mono text-[11px] text-red"
+            >
+              must be a non-negative integer
+            </p>
+          )}
+        </div>
+
+        {showHpaWarning && replicasOwner && (
+          <div className="rounded-sm border-l-[3px] border-yellow bg-yellow-soft px-3 py-2">
+            <div className="font-mono text-[10.5px] font-medium text-yellow">
+              {replicasOwner.display} controls replicas
+            </div>
+            <p className="mt-1 text-[12px] leading-relaxed text-ink">
+              {replicasOwner.consequence ||
+                "A controller will likely overwrite your scale on the next reconcile."}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-sm border border-border-strong px-3 py-1.5 font-mono text-sm text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
+        >
+          cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitDisabled}
+          className="rounded-sm bg-accent px-3 py-1.5 font-mono text-sm text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          title="⌘/Ctrl+Enter to submit"
+        >
+          scale
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/search/SearchPalette.tsx
+++ b/web/src/components/search/SearchPalette.tsx
@@ -3,6 +3,7 @@ import { useMatch, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../lib/api";
 import { cn } from "../../lib/cn";
+import { queryKeys } from "../../lib/queryKeys";
 import type { SearchKind, SearchResult } from "../../lib/types";
 
 const IS_MAC =
@@ -96,7 +97,7 @@ export function SearchPalette({
   }, [query]);
 
   const { data, isFetching, isError } = useQuery({
-    queryKey: ["search", cluster, debounced],
+    queryKey: queryKeys.cluster(cluster).search(debounced),
     enabled: Boolean(open && cluster && debounced.length > 0),
     queryFn: ({ signal }) =>
       api.search(cluster, debounced, { limit: 10 }, signal),

--- a/web/src/components/shell/GlobalFetchingBar.tsx
+++ b/web/src/components/shell/GlobalFetchingBar.tsx
@@ -3,9 +3,9 @@
 // to queries that already have data (predicate), so cold loads keep
 // rendering their per-page skeletons without a doubled-up indicator.
 //
-// Mounted as the first child of <main> in AppShell so it sits above
-// the page content but below the global sidebar — implying the
-// content is refreshing, not the static nav.
+// Mounted at the top of the App layout (above the AppShell), so the
+// 2px sweep spans the full viewport whenever any cached query is
+// refetching. Visible above sidebar + content alike.
 //
 // Animation: see `.animate-fetchbar` in src/index.css. Single keyframe
 // + a custom utility — no Tailwind config (we're on v4 CSS-mode) and

--- a/web/src/components/shell/GlobalFetchingBar.tsx
+++ b/web/src/components/shell/GlobalFetchingBar.tsx
@@ -1,0 +1,31 @@
+// GlobalFetchingBar — 2px indeterminate sweep at the top of the main
+// content region whenever a background refetch is in flight. Filtered
+// to queries that already have data (predicate), so cold loads keep
+// rendering their per-page skeletons without a doubled-up indicator.
+//
+// Mounted as the first child of <main> in AppShell so it sits above
+// the page content but below the global sidebar — implying the
+// content is refreshing, not the static nav.
+//
+// Animation: see `.animate-fetchbar` in src/index.css. Single keyframe
+// + a custom utility — no Tailwind config (we're on v4 CSS-mode) and
+// no new dependency.
+
+import { useIsFetching } from "@tanstack/react-query";
+
+export function GlobalFetchingBar() {
+  const fetching = useIsFetching({
+    predicate: (q) => q.state.data !== undefined,
+  });
+  if (fetching === 0) return null;
+  return (
+    <div
+      role="progressbar"
+      aria-busy="true"
+      aria-label="Refreshing data"
+      className="h-0.5 w-full overflow-hidden bg-transparent"
+    >
+      <div className="h-full w-1/3 animate-fetchbar bg-accent" />
+    </div>
+  );
+}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,0 +1,105 @@
+// Modal — shared primitive for dialog overlays.
+//
+// Wraps the fixed-inset overlay + backdrop + Esc/click-outside-to-close
+// + role="dialog"/aria-modal that DeleteResourceModal, TakeoverDialog,
+// DriftDiffOverlay, ScaleModal, and EditLabelsModal each used to
+// hand-roll. Keeps all five visually consistent and avoids drift when
+// adding a sixth.
+//
+// Behaviour:
+//   - Esc dismisses (unless the consumer disables via `dismissOnEsc=false`,
+//     useful when a destructive action is in flight and you want to
+//     prevent accidental cancel).
+//   - Click on the backdrop dismisses (same disable knob via
+//     `dismissOnBackdrop=false`).
+//   - On unmount, focus returns to whatever element opened the modal.
+//   - `size` controls the max-width: sm=420px, md=560px, lg=1100px.
+//   - `z` controls the stacking layer (default 50; takeovers may want 60).
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Element id of the title node — wired to aria-labelledby. */
+  labelledBy: string;
+  size?: "sm" | "md" | "lg";
+  z?: 50 | 60;
+  dismissOnEsc?: boolean;
+  dismissOnBackdrop?: boolean;
+  /** Tailwind classes appended to the panel. Use for unusual fits. */
+  panelClassName?: string;
+  children: ReactNode;
+}
+
+const SIZE_CLASS: Record<NonNullable<ModalProps["size"]>, string> = {
+  sm: "max-w-md",
+  md: "max-w-[560px]",
+  lg: "max-w-[1100px]",
+};
+
+export function Modal({
+  open,
+  onClose,
+  labelledBy,
+  size = "md",
+  z = 50,
+  dismissOnEsc = true,
+  dismissOnBackdrop = true,
+  panelClassName,
+  children,
+}: ModalProps) {
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture the element that had focus when the modal opened so we can
+  // restore it on close. Without this, after Esc the focus drops to
+  // <body> and keyboard users lose their place in the page.
+  useEffect(() => {
+    if (!open) return;
+    returnFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    return () => {
+      returnFocusRef.current?.focus?.();
+      returnFocusRef.current = null;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !dismissOnEsc) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, dismissOnEsc]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      className={cn(
+        "fixed inset-0 flex items-center justify-center bg-black/40 px-4",
+        z === 60 ? "z-[60]" : "z-50",
+      )}
+      onClick={(e) => {
+        if (dismissOnBackdrop && e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className={cn(
+          "w-full rounded-md border border-border-strong bg-surface shadow-2xl",
+          SIZE_CLASS[size],
+          panelClassName,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/mutations/_useOptimistic.ts
+++ b/web/src/hooks/mutations/_useOptimistic.ts
@@ -1,0 +1,91 @@
+// _useOptimistic — shared lifecycle for the three Lane 2 mutation hooks
+// (scale, label edit, delete). Wraps useMutation with the canonical
+// react-query optimistic shape:
+//
+//   onMutate     cancel in-flight queries, snapshot the affected
+//                cache entries, apply the optimistic update.
+//   onError      restore the snapshot, surface an error toast.
+//   onSuccess    invalidate detail + meta + list (in that order) so the
+//                next render reflects the server's authoritative state.
+//                The await on meta is load-bearing: drift detection
+//                polls every 15s and filters writes by manager
+//                "periscope-spa" (lib/drift.ts:62) — we need the meta
+//                query to refetch before the next drift evaluation, or
+//                a false-positive banner can flash for fields the user
+//                themselves just updated.
+//
+// We do NOT setQueryData(detailKey, applyResponse.object): the apply
+// endpoint returns the raw K8s object, but the *Detail types in the
+// cache are pre-flattened by the backend. The shapes are incompatible.
+// Invalidation forces a refetch through the flattening pipeline.
+
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { showToast } from "../../lib/toastBus";
+
+interface OptimisticArgs<TVars, TSnap, TRes, TError> {
+  /** All keys to invalidate in onSuccess and to restore on rollback. */
+  detailKey: QueryKey;
+  metaKey: QueryKey;
+  listKey?: QueryKey;
+  /** Apply the optimistic update; return a snapshot for rollback. */
+  applyOptimistic: (qc: ReturnType<typeof useQueryClient>, vars: TVars) => TSnap;
+  rollback: (qc: ReturnType<typeof useQueryClient>, snap: TSnap) => void;
+  mutationFn: (vars: TVars) => Promise<TRes>;
+  successToast: (vars: TVars) => string;
+  errorToast: (err: TError, vars: TVars) => string;
+  /** Suppress success toast (used by delete which has its own messaging). */
+  successToneOverride?: { message: (v: TVars) => string; durationMs?: number };
+}
+
+export function useOptimisticMutation<
+  TVars,
+  TSnap,
+  TRes = unknown,
+  TError = Error,
+>({
+  detailKey,
+  metaKey,
+  listKey,
+  applyOptimistic,
+  rollback,
+  mutationFn,
+  successToast,
+  errorToast,
+}: OptimisticArgs<TVars, TSnap, TRes, TError>): UseMutationResult<
+  TRes,
+  TError,
+  TVars,
+  { snap: TSnap }
+> {
+  const qc = useQueryClient();
+
+  return useMutation<TRes, TError, TVars, { snap: TSnap }>({
+    mutationFn,
+    onMutate: async (vars) => {
+      // Cancel everything that could land mid-mutation and clobber
+      // our optimistic write.
+      await qc.cancelQueries({ queryKey: detailKey });
+      if (listKey) await qc.cancelQueries({ queryKey: listKey });
+      const snap = applyOptimistic(qc, vars);
+      return { snap };
+    },
+    onError: (err, vars, ctx) => {
+      if (ctx) rollback(qc, ctx.snap);
+      showToast(errorToast(err, vars), "error", 5000);
+    },
+    onSuccess: async (_res, vars) => {
+      // Order matters: detail first (visible cache), then meta (drift
+      // gating), then list (cleanup). All awaited — the success toast
+      // should not fire until the cache is reconciled.
+      await qc.invalidateQueries({ queryKey: detailKey });
+      await qc.invalidateQueries({ queryKey: metaKey });
+      if (listKey) await qc.invalidateQueries({ queryKey: listKey });
+      showToast(successToast(vars), "success", 2000);
+    },
+  });
+}

--- a/web/src/hooks/mutations/useDeleteResource.ts
+++ b/web/src/hooks/mutations/useDeleteResource.ts
@@ -1,0 +1,81 @@
+// useDeleteResource — optimistic delete. The row vanishes from the
+// list cache before the DELETE flies; on error we restore the
+// snapshot. There is no undo affordance and there will not be one:
+// Kubernetes has no transaction log to re-create from, delaying the
+// API call risks orphaned actions if the tab closes during the undo
+// window, and controllers may notice the resource going stale and
+// react in ways the user can't unwind. Lens, Headlamp, and Rancher
+// all match this confirm-then-go shape (per Lane 2 UX research).
+
+import { ApiError, api, type YamlKind } from "../../lib/api";
+import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import { queryKeys } from "../../lib/queryKeys";
+import { removeRowFromList } from "../../lib/listShape";
+import type { ResourceListResponse } from "../../lib/types";
+import { useOptimisticMutation } from "./_useOptimistic";
+
+interface DeleteArgs {
+  cluster: string;
+  kind: YamlKind;
+  /** Empty string for cluster-scoped resources. */
+  namespace: string;
+  name: string;
+}
+
+// No mutation variables — the args carry everything.
+type DeleteVars = void;
+
+interface Snap {
+  list: ResourceListResponse | undefined;
+  detail: unknown;
+}
+
+export function useDeleteResource(args: DeleteArgs) {
+  const meta = KIND_REGISTRY[args.kind];
+  const detailKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .detail(args.namespace, args.name);
+  const metaKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .meta(args.namespace, args.name);
+  const listKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .list(args.namespace);
+
+  return useOptimisticMutation<DeleteVars, Snap, unknown, ApiError | Error>({
+    detailKey,
+    metaKey,
+    listKey,
+    applyOptimistic: (qc) => {
+      const list = qc.getQueryData<ResourceListResponse>(listKey);
+      const detail = qc.getQueryData(detailKey);
+      qc.setQueryData<ResourceListResponse | undefined>(listKey, (prev) =>
+        removeRowFromList(prev, args.kind, {
+          name: args.name,
+          namespace: args.namespace || undefined,
+        }),
+      );
+      qc.setQueryData(detailKey, undefined);
+      return { list, detail };
+    },
+    rollback: (qc, snap) => {
+      qc.setQueryData(listKey, snap.list);
+      qc.setQueryData(detailKey, snap.detail);
+    },
+    mutationFn: () =>
+      api.deleteResource({
+        cluster: args.cluster,
+        group: meta.group,
+        version: meta.version,
+        resource: meta.resource,
+        namespace: args.namespace || undefined,
+        name: args.name,
+      }),
+    successToast: () => `deleted ${args.kind}/${args.name}`,
+    errorToast: (err) =>
+      `failed to delete ${args.kind}/${args.name}: ${err?.message ?? "unknown"}`,
+  });
+}

--- a/web/src/hooks/mutations/useDeleteResource.ts
+++ b/web/src/hooks/mutations/useDeleteResource.ts
@@ -1,17 +1,26 @@
-// useDeleteResource — optimistic delete. The row vanishes from the
-// list cache before the DELETE flies; on error we restore the
+// useDeleteResource — optimistic delete. The row vanishes from every
+// loaded list cache before the DELETE flies; on error we restore the
 // snapshot. There is no undo affordance and there will not be one:
 // Kubernetes has no transaction log to re-create from, delaying the
 // API call risks orphaned actions if the tab closes during the undo
 // window, and controllers may notice the resource going stale and
 // react in ways the user can't unwind. Lens, Headlamp, and Rancher
 // all match this confirm-then-go shape (per Lane 2 UX research).
+//
+// IMPORTANT: list caches are namespace-keyed
+// (queryKeys.cluster(c).kind(k).list(ns)). The user may be viewing
+// all namespaces (ns="") AND have a per-namespace cache loaded
+// elsewhere from a prior selection. Patching only the deleted row's
+// namespace would miss the all-namespaces view that's actually on
+// screen. We use setQueriesData with the kind prefix to patch every
+// loaded list at once.
 
 import { ApiError, api, type YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { removeRowFromList } from "../../lib/listShape";
+import { patchRowInList, removeRowFromList } from "../../lib/listShape";
 import type { ResourceListResponse } from "../../lib/types";
+import type { QueryKey } from "@tanstack/react-query";
 import { useOptimisticMutation } from "./_useOptimistic";
 
 interface DeleteArgs {
@@ -22,12 +31,11 @@ interface DeleteArgs {
   name: string;
 }
 
-// No mutation variables — the args carry everything.
 type DeleteVars = void;
 
 interface Snap {
-  list: ResourceListResponse | undefined;
   detail: unknown;
+  lists: Array<[QueryKey, ResourceListResponse | undefined]>;
 }
 
 export function useDeleteResource(args: DeleteArgs) {
@@ -40,30 +48,57 @@ export function useDeleteResource(args: DeleteArgs) {
     .cluster(args.cluster)
     .kind(args.kind)
     .meta(args.namespace, args.name);
-  const listKey = queryKeys
-    .cluster(args.cluster)
-    .kind(args.kind)
-    .list(args.namespace);
+  // Prefix that covers every list / detail / yaml / events / meta /
+  // metrics under this kind. cancelQueries + invalidateQueries
+  // operate on the prefix so we don't have to enumerate every
+  // namespace-pinned list cache.
+  const kindPrefix = queryKeys.cluster(args.cluster).kind(args.kind).all;
 
   return useOptimisticMutation<DeleteVars, Snap, unknown, ApiError | Error>({
     detailKey,
     metaKey,
-    listKey,
+    listKey: kindPrefix,
     applyOptimistic: (qc) => {
-      const list = qc.getQueryData<ResourceListResponse>(listKey);
       const detail = qc.getQueryData(detailKey);
-      qc.setQueryData<ResourceListResponse | undefined>(listKey, (prev) =>
-        removeRowFromList(prev, args.kind, {
-          name: args.name,
-          namespace: args.namespace || undefined,
-        }),
+      // Snapshot every loaded list cache for this kind, then patch
+      // each one. setQueriesData reaches both list("") (the
+      // all-namespaces view) and list("<ns>") (a specific namespace
+      // view) so the row disappears wherever it's currently
+      // rendered.
+      const lists = qc.getQueriesData<ResourceListResponse>({
+        queryKey: kindPrefix,
+        predicate: (q) =>
+          Array.isArray(q.queryKey) && q.queryKey[4] === "list",
+      });
+      // Pods linger in Terminating phase for ~30s after delete;
+      // patching their phase keeps the row visible and matches what
+      // the refetch will return. Every other kind disappears promptly,
+      // so removing the row optimistically gives the cleaner UX.
+      const isPod = args.kind === "pods";
+      qc.setQueriesData<ResourceListResponse | undefined>(
+        {
+          queryKey: kindPrefix,
+          predicate: (q) =>
+            Array.isArray(q.queryKey) && q.queryKey[4] === "list",
+        },
+        (prev) =>
+          isPod
+            ? patchRowInList<{ name: string; namespace?: string; phase?: string }>(
+                prev,
+                args.kind,
+                { name: args.name, namespace: args.namespace || undefined },
+                (row) => ({ ...row, phase: "Terminating" }),
+              )
+            : removeRowFromList(prev, args.kind, {
+                name: args.name,
+                namespace: args.namespace || undefined,
+              }),
       );
-      qc.setQueryData(detailKey, undefined);
-      return { list, detail };
+      return { detail, lists };
     },
     rollback: (qc, snap) => {
-      qc.setQueryData(listKey, snap.list);
       qc.setQueryData(detailKey, snap.detail);
+      for (const [key, data] of snap.lists) qc.setQueryData(key, data);
     },
     mutationFn: () =>
       api.deleteResource({

--- a/web/src/hooks/mutations/useEditLabels.ts
+++ b/web/src/hooks/mutations/useEditLabels.ts
@@ -1,0 +1,90 @@
+// useEditLabels — optimistic label editor. Builds a minimal SSA payload
+// touching only metadata.labels so periscope-spa registers as the
+// manager of the labels we wrote, leaving every other field's manager
+// intact. Detail cache is patched optimistically so MetaPills updates
+// pre-roundtrip; list cache is invalidated rather than optimistically
+// patched (some pages derive filter chips from labels and rebuilding
+// those derivations correctly in the optimistic phase is fragile).
+
+import { ApiError, api, type YamlKind } from "../../lib/api";
+import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import { queryKeys } from "../../lib/queryKeys";
+import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { useOptimisticMutation } from "./_useOptimistic";
+
+interface EditLabelsArgs {
+  cluster: string;
+  kind: YamlKind;
+  /** Empty string for cluster-scoped resources. */
+  namespace: string;
+  name: string;
+}
+
+interface EditLabelsVars {
+  labels: Record<string, string>;
+}
+
+interface DetailLike {
+  labels?: Record<string, string>;
+}
+
+interface Snap {
+  detail: DetailLike | undefined;
+}
+
+export function useEditLabels(args: EditLabelsArgs) {
+  const meta = KIND_REGISTRY[args.kind];
+  const detailKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .detail(args.namespace, args.name);
+  const metaKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .meta(args.namespace, args.name);
+  const listKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .list(args.namespace);
+
+  return useOptimisticMutation<EditLabelsVars, Snap, unknown, ApiError | Error>({
+    detailKey,
+    metaKey,
+    listKey,
+    applyOptimistic: (qc, vars) => {
+      const detail = qc.getQueryData<DetailLike>(detailKey);
+      qc.setQueryData<DetailLike>(detailKey, (prev) =>
+        prev ? { ...prev, labels: vars.labels } : prev,
+      );
+      return { detail };
+    },
+    rollback: (qc, snap) => {
+      qc.setQueryData(detailKey, snap.detail);
+    },
+    mutationFn: (vars) => {
+      const identity: Identity = {
+        apiVersion: meta.group ? `${meta.group}/${meta.version}` : meta.version,
+        kind: meta.kind,
+        name: args.name,
+        namespace: args.namespace || undefined,
+      };
+      const yaml = buildMinimalSSA(
+        [{ op: "replace", path: ["metadata", "labels"], value: vars.labels }],
+        identity,
+      );
+      return api.applyResource({
+        cluster: args.cluster,
+        group: meta.group,
+        version: meta.version,
+        resource: meta.resource,
+        namespace: args.namespace || undefined,
+        name: args.name,
+        yaml,
+        force: false,
+      });
+    },
+    successToast: () => `updated labels on ${args.name}`,
+    errorToast: (err) =>
+      `failed to update labels on ${args.name}: ${err?.message ?? "unknown"}`,
+  });
+}

--- a/web/src/hooks/mutations/useEditLabels.ts
+++ b/web/src/hooks/mutations/useEditLabels.ts
@@ -42,10 +42,11 @@ export function useEditLabels(args: EditLabelsArgs) {
     .cluster(args.cluster)
     .kind(args.kind)
     .meta(args.namespace, args.name);
-  const listKey = queryKeys
-    .cluster(args.cluster)
-    .kind(args.kind)
-    .list(args.namespace);
+  // Kind prefix so the post-success invalidation sweeps every loaded
+  // list cache for this kind (all-namespaces view + any specific-
+  // namespace view). Pinning to a single ns would miss the visible
+  // list when the user is browsing all namespaces.
+  const listKey = queryKeys.cluster(args.cluster).kind(args.kind).all;
 
   return useOptimisticMutation<EditLabelsVars, Snap, unknown, ApiError | Error>({
     detailKey,

--- a/web/src/hooks/mutations/useScaleResource.ts
+++ b/web/src/hooks/mutations/useScaleResource.ts
@@ -1,0 +1,117 @@
+// useScaleResource — optimistic scale for deployments / statefulsets /
+// replicasets. Builds a minimal SSA payload touching only spec.replicas
+// so periscope-spa claims ownership of just that field, leaving every
+// other field's manager intact. The cache is updated optimistically so
+// the StatStrip flips to the new desired count within one render;
+// readyReplicas stays at the prior value until the refetch lands —
+// which is honest UX because the new pods aren't ready yet.
+
+import { ApiError, api, type YamlKind } from "../../lib/api";
+import { KIND_REGISTRY } from "../../lib/k8sKinds";
+import { queryKeys } from "../../lib/queryKeys";
+import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { patchRowInList } from "../../lib/listShape";
+import { useOptimisticMutation } from "./_useOptimistic";
+
+export type ScalableKind = "deployments" | "statefulsets" | "replicasets";
+
+export const SCALABLE_KINDS: ScalableKind[] = [
+  "deployments",
+  "statefulsets",
+  "replicasets",
+];
+
+export function isScalable(kind: string): kind is ScalableKind {
+  return (SCALABLE_KINDS as string[]).includes(kind);
+}
+
+interface ScaleArgs {
+  cluster: string;
+  // Accepts any YamlKind for hook ergonomics (callers may construct
+  // before narrowing). Non-scalable kinds will get a 422 from the
+  // apiserver if the mutation is ever fired — the UI gates this via
+  // isScalable() so it should be unreachable in practice.
+  kind: YamlKind;
+  namespace: string;
+  name: string;
+}
+
+interface ScaleVars {
+  replicas: number;
+}
+
+interface DetailLike {
+  replicas?: number;
+}
+
+interface Snap {
+  detail: DetailLike | undefined;
+  list: unknown;
+}
+
+export function useScaleResource(args: ScaleArgs) {
+  const meta = KIND_REGISTRY[args.kind];
+  const detailKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .detail(args.namespace, args.name);
+  const metaKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .meta(args.namespace, args.name);
+  const listKey = queryKeys
+    .cluster(args.cluster)
+    .kind(args.kind)
+    .list(args.namespace);
+
+  return useOptimisticMutation<ScaleVars, Snap, unknown, ApiError | Error>({
+    detailKey,
+    metaKey,
+    listKey,
+    applyOptimistic: (qc, vars) => {
+      const detail = qc.getQueryData<DetailLike>(detailKey);
+      const list = qc.getQueryData(listKey);
+      qc.setQueryData<DetailLike>(detailKey, (prev) =>
+        prev ? { ...prev, replicas: vars.replicas } : prev,
+      );
+      qc.setQueryData(listKey, (prev) =>
+        patchRowInList<{ name: string; namespace?: string; replicas?: number }>(
+          prev as never,
+          args.kind,
+          { name: args.name, namespace: args.namespace },
+          (row) => ({ ...row, replicas: vars.replicas }),
+        ),
+      );
+      return { detail, list };
+    },
+    rollback: (qc, snap) => {
+      qc.setQueryData(detailKey, snap.detail);
+      qc.setQueryData(listKey, snap.list);
+    },
+    mutationFn: (vars) => {
+      const identity: Identity = {
+        apiVersion: meta.group ? `${meta.group}/${meta.version}` : meta.version,
+        kind: meta.kind,
+        name: args.name,
+        namespace: args.namespace,
+      };
+      const yaml = buildMinimalSSA(
+        [{ op: "replace", path: ["spec", "replicas"], value: vars.replicas }],
+        identity,
+      );
+      return api.applyResource({
+        cluster: args.cluster,
+        group: meta.group,
+        version: meta.version,
+        resource: meta.resource,
+        namespace: args.namespace,
+        name: args.name,
+        yaml,
+        force: false,
+      });
+    },
+    successToast: (vars) => `scaled ${args.name} to ${vars.replicas}`,
+    errorToast: (err, vars) =>
+      `failed to scale ${args.name} to ${vars.replicas}: ${err?.message ?? "unknown"}`,
+  });
+}

--- a/web/src/hooks/mutations/useScaleResource.ts
+++ b/web/src/hooks/mutations/useScaleResource.ts
@@ -2,15 +2,22 @@
 // replicasets. Builds a minimal SSA payload touching only spec.replicas
 // so periscope-spa claims ownership of just that field, leaving every
 // other field's manager intact. The cache is updated optimistically so
-// the StatStrip flips to the new desired count within one render;
-// readyReplicas stays at the prior value until the refetch lands —
-// which is honest UX because the new pods aren't ready yet.
+// the StatStrip and the table flip to the new desired count within
+// one render; readyReplicas stays at the prior value until the refetch
+// lands — which is honest UX because the new pods aren't ready yet.
+//
+// As with useDeleteResource, we patch every loaded list cache for
+// the kind via setQueriesData so the row updates wherever it's
+// currently rendered (all-namespaces view, specific-namespace view,
+// or both at once).
 
 import { ApiError, api, type YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
 import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
 import { patchRowInList } from "../../lib/listShape";
+import type { ResourceListResponse } from "../../lib/types";
+import type { QueryKey } from "@tanstack/react-query";
 import { useOptimisticMutation } from "./_useOptimistic";
 
 export type ScalableKind = "deployments" | "statefulsets" | "replicasets";
@@ -46,7 +53,7 @@ interface DetailLike {
 
 interface Snap {
   detail: DetailLike | undefined;
-  list: unknown;
+  lists: Array<[QueryKey, ResourceListResponse | undefined]>;
 }
 
 export function useScaleResource(args: ScaleArgs) {
@@ -59,34 +66,41 @@ export function useScaleResource(args: ScaleArgs) {
     .cluster(args.cluster)
     .kind(args.kind)
     .meta(args.namespace, args.name);
-  const listKey = queryKeys
-    .cluster(args.cluster)
-    .kind(args.kind)
-    .list(args.namespace);
+  const kindPrefix = queryKeys.cluster(args.cluster).kind(args.kind).all;
 
   return useOptimisticMutation<ScaleVars, Snap, unknown, ApiError | Error>({
     detailKey,
     metaKey,
-    listKey,
+    listKey: kindPrefix,
     applyOptimistic: (qc, vars) => {
       const detail = qc.getQueryData<DetailLike>(detailKey);
-      const list = qc.getQueryData(listKey);
+      const lists = qc.getQueriesData<ResourceListResponse>({
+        queryKey: kindPrefix,
+        predicate: (q) =>
+          Array.isArray(q.queryKey) && q.queryKey[4] === "list",
+      });
       qc.setQueryData<DetailLike>(detailKey, (prev) =>
         prev ? { ...prev, replicas: vars.replicas } : prev,
       );
-      qc.setQueryData(listKey, (prev) =>
-        patchRowInList<{ name: string; namespace?: string; replicas?: number }>(
-          prev as never,
-          args.kind,
-          { name: args.name, namespace: args.namespace },
-          (row) => ({ ...row, replicas: vars.replicas }),
-        ),
+      qc.setQueriesData<ResourceListResponse | undefined>(
+        {
+          queryKey: kindPrefix,
+          predicate: (q) =>
+            Array.isArray(q.queryKey) && q.queryKey[4] === "list",
+        },
+        (prev) =>
+          patchRowInList<{ name: string; namespace?: string; replicas?: number }>(
+            prev as never,
+            args.kind,
+            { name: args.name, namespace: args.namespace },
+            (row) => ({ ...row, replicas: vars.replicas }),
+          ),
       );
-      return { detail, list };
+      return { detail, lists };
     },
     rollback: (qc, snap) => {
       qc.setQueryData(detailKey, snap.detail);
-      qc.setQueryData(listKey, snap.list);
+      for (const [key, data] of snap.lists) qc.setQueryData(key, data);
     },
     mutationFn: (vars) => {
       const identity: Identity = {

--- a/web/src/hooks/useClusters.ts
+++ b/web/src/hooks/useClusters.ts
@@ -1,16 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../lib/api";
+import { queryKeys } from "../lib/queryKeys";
 
 export function useClusters() {
   return useQuery({
-    queryKey: ["clusters"],
+    queryKey: queryKeys.clusters(),
     queryFn: ({ signal }) => api.clusters(signal),
   });
 }
 
 export function useNamespaces(cluster: string | undefined) {
   return useQuery({
-    queryKey: ["namespaces", cluster],
+    queryKey: queryKeys.cluster(cluster ?? "").namespaces(),
     queryFn: ({ signal }) => api.namespaces(cluster!, signal),
     enabled: Boolean(cluster),
   });

--- a/web/src/hooks/useEditorDirty.ts
+++ b/web/src/hooks/useEditorDirty.ts
@@ -10,6 +10,7 @@
 
 import { skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { queryKeys } from "../lib/queryKeys";
 
 interface DirtyState {
   dirty: boolean;
@@ -18,7 +19,7 @@ interface DirtyState {
 const DEFAULT: DirtyState = { dirty: false };
 
 function dirtyKey(cluster: string, kind: string, ns: string | undefined, name: string) {
-  return ["edit", cluster, kind, ns ?? "", name];
+  return queryKeys.edit(cluster, kind, ns ?? "", name);
 }
 
 /**

--- a/web/src/hooks/useResource.ts
+++ b/web/src/hooks/useResource.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api, type ClusterScopedKind, type OpenAPIDoc, type ResourceMeta, type YamlKind } from "../lib/api";
+import { queryKeys } from "../lib/queryKeys";
 import type {
   ClusterEventList,
   ClusterRoleBindingDetail,
@@ -47,7 +48,7 @@ interface ResourceQueryArgs {
 
 export function useResource({ cluster, resource, namespace }: ResourceQueryArgs) {
   return useQuery<ResourceListResponse>({
-    queryKey: ["resource", cluster, resource, namespace ?? ""],
+    queryKey: queryKeys.cluster(cluster ?? "").kind(resource).list(namespace ?? ""),
     queryFn: ({ signal }): Promise<ResourceListResponse> => {
       switch (resource) {
         case "nodes":
@@ -122,7 +123,7 @@ export function useResource({ cluster, resource, namespace }: ResourceQueryArgs)
 
 export function usePodDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<PodDetail>({
-    queryKey: ["pod-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("pods").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getPod(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -130,7 +131,7 @@ export function usePodDetail(cluster: string, ns: string, name: string | null) {
 
 export function useDeploymentDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<DeploymentDetail>({
-    queryKey: ["deployment-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("deployments").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getDeployment(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -138,7 +139,7 @@ export function useDeploymentDetail(cluster: string, ns: string, name: string | 
 
 export function useStatefulSetDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<StatefulSetDetail>({
-    queryKey: ["statefulset-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("statefulsets").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getStatefulSet(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -146,7 +147,7 @@ export function useStatefulSetDetail(cluster: string, ns: string, name: string |
 
 export function useDaemonSetDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<DaemonSetDetail>({
-    queryKey: ["daemonset-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("daemonsets").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getDaemonSet(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -154,7 +155,7 @@ export function useDaemonSetDetail(cluster: string, ns: string, name: string | n
 
 export function useServiceDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<ServiceDetail>({
-    queryKey: ["service-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("services").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getService(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -162,7 +163,7 @@ export function useServiceDetail(cluster: string, ns: string, name: string | nul
 
 export function useIngressDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<IngressDetail>({
-    queryKey: ["ingress-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("ingresses").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getIngress(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -170,7 +171,7 @@ export function useIngressDetail(cluster: string, ns: string, name: string | nul
 
 export function useConfigMapDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<ConfigMapDetail>({
-    queryKey: ["configmap-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("configmaps").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getConfigMap(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -178,7 +179,7 @@ export function useConfigMapDetail(cluster: string, ns: string, name: string | n
 
 export function useSecretDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<SecretDetail>({
-    queryKey: ["secret-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("secrets").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getSecret(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -186,7 +187,7 @@ export function useSecretDetail(cluster: string, ns: string, name: string | null
 
 export function useJobDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<JobDetail>({
-    queryKey: ["job-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("jobs").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getJob(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -194,7 +195,7 @@ export function useJobDetail(cluster: string, ns: string, name: string | null) {
 
 export function useCronJobDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<CronJobDetail>({
-    queryKey: ["cronjob-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("cronjobs").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getCronJob(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -202,7 +203,7 @@ export function useCronJobDetail(cluster: string, ns: string, name: string | nul
 
 export function useClusterEvents(cluster: string, namespace?: string) {
   return useQuery<ClusterEventList>({
-    queryKey: ["cluster-events", cluster, namespace ?? ""],
+    queryKey: queryKeys.cluster(cluster).clusterEvents(namespace ?? ""),
     queryFn: ({ signal }) => api.clusterEvents(cluster, namespace, signal),
     enabled: Boolean(cluster),
     refetchInterval: 15_000,
@@ -211,7 +212,7 @@ export function useClusterEvents(cluster: string, namespace?: string) {
 
 export function usePVCDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<PVCDetail>({
-    queryKey: ["pvc-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("pvcs").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getPVC(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -219,7 +220,7 @@ export function usePVCDetail(cluster: string, ns: string, name: string | null) {
 
 export function usePVDetail(cluster: string, name: string | null) {
   return useQuery<PVDetail>({
-    queryKey: ["pv-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("pvs").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getPV(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -227,7 +228,7 @@ export function usePVDetail(cluster: string, name: string | null) {
 
 export function useStorageClassDetail(cluster: string, name: string | null) {
   return useQuery<StorageClassDetail>({
-    queryKey: ["storageclass-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("storageclasses").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getStorageClass(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -235,7 +236,7 @@ export function useStorageClassDetail(cluster: string, name: string | null) {
 
 export function useNamespaceDetail(cluster: string, name: string | null) {
   return useQuery<NamespaceDetail>({
-    queryKey: ["namespace-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("namespaces").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getNamespace(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -243,7 +244,7 @@ export function useNamespaceDetail(cluster: string, name: string | null) {
 
 export function useNodeDetail(cluster: string, name: string | null) {
   return useQuery<NodeDetail>({
-    queryKey: ["node-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("nodes").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getNode(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -251,7 +252,7 @@ export function useNodeDetail(cluster: string, name: string | null) {
 
 export function useNodeMetrics(cluster: string, name: string | null) {
   return useQuery<NodeMetrics>({
-    queryKey: ["node-metrics", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("nodes").metrics("", name ?? ""),
     queryFn: ({ signal }) => api.getNodeMetrics(cluster, name!, signal),
     enabled: Boolean(name),
     refetchInterval: 30_000,
@@ -260,7 +261,7 @@ export function useNodeMetrics(cluster: string, name: string | null) {
 
 export function usePodMetrics(cluster: string, ns: string, name: string | null) {
   return useQuery<PodMetrics>({
-    queryKey: ["pod-metrics", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("pods").metrics(ns, name ?? ""),
     queryFn: ({ signal }) => api.getPodMetrics(cluster, ns, name!, signal),
     enabled: Boolean(name),
     refetchInterval: 30_000,
@@ -297,7 +298,7 @@ export function useYaml(
   enabled: boolean,
 ) {
   return useQuery<string>({
-    queryKey: ["yaml", cluster, kind, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind(kind).yaml(ns, name ?? ""),
     queryFn: ({ signal }) =>
       (["namespaces", "pvs", "storageclasses", "clusterroles", "clusterrolebindings", "ingressclasses", "priorityclasses", "runtimeclasses"] as ClusterScopedKind[]).includes(kind as ClusterScopedKind)
         ? api.clusterScopedYaml(cluster, kind as ClusterScopedKind, name!, signal)
@@ -311,19 +312,18 @@ export function useYaml(
 
 export function useResourceMeta(
   cluster: string,
+  // `kind` is the YAML/URL plural (matches KIND_REGISTRY). Required so
+  // meta lives under the same kind subtree as list/detail/yaml/events
+  // and a single prefix invalidation sweeps it on apply.
+  kind: YamlKind,
   resource: { group: string; version: string; resource: string; namespace?: string; name: string } | null,
   enabled: boolean,
 ) {
   return useQuery<ResourceMeta>({
-    queryKey: [
-      "meta",
-      cluster,
-      resource?.group,
-      resource?.version,
-      resource?.resource,
-      resource?.namespace ?? "",
-      resource?.name,
-    ],
+    queryKey: queryKeys
+      .cluster(cluster)
+      .kind(kind)
+      .meta(resource?.namespace ?? "", resource?.name ?? ""),
     queryFn: ({ signal }) =>
       api.getMeta(
         {
@@ -360,7 +360,7 @@ export function useOpenAPISchema(
   enabled: boolean,
 ) {
   return useQuery<OpenAPIDoc>({
-    queryKey: ["openapi", cluster, group, version],
+    queryKey: queryKeys.cluster(cluster).openapi(group, version),
     queryFn: ({ signal }) => api.getOpenAPISchema(cluster, group, version, signal),
     enabled: enabled && Boolean(cluster && version),
     // Schemas only change on cluster upgrade — and a backend restart
@@ -374,7 +374,7 @@ export function useOpenAPISchema(
 
 export function useClusterSummary(cluster: string) {
   return useQuery<ClusterSummary>({
-    queryKey: ["cluster-summary", cluster],
+    queryKey: queryKeys.cluster(cluster).summary(),
     queryFn: ({ signal }) => api.getClusterSummary(cluster, signal),
     refetchInterval: 30_000,
   });
@@ -384,7 +384,7 @@ export function useClusterSummary(cluster: string) {
 
 export function useRoleDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<RoleDetail>({
-    queryKey: ["role-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("roles").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getRoles(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -392,7 +392,7 @@ export function useRoleDetail(cluster: string, ns: string, name: string | null) 
 
 export function useClusterRoleDetail(cluster: string, name: string | null) {
   return useQuery<ClusterRoleDetail>({
-    queryKey: ["clusterrole-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("clusterroles").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getClusterRole(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -400,7 +400,7 @@ export function useClusterRoleDetail(cluster: string, name: string | null) {
 
 export function useRoleBindingDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<RoleBindingDetail>({
-    queryKey: ["rolebinding-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("rolebindings").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getRoleBinding(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -408,7 +408,7 @@ export function useRoleBindingDetail(cluster: string, ns: string, name: string |
 
 export function useClusterRoleBindingDetail(cluster: string, name: string | null) {
   return useQuery<ClusterRoleBindingDetail>({
-    queryKey: ["clusterrolebinding-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("clusterrolebindings").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getClusterRoleBinding(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -416,7 +416,7 @@ export function useClusterRoleBindingDetail(cluster: string, name: string | null
 
 export function useServiceAccountDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<ServiceAccountDetail>({
-    queryKey: ["serviceaccount-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("serviceaccounts").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getServiceAccount(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -432,7 +432,7 @@ export function useObjectEvents(
   enabled: boolean,
 ) {
   return useQuery<EventList>({
-    queryKey: ["events", cluster, kind, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind(kind).events(ns, name ?? ""),
     queryFn: ({ signal }) =>
       (["namespaces", "pvs", "storageclasses", "clusterroles", "clusterrolebindings", "ingressclasses", "priorityclasses", "runtimeclasses"] as ClusterScopedKind[]).includes(kind as ClusterScopedKind)
         ? api.clusterScopedEvents(cluster, kind as ClusterScopedKind, name!, signal)
@@ -445,7 +445,7 @@ export function useObjectEvents(
 
 export function useHPADetail(cluster: string, ns: string, name: string | null) {
   return useQuery<HPADetail>({
-    queryKey: ["hpa-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("horizontalpodautoscalers").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getHPA(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -453,7 +453,7 @@ export function useHPADetail(cluster: string, ns: string, name: string | null) {
 
 export function usePDBDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<PDBDetail>({
-    queryKey: ["pdb-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("poddisruptionbudgets").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getPDB(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -461,7 +461,7 @@ export function usePDBDetail(cluster: string, ns: string, name: string | null) {
 
 export function useReplicaSetDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<ReplicaSetDetail>({
-    queryKey: ["replicaset-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("replicasets").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getReplicaSet(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -469,7 +469,7 @@ export function useReplicaSetDetail(cluster: string, ns: string, name: string | 
 
 export function useNetworkPolicyDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<NetworkPolicyDetail>({
-    queryKey: ["networkpolicy-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("networkpolicies").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getNetworkPolicy(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -477,7 +477,7 @@ export function useNetworkPolicyDetail(cluster: string, ns: string, name: string
 
 export function useIngressClassDetail(cluster: string, name: string | null) {
   return useQuery<IngressClassDetail>({
-    queryKey: ["ingressclass-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("ingressclasses").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getIngressClass(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -485,7 +485,7 @@ export function useIngressClassDetail(cluster: string, name: string | null) {
 
 export function useResourceQuotaDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<ResourceQuota>({
-    queryKey: ["resourcequota-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("resourcequotas").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getResourceQuota(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -493,7 +493,7 @@ export function useResourceQuotaDetail(cluster: string, ns: string, name: string
 
 export function useLimitRangeDetail(cluster: string, ns: string, name: string | null) {
   return useQuery<LimitRangeDetail>({
-    queryKey: ["limitrange-detail", cluster, ns, name],
+    queryKey: queryKeys.cluster(cluster).kind("limitranges").detail(ns, name ?? ""),
     queryFn: ({ signal }) => api.getLimitRange(cluster, ns, name!, signal),
     enabled: Boolean(name),
   });
@@ -501,7 +501,7 @@ export function useLimitRangeDetail(cluster: string, ns: string, name: string | 
 
 export function usePriorityClassDetail(cluster: string, name: string | null) {
   return useQuery<PriorityClassDetail>({
-    queryKey: ["priorityclass-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("priorityclasses").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getPriorityClass(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -509,7 +509,7 @@ export function usePriorityClassDetail(cluster: string, name: string | null) {
 
 export function useRuntimeClassDetail(cluster: string, name: string | null) {
   return useQuery<RuntimeClassDetail>({
-    queryKey: ["runtimeclass-detail", cluster, name],
+    queryKey: queryKeys.cluster(cluster).kind("runtimeclasses").detail("", name ?? ""),
     queryFn: ({ signal }) => api.getRuntimeClass(cluster, name!, signal),
     enabled: Boolean(name),
   });
@@ -519,7 +519,7 @@ export function useRuntimeClassDetail(cluster: string, name: string | null) {
 
 export function useCRDs(cluster: string) {
   return useQuery({
-    queryKey: ["crds", cluster],
+    queryKey: queryKeys.cluster(cluster).crds(),
     queryFn: ({ signal }) => api.crds(cluster, signal),
     // CRDs change infrequently — cache hit is the common case.
     staleTime: 30_000,
@@ -534,7 +534,7 @@ export function useCustomResources(
   namespace?: string,
 ) {
   return useQuery({
-    queryKey: ["customresources", cluster, group, version, plural, namespace ?? ""],
+    queryKey: queryKeys.cluster(cluster).cr(group, version, plural).list(namespace ?? ""),
     queryFn: ({ signal }) =>
       api.customResources(cluster, group, version, plural, namespace, signal),
     enabled: Boolean(group && version && plural),
@@ -550,7 +550,10 @@ export function useCustomResourceDetail(
   name: string | null,
 ) {
   return useQuery({
-    queryKey: ["customresource", cluster, group, version, plural, namespace ?? "", name ?? ""],
+    queryKey: queryKeys
+      .cluster(cluster)
+      .cr(group, version, plural)
+      .detail(namespace ?? "", name ?? ""),
     queryFn: ({ signal }) =>
       api.getCustomResource(cluster, group, version, plural, namespace, name!, signal),
     enabled: Boolean(name && group && version && plural),

--- a/web/src/hooks/useResource.ts
+++ b/web/src/hooks/useResource.ts
@@ -47,6 +47,20 @@ interface ResourceQueryArgs {
   namespace?: string;
 }
 
+// Per-kind background-refresh cadence. Only kinds whose state
+// transitions on its own (controller-driven, ephemeral, or
+// short-lived) get polled — the rest stay refresh-on-demand to keep
+// the request rate predictable.
+//
+// Holding pattern until issue #4 (real-time push via K8s watch
+// streams) lands; once that ships these intervals become moot.
+const LIST_REFETCH_INTERVAL: Partial<Record<ResourceKind, number>> = {
+  pods: 15_000,
+  replicasets: 30_000,
+  events: 15_000,
+  jobs: 30_000,
+};
+
 export function useResource({ cluster, resource, namespace }: ResourceQueryArgs) {
   return useQuery<ResourceListResponse>({
     queryKey: queryKeys.cluster(cluster ?? "").kind(resource).list(namespace ?? ""),
@@ -117,6 +131,8 @@ export function useResource({ cluster, resource, namespace }: ResourceQueryArgs)
       }
     },
     enabled: Boolean(cluster),
+    refetchInterval: LIST_REFETCH_INTERVAL[resource] ?? false,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -139,6 +139,22 @@ pre,
   }
 }
 
+/* fetchbar — indeterminate left-to-right sweep used by GlobalFetchingBar
+   to signal background refetches. The bar element is 33% wide; the
+   keyframe slides it from -100% to 200% so it traverses the full
+   viewport width regardless of container size. */
+@keyframes fetchbar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+}
+.animate-fetchbar {
+  animation: fetchbar 1.2s ease-in-out infinite;
+}
+
 /* Owner-glyph margin — colored 4px bars in Monaco's gutter showing
    which K8s SSA field manager owns each line. Categories map to the
    accent palette also used in ConflictResolutionView's manager

--- a/web/src/lib/labels.test.ts
+++ b/web/src/lib/labels.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  findDuplicateKeys,
+  validateLabelKey,
+  validateLabelValue,
+} from "./labels";
+
+describe("validateLabelKey", () => {
+  it("accepts simple alphanumeric keys", () => {
+    expect(validateLabelKey("env")).toBeNull();
+    expect(validateLabelKey("app")).toBeNull();
+    expect(validateLabelKey("Tier1")).toBeNull();
+  });
+
+  it("accepts keys with prefixes", () => {
+    expect(validateLabelKey("app.kubernetes.io/name")).toBeNull();
+    expect(validateLabelKey("example.com/team")).toBeNull();
+  });
+
+  it("accepts keys with - _ . in the interior", () => {
+    expect(validateLabelKey("my-app")).toBeNull();
+    expect(validateLabelKey("my_app")).toBeNull();
+    expect(validateLabelKey("my.app")).toBeNull();
+  });
+
+  it("rejects empty key", () => {
+    expect(validateLabelKey("")).toMatch(/required/);
+  });
+
+  it("rejects empty prefix", () => {
+    expect(validateLabelKey("/name")).toMatch(/prefix/);
+  });
+
+  it("rejects empty name segment", () => {
+    expect(validateLabelKey("example.com/")).toMatch(/name segment/);
+  });
+
+  it("rejects name segment longer than 63 chars", () => {
+    expect(validateLabelKey("a".repeat(64))).toMatch(/63/);
+  });
+
+  it("rejects prefix longer than 253 chars", () => {
+    expect(validateLabelKey(`${"a".repeat(254)}/name`)).toMatch(/253/);
+  });
+
+  it("rejects name segment with invalid edges", () => {
+    expect(validateLabelKey("-foo")).not.toBeNull();
+    expect(validateLabelKey("foo-")).not.toBeNull();
+    expect(validateLabelKey(".foo")).not.toBeNull();
+  });
+
+  it("rejects prefix that's not a DNS subdomain", () => {
+    expect(validateLabelKey("Foo.Bar/name")).toMatch(/DNS/);
+    expect(validateLabelKey("foo_bar/name")).toMatch(/DNS/);
+  });
+});
+
+describe("validateLabelValue", () => {
+  it("allows empty value", () => {
+    expect(validateLabelValue("")).toBeNull();
+  });
+
+  it("accepts simple values", () => {
+    expect(validateLabelValue("production")).toBeNull();
+    expect(validateLabelValue("v1.2.3")).toBeNull();
+    expect(validateLabelValue("a-b_c.d")).toBeNull();
+  });
+
+  it("rejects values longer than 63 chars", () => {
+    expect(validateLabelValue("a".repeat(64))).toMatch(/63/);
+  });
+
+  it("rejects values with invalid edges", () => {
+    expect(validateLabelValue("-foo")).not.toBeNull();
+    expect(validateLabelValue("foo-")).not.toBeNull();
+  });
+});
+
+describe("findDuplicateKeys", () => {
+  it("returns empty set when keys are unique", () => {
+    const dups = findDuplicateKeys([
+      { key: "a", value: "1" },
+      { key: "b", value: "2" },
+    ]);
+    expect(dups.size).toBe(0);
+  });
+
+  it("flags duplicates", () => {
+    const dups = findDuplicateKeys([
+      { key: "a", value: "1" },
+      { key: "a", value: "2" },
+      { key: "b", value: "3" },
+    ]);
+    expect(dups.has("a")).toBe(true);
+    expect(dups.has("b")).toBe(false);
+  });
+
+  it("ignores empty keys", () => {
+    const dups = findDuplicateKeys([
+      { key: "", value: "1" },
+      { key: "", value: "2" },
+    ]);
+    expect(dups.size).toBe(0);
+  });
+});

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -1,0 +1,74 @@
+// labels — validation for Kubernetes label keys and values.
+//
+// Mirrors the apiserver's enforcement so the EditLabelsModal can red-line
+// invalid rows inline rather than waiting for a 422 round-trip. Rules
+// from https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
+//
+// Key
+//   Optional `prefix/`, where prefix is a DNS subdomain (≤253 chars).
+//   Name segment: ≤63 chars, alphanumeric edges, interior may include
+//   `-`, `_`, `.`. Required.
+//
+// Value
+//   ≤63 chars, same character class as the name segment, OR empty.
+
+const SEGMENT = /^[a-z0-9A-Z]([-a-z0-9A-Z_.]*[a-z0-9A-Z])?$/;
+
+// DNS subdomain (RFC 1123): lowercase labels separated by dots, each
+// label ≤63 chars and alphanumeric edges. Used for the optional key
+// prefix and validated separately so we can give a specific error.
+const DNS_SUBDOMAIN_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+export function validateLabelKey(key: string): string | null {
+  if (key.length === 0) return "key is required";
+  const slash = key.indexOf("/");
+  let prefix: string | null = null;
+  let name: string;
+  if (slash >= 0) {
+    prefix = key.slice(0, slash);
+    name = key.slice(slash + 1);
+  } else {
+    name = key;
+  }
+  if (prefix !== null) {
+    if (prefix.length === 0) return "prefix before '/' is empty";
+    if (prefix.length > 253) return "prefix must be ≤253 chars";
+    const labels = prefix.split(".");
+    if (labels.some((l) => !DNS_SUBDOMAIN_LABEL.test(l))) {
+      return "prefix must be a DNS subdomain (lowercase, alphanumeric, dot-separated)";
+    }
+  }
+  if (name.length === 0) return "name segment after '/' is empty";
+  if (name.length > 63) return "name segment must be ≤63 chars";
+  if (!SEGMENT.test(name)) {
+    return "name must start/end with alphanumeric; interior may use - _ .";
+  }
+  return null;
+}
+
+export function validateLabelValue(value: string): string | null {
+  if (value.length === 0) return null; // empty value is allowed
+  if (value.length > 63) return "value must be ≤63 chars";
+  if (!SEGMENT.test(value)) {
+    return "value must start/end with alphanumeric; interior may use - _ .";
+  }
+  return null;
+}
+
+export interface LabelRow {
+  key: string;
+  value: string;
+}
+
+// findDuplicateKeys returns the set of keys that appear more than once.
+// Empty keys are ignored — they're already flagged by validateLabelKey.
+export function findDuplicateKeys(rows: LabelRow[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const r of rows) {
+    if (r.key.length === 0) continue;
+    counts.set(r.key, (counts.get(r.key) ?? 0) + 1);
+  }
+  const dups = new Set<string>();
+  for (const [k, n] of counts) if (n > 1) dups.add(k);
+  return dups;
+}

--- a/web/src/lib/listShape.ts
+++ b/web/src/lib/listShape.ts
@@ -1,0 +1,125 @@
+// listShape — maps a YAML/URL plural kind to the field name on its
+// corresponding *List response type.
+//
+// The /api/clusters/{cluster}/{kind} endpoints return kind-specific
+// shapes (DeploymentList = { deployments: Deployment[] },
+// ReplicaSetList = { replicaSets: ReplicaSet[] }, …) — the array isn't
+// always under the URL kind verbatim. Optimistic mutations that need
+// to splice the list (delete, scale-affecting-list-row) need this map
+// so a generic helper can locate the array regardless of kind.
+//
+// Keep in sync with src/lib/types.ts list-interface field names.
+
+import type { ResourceListResponse } from "./types";
+
+export const LIST_ITEMS_KEY: Record<string, string> = {
+  // core/v1
+  pods: "pods",
+  services: "services",
+  configmaps: "configMaps",
+  secrets: "secrets",
+  namespaces: "namespaces",
+  pvs: "pvs",
+  pvcs: "pvcs",
+  serviceaccounts: "serviceAccounts",
+  resourcequotas: "resourceQuotas",
+  limitranges: "limitRanges",
+  nodes: "nodes",
+
+  // apps/v1
+  deployments: "deployments",
+  statefulsets: "statefulSets",
+  daemonsets: "daemonSets",
+  replicasets: "replicaSets",
+
+  // batch/v1
+  jobs: "jobs",
+  cronjobs: "cronJobs",
+
+  // networking.k8s.io/v1
+  ingresses: "ingresses",
+  ingressclasses: "ingressClasses",
+  networkpolicies: "networkPolicies",
+
+  // rbac.authorization.k8s.io/v1
+  roles: "roles",
+  rolebindings: "roleBindings",
+  clusterroles: "clusterRoles",
+  clusterrolebindings: "clusterRoleBindings",
+
+  // storage.k8s.io/v1
+  storageclasses: "storageClasses",
+
+  // autoscaling/v2
+  horizontalpodautoscalers: "hpas",
+
+  // policy/v1
+  poddisruptionbudgets: "pdbs",
+
+  // scheduling.k8s.io/v1
+  priorityclasses: "priorityClasses",
+
+  // node.k8s.io/v1
+  runtimeclasses: "runtimeClasses",
+};
+
+interface ListLike {
+  [field: string]: unknown;
+}
+
+interface NamedRow {
+  name: string;
+  namespace?: string;
+}
+
+// Returns a shallow-cloned list with the row matching (name, namespace)
+// filtered out. Returns the original reference unchanged if the kind
+// has no known field or the row doesn't match.
+export function removeRowFromList(
+  list: ResourceListResponse | undefined,
+  kind: string,
+  match: NamedRow,
+): ResourceListResponse | undefined {
+  if (!list) return list;
+  const field = LIST_ITEMS_KEY[kind];
+  if (!field) return list;
+  const obj = list as unknown as ListLike;
+  const items = obj[field];
+  if (!Array.isArray(items)) return list;
+  const next = items.filter((row) => {
+    const r = row as NamedRow;
+    if (r.name !== match.name) return true;
+    // Match namespace too when present (cluster-scoped resources have
+    // no namespace; treat undefined === undefined as a match).
+    return (r.namespace ?? undefined) !== (match.namespace ?? undefined);
+  });
+  if (next.length === items.length) return list;
+  return { ...obj, [field]: next } as unknown as ResourceListResponse;
+}
+
+// Returns a shallow-cloned list with the row matching (name, namespace)
+// patched via `patch(row)`. Returns the original reference unchanged if
+// the kind has no known field or the row doesn't match.
+export function patchRowInList<T extends NamedRow>(
+  list: ResourceListResponse | undefined,
+  kind: string,
+  match: NamedRow,
+  patch: (row: T) => T,
+): ResourceListResponse | undefined {
+  if (!list) return list;
+  const field = LIST_ITEMS_KEY[kind];
+  if (!field) return list;
+  const obj = list as unknown as ListLike;
+  const items = obj[field];
+  if (!Array.isArray(items)) return list;
+  let touched = false;
+  const next = items.map((row) => {
+    const r = row as T;
+    if (r.name !== match.name) return row;
+    if ((r.namespace ?? undefined) !== (match.namespace ?? undefined)) return row;
+    touched = true;
+    return patch(r);
+  });
+  if (!touched) return list;
+  return { ...obj, [field]: next } as unknown as ResourceListResponse;
+}

--- a/web/src/lib/queryKeys.test.ts
+++ b/web/src/lib/queryKeys.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+
+// Strict prefix means: arr is shorter than other AND every element of
+// arr equals the corresponding element of other. Mirrors react-query's
+// own partialMatchKey contract — invalidating a prefix sweeps every
+// query whose key starts with that prefix.
+function isStrictPrefix(arr: readonly unknown[], other: readonly unknown[]) {
+  if (arr.length >= other.length) return false;
+  return arr.every((v, i) => v === other[i]);
+}
+
+describe("queryKeys factory", () => {
+  it("kind.all is a strict prefix of every per-kind view", () => {
+    const k = queryKeys.cluster("c").kind("deployments");
+    expect(isStrictPrefix(k.all, k.list("ns"))).toBe(true);
+    expect(isStrictPrefix(k.all, k.detail("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(k.all, k.yaml("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(k.all, k.events("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(k.all, k.meta("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(k.all, k.metrics("ns", "n"))).toBe(true);
+  });
+
+  it("cluster.all is a strict prefix of every per-cluster query", () => {
+    const c = queryKeys.cluster("c");
+    expect(isStrictPrefix(c.all, c.summary())).toBe(true);
+    expect(isStrictPrefix(c.all, c.namespaces())).toBe(true);
+    expect(isStrictPrefix(c.all, c.crds())).toBe(true);
+    expect(isStrictPrefix(c.all, c.openapi("apps", "v1"))).toBe(true);
+    expect(isStrictPrefix(c.all, c.search("foo"))).toBe(true);
+    expect(isStrictPrefix(c.all, c.kind("pods").all)).toBe(true);
+    expect(isStrictPrefix(c.all, c.cr("g", "v", "widgets").all)).toBe(true);
+  });
+
+  it("edit() keys do not start with the cluster subtree", () => {
+    const e = queryKeys.edit("c", "deployments", "ns", "n");
+    expect(e[0]).toBe("edit");
+    expect(isStrictPrefix(["cluster", "c"], e)).toBe(false);
+  });
+
+  it("clusters() is a sibling of cluster(c).all, not nested", () => {
+    const list = queryKeys.clusters();
+    const c = queryKeys.cluster("c").all;
+    expect(list[0]).toBe("clusters");
+    expect(c[0]).toBe("cluster");
+    expect(isStrictPrefix(list, c)).toBe(false);
+    expect(isStrictPrefix(c, list)).toBe(false);
+  });
+
+  it("cluster(a).all is not a prefix of cluster(b).all", () => {
+    const a = queryKeys.cluster("a").all;
+    const b = queryKeys.cluster("b").all;
+    expect(isStrictPrefix(a, b)).toBe(false);
+    expect(isStrictPrefix(b, a)).toBe(false);
+  });
+
+  it("cr.all is a strict prefix of every per-CR view", () => {
+    const cr = queryKeys.cluster("c").cr("g", "v1", "widgets");
+    expect(isStrictPrefix(cr.all, cr.list("ns"))).toBe(true);
+    expect(isStrictPrefix(cr.all, cr.detail("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(cr.all, cr.yaml("ns", "n"))).toBe(true);
+    expect(isStrictPrefix(cr.all, cr.events("ns", "n"))).toBe(true);
+  });
+});

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -1,0 +1,95 @@
+// queryKeys — single source of truth for every React Query key in the
+// app. Replaces the prior pattern of inline string-literal keys
+// scattered across hooks and mutation call sites, which let small
+// drift (e.g. plural/singular mismatches) silently break invalidation.
+//
+// Shape: hierarchical tuples that nest the cluster id, the resource
+// kind, and the view (list / detail / yaml / events / meta / metrics).
+// Each branch exposes an `all` prefix so a mutation can invalidate the
+// whole subtree in one call:
+//
+//     qc.invalidateQueries({
+//       queryKey: queryKeys.cluster(c).kind("deployments").all,
+//     });
+//
+// cascades to the deployments list, every loaded deployment detail,
+// yaml, events, meta, and metrics for that cluster.
+//
+// Two top-level subtrees plus two registry siblings:
+//   ['cluster', c, ...]   — every per-cluster query.
+//   ['edit', ...]         — editor dirty-bit pub/sub. Sibling of
+//                            ['cluster', ...] so resource invalidation
+//                            cannot blow away the editor's dirty
+//                            indicator.
+//   ['clusters']          — the cluster registry (list of clusters);
+//                            sibling, not nested under ['cluster', c],
+//                            because it is not data inside a cluster.
+//
+// Adding a new query? Add the factory here, then call it from the
+// hook. Static check (run before merge):
+//
+//     grep -RnE 'queryKey:\s*\[' web/src --include='*.ts' --include='*.tsx'
+//
+// Only this file should match.
+
+export const queryKeys = {
+  clusters: () => ["clusters"] as const,
+
+  cluster: (c: string) => ({
+    all: ["cluster", c] as const,
+
+    summary: () => ["cluster", c, "summary"] as const,
+    namespaces: () => ["cluster", c, "namespaces"] as const,
+    crds: () => ["cluster", c, "crds"] as const,
+    openapi: (group: string, version: string) =>
+      ["cluster", c, "openapi", group, version] as const,
+    search: (q: string) => ["cluster", c, "search", q] as const,
+    clusterEvents: (ns: string) =>
+      ["cluster", c, "cluster-events", ns] as const,
+
+    // Per-kind cascade. The `kind` string is the YAML/URL plural
+    // ("deployments", "ingresses", …) — the same token the rest of
+    // the app uses to address the resource type.
+    kind: (kind: string) => ({
+      all: ["cluster", c, "kind", kind] as const,
+      list: (ns: string) => ["cluster", c, "kind", kind, "list", ns] as const,
+      detail: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "detail", ns, name] as const,
+      yaml: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "yaml", ns, name] as const,
+      events: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "events", ns, name] as const,
+      meta: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "meta", ns, name] as const,
+      metrics: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "metrics", ns, name] as const,
+      // Side-channel YAML fetch for the drift-diff modal — distinct
+      // from `yaml(...)` so it doesn't compete with the editor's
+      // pristine-flowing yamlQuery. Still under the kind subtree so a
+      // single prefix invalidation sweeps it.
+      yamlDrift: (ns: string, name: string) =>
+        ["cluster", c, "kind", kind, "yaml-drift", ns, name] as const,
+    }),
+
+    // Custom resources are addressed by GVR (no static registry), so
+    // they get a parallel subtree keyed on (group, version, plural).
+    cr: (group: string, version: string, plural: string) => ({
+      all: ["cluster", c, "cr", group, version, plural] as const,
+      list: (ns: string) =>
+        ["cluster", c, "cr", group, version, plural, "list", ns] as const,
+      detail: (ns: string, name: string) =>
+        ["cluster", c, "cr", group, version, plural, "detail", ns, name] as const,
+      yaml: (ns: string, name: string) =>
+        ["cluster", c, "cr", group, version, plural, "yaml", ns, name] as const,
+      events: (ns: string, name: string) =>
+        ["cluster", c, "cr", group, version, plural, "events", ns, name] as const,
+    }),
+  }),
+
+  // Editor dirty-bit pub/sub channel (see hooks/useEditorDirty). Lives
+  // outside the ['cluster', ...] subtree on purpose: a resource
+  // invalidation must NOT clear the dirty indicator the user is
+  // currently looking at.
+  edit: (cluster: string, kind: string, ns: string, name: string) =>
+    ["edit", cluster, kind, ns, name] as const,
+} as const;

--- a/web/src/pages/CustomResourcesPage.tsx
+++ b/web/src/pages/CustomResourcesPage.tsx
@@ -8,6 +8,7 @@ import {
 import { api } from "../lib/api";
 import { ageFrom, nameMatches } from "../lib/format";
 import { cn } from "../lib/cn";
+import { queryKeys } from "../lib/queryKeys";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
 import {
@@ -310,7 +311,7 @@ export function CustomResourcesPage({ cluster }: { cluster: string }) {
 function CustomResourceYamlView(props: CRDetailRefProps) {
   const { cluster, group, version, plural, namespace, name } = props;
   const yamlQuery = useQuery({
-    queryKey: ["cr-yaml", cluster, group, version, plural, namespace ?? "", name],
+    queryKey: queryKeys.cluster(cluster).cr(group, version, plural).yaml(namespace ?? "", name),
     queryFn: ({ signal }) =>
       api.getCustomResourceYAML(cluster, group, version, plural, namespace, name, signal),
     enabled: Boolean(name),
@@ -372,7 +373,7 @@ function CustomResourceYamlView(props: CRDetailRefProps) {
 function CustomResourceEventsView(props: CRDetailRefProps) {
   const { cluster, group, version, plural, namespace, name } = props;
   const eventsQuery = useQuery({
-    queryKey: ["cr-events", cluster, group, version, plural, namespace ?? "", name],
+    queryKey: queryKeys.cluster(cluster).cr(group, version, plural).events(namespace ?? "", name),
     queryFn: async ({ signal }) => {
       const ns = namespace && namespace.length > 0 ? namespace : "_";
       const url = `/api/clusters/${encodeURIComponent(cluster)}/customresources/${encodeURIComponent(group)}/${encodeURIComponent(version)}/${encodeURIComponent(plural)}/${encodeURIComponent(ns)}/${encodeURIComponent(name)}/events`;

--- a/web/src/routeShells.tsx
+++ b/web/src/routeShells.tsx
@@ -21,6 +21,28 @@ import { useClusters } from "./hooks/useClusters";
 import { queryKeys } from "./lib/queryKeys";
 
 export function AppShell() {
+  const { cluster } = useParams<{ cluster: string }>();
+  const qc = useQueryClient();
+  const prevCluster = useRef<string | undefined>(undefined);
+
+  // Single-cluster-at-a-time UX: when the route's cluster id changes,
+  // evict the prior cluster's subtree so its stale entries don't sit
+  // in the cache (and don't trigger ghost background refetches).
+  // Lives here (the /clusters/:cluster layout) rather than on each
+  // page's WithCluster wrapper because per-page WithClusters unmount
+  // when navigating between pages — the ref would lose its history.
+  // AppShell stays mounted across page changes within a cluster, so
+  // the ref correctly tracks the previous cluster across all
+  // navigations.
+  useEffect(() => {
+    if (cluster && prevCluster.current && prevCluster.current !== cluster) {
+      qc.removeQueries({
+        queryKey: queryKeys.cluster(prevCluster.current).all,
+      });
+    }
+    prevCluster.current = cluster;
+  }, [cluster, qc]);
+
   return (
     <div className="flex h-full">
       <div className="flex h-full shrink-0 flex-col border-r border-border bg-surface">
@@ -44,21 +66,6 @@ export function WithCluster<P extends { cluster: string }>({
   Page: React.ComponentType<P>;
 }) {
   const { cluster } = useParams<{ cluster: string }>();
-  const qc = useQueryClient();
-  const prevCluster = useRef<string | undefined>(undefined);
-
-  // Single-cluster-at-a-time UX: when the route's cluster id changes,
-  // evict the prior cluster's subtree so its stale entries don't sit
-  // in the cache (and don't trigger ghost background refetches).
-  useEffect(() => {
-    if (cluster && prevCluster.current && prevCluster.current !== cluster) {
-      qc.removeQueries({
-        queryKey: queryKeys.cluster(prevCluster.current).all,
-      });
-    }
-    prevCluster.current = cluster;
-  }, [cluster, qc]);
-
   if (!cluster) return null;
   return <Page {...({ cluster } as unknown as P)} />;
 }


### PR DESCRIPTION
Introduce web/src/lib/queryKeys.ts as the single source of truth for every React Query key. Keys nest as ['cluster', c, 'kind', k, view, ns, name] so a single prefix invalidation cascades to list, detail, yaml, events, meta and metrics for that kind. Replaces the prior pattern of inline literal keys plus a buggy singularize() helper, which silently mis-keyed *-detail invalidation for irregular plurals (ingresses, policies, …) — the root cause of post-apply UIs not refreshing without a manual reload.

YamlEditor's apply paths now await a single prefix invalidation in place of five scattered calls plus the 400ms setTimeout that masked the unmount/refetch race. ResourceActions awaits the same prefix invalidation before navigating away on delete. The drift overlay's side-channel YAML fetch keeps a sibling key (kind.yamlDrift) so it doesn't compete with the editor's pristine flow.

Add GlobalFetchingBar — 2px indeterminate sweep above the page content, gated to background refetches via
useIsFetching({ predicate: q => q.state.data !== undefined }) so cold loads keep their per-page skeletons. Custom keyframe in index.css (Tailwind v4 CSS-mode, no config file).

WithCluster evicts the previous cluster's subtree on cluster switch via removeQueries({ queryKey: queryKeys.cluster(prev).all }) — bounded memory and no ghost refetches for the single-cluster-at-a-time UX.

Verified: vitest 32/32 (incl. 6 new queryKeys factory tests), tsc -b clean, eslint clean.