### PR TITLE
Add operator documentation for pod exec, watch streams, and helm browser

### DIFF
--- a/deploy/helm/periscope/README.md
+++ b/deploy/helm/periscope/README.md
@@ -83,6 +83,26 @@ The chart defaults to a plain ServiceAccount. Pick one path:
 
 The Periscope code is identical for both — same default credential chain.
 
+## Pod exec
+
+Pod exec is enabled on every cluster by default. Tune the global
+defaults under `exec:` (idle/heartbeat/cap settings) and override
+per-cluster under `clusters[].exec:` (partial overrides are fine —
+omitted fields fall back to the global default). Set
+`clusters[<i>].exec.enabled: false` to opt a specific cluster out.
+
+See `docs/setup/pod-exec.md` for the operator guide and RFC 0001 for
+the design.
+
+## Helm release browser
+
+The chart deploys a read-only Helm release browser as part of the
+Periscope binary — it surfaces under `/api/clusters/{cluster}/helm/...`
+and the SPA's "Helm" sidebar group. No additional values; the
+impersonated user's RBAC governs visibility (the browser needs `get`
+on `secrets` in release namespaces, which is the default storage
+driver). See `docs/setup/helm-releases.md`.
+
 ## Values reference
 
 See `values.yaml` for the full surface with inline comments.

--- a/deploy/helm/periscope/templates/deployment.yaml
+++ b/deploy/helm/periscope/templates/deployment.yaml
@@ -80,6 +80,37 @@ spec:
             - name: PERISCOPE_AUDIT_VACUUM_INTERVAL
               value: {{ .Values.audit.vacuumInterval | quote }}
             {{- end }}
+            {{- /*
+              Pod exec global defaults. Per-cluster overrides live in
+              clusters.yaml (rendered by configmap-clusters.yaml) and
+              are merged on top of these values inside the binary.
+            */}}
+            {{- with .Values.exec }}
+            {{- if .serverIdleSeconds }}
+            - name: PERISCOPE_EXEC_IDLE_SECONDS
+              value: {{ .serverIdleSeconds | quote }}
+            {{- end }}
+            {{- if .idleWarnSeconds }}
+            - name: PERISCOPE_EXEC_IDLE_WARN_SECONDS
+              value: {{ .idleWarnSeconds | quote }}
+            {{- end }}
+            {{- if .heartbeatSeconds }}
+            - name: PERISCOPE_EXEC_HEARTBEAT_SECONDS
+              value: {{ .heartbeatSeconds | quote }}
+            {{- end }}
+            {{- if .maxSessionsPerUser }}
+            - name: PERISCOPE_EXEC_MAX_SESSIONS_PER_USER
+              value: {{ .maxSessionsPerUser | quote }}
+            {{- end }}
+            {{- if .maxSessionsTotal }}
+            - name: PERISCOPE_EXEC_MAX_SESSIONS_TOTAL
+              value: {{ .maxSessionsTotal | quote }}
+            {{- end }}
+            {{- if .probeClustersOnBoot }}
+            - name: PERISCOPE_PROBE_CLUSTERS_ON_BOOT
+              value: "1"
+            {{- end }}
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/periscope/values.schema.json
+++ b/deploy/helm/periscope/values.schema.json
@@ -155,6 +155,42 @@
       "properties": {
         "enabled": { "type": "boolean" }
       }
+    },
+    "exec": {
+      "type": "object",
+      "description": "Pod exec global defaults. Per-cluster overrides in clusters[].exec take precedence. See docs/setup/pod-exec.md.",
+      "properties": {
+        "serverIdleSeconds":   { "type": "integer", "minimum": 1 },
+        "idleWarnSeconds":     { "type": "integer", "minimum": 1 },
+        "heartbeatSeconds":    { "type": "integer", "minimum": 1 },
+        "maxSessionsPerUser":  { "type": "integer", "minimum": 1 },
+        "maxSessionsTotal":    { "type": "integer", "minimum": 1 },
+        "probeClustersOnBoot": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "clusters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name":    { "type": "string", "minLength": 1 },
+          "backend": { "type": "string", "enum": ["eks", "kubeconfig"] },
+          "exec": {
+            "type": "object",
+            "description": "Per-cluster pod-exec overrides. Partial overrides are fine — omitted fields fall back to the global .exec defaults.",
+            "properties": {
+              "enabled":            { "type": "boolean" },
+              "serverIdleSeconds":  { "type": "integer", "minimum": 1 },
+              "idleWarnSeconds":    { "type": "integer", "minimum": 1 },
+              "heartbeatSeconds":   { "type": "integer", "minimum": 1 },
+              "maxSessionsPerUser": { "type": "integer", "minimum": 1 },
+              "maxSessionsTotal":   { "type": "integer", "minimum": 1 }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
     }
   }
 }

--- a/deploy/helm/periscope/values.yaml
+++ b/deploy/helm/periscope/values.yaml
@@ -117,6 +117,31 @@ auth:
 # Clusters registry — written verbatim into a ConfigMap as clusters.yaml.
 # See examples/config/clusters.yaml for a fuller example with multiple
 # backends.
+#
+# Per-cluster `exec:` overrides
+# -----------------------------
+# Any cluster entry MAY override the global pod-exec defaults (set under
+# the top-level .exec block) on a field-by-field basis. Omitted fields
+# fall through to the global default — partial overrides are fine.
+#
+# Example with overrides:
+#   - name: prod-eu-west-1
+#     backend: eks
+#     region: eu-west-1
+#     arn: arn:aws:eks:eu-west-1:222222222222:cluster/prod-eu-west-1
+#     exec:
+#       # Long-running prod debugging: 30-min idle timeout, beefier caps.
+#       serverIdleSeconds: 1800
+#       maxSessionsPerUser: 10
+#       maxSessionsTotal: 100
+#
+#   - name: locked-down
+#     backend: eks
+#     region: us-west-2
+#     arn: arn:aws:eks:us-west-2:333333333333:cluster/locked
+#     exec:
+#       # Disable interactive shell entirely on this cluster.
+#       enabled: false
 # -----------------------------------------------------------------------------
 clusters: []
 # - name: prod-eu-west-1
@@ -313,6 +338,64 @@ audit:
     # is sufficient for the v1 single-replica topology.
     storageClass: ""
     accessMode: ReadWriteOnce
+
+# -----------------------------------------------------------------------------
+# Pod exec (interactive shell into containers)
+#
+# Periscope ships pod exec on by default. The route is registered for
+# every cluster in the registry; a user clicking "Open Shell" upgrades
+# to a WebSocket and the binary streams stdin/stdout/stderr from the
+# kube-apiserver under the user's impersonated identity.
+#
+# These are GLOBAL DEFAULTS — applied to every cluster's sessions
+# unless a cluster entry overrides them in clusters[].exec (see the
+# clusters: section above).
+#
+# There is intentionally no global `exec.enabled` switch. Disabling
+# exec is a per-cluster decision: set `clusters[<i>].exec.enabled:
+# false` to opt a specific cluster out (the UI hides the action and
+# the API returns 403 / E_EXEC_DISABLED). To turn exec off everywhere,
+# set it false on every cluster entry — typically a sign the feature
+# is the wrong fit for your deployment.
+#
+# See docs/setup/pod-exec.md for the operator guide (caps, transports,
+# circuit breaker, troubleshooting) and RFC 0001 for the design.
+# -----------------------------------------------------------------------------
+exec:
+  # Server-side idle timeout. No stdin/stdout activity for this long
+  # tears the session down. The browser shows a 30-second warning
+  # banner before the cut. Bump for clusters where long-running
+  # debugging is normal (e.g. prod incident response → 1800s).
+  serverIdleSeconds: 600
+
+  # How long before the server idle cut the browser is warned.
+  # Subtracted from the idle deadline, so users can keep the session
+  # alive by typing.
+  idleWarnSeconds: 30
+
+  # WebSocket heartbeat interval. Sends a ping frame every N seconds
+  # to keep intermediate proxies (ingress, NLB, CloudFront) from
+  # silently dropping idle sockets.
+  heartbeatSeconds: 20
+
+  # Concurrent exec sessions per OIDC subject, across all clusters
+  # they have access to. Hit the cap → HTTP 429 with the active
+  # sessions in the response body. Per-cluster overrides win.
+  maxSessionsPerUser: 5
+
+  # Concurrent exec sessions per cluster, total across all users.
+  # Soft ceiling that protects the apiserver and the Periscope pod's
+  # memory — each session pins ~1 MiB of buffers. Per-cluster
+  # overrides win.
+  maxSessionsTotal: 50
+
+  # When true, Periscope pre-warms each cluster's IAM credentials and
+  # exec policy at boot. Off by default; turn on when first-exec
+  # latency on cold clusters is a UX problem (typically ~3-5s the
+  # first time a cluster is touched after a restart).
+  probeClustersOnBoot: false
+
+# -----------------------------------------------------------------------------
 # Pod Disruption Budget
 #
 # v1 is single-replica (in-memory session store) so a node drain takes

--- a/docs/architecture/watch-streams.md
+++ b/docs/architecture/watch-streams.md
@@ -1,0 +1,322 @@
+# Watch streams
+
+This is a **contributor / architecture** doc. The audience is someone
+extending Periscope's real-time list updates to a new resource kind,
+or debugging an existing one. Operator-facing config is documented
+inline in [`deploy/helm/periscope/values.yaml`](../../deploy/helm/periscope/values.yaml)
+and the audit / pod-exec pages — there is no helm config here because
+watch streams are on by default for the four shipped kinds.
+
+For the SSE plumbing on the frontend (`useResourceStream`,
+`StreamHealthBadge`, drop-in dispatch into React Query), see the
+relevant `web/` files; this page covers only the server side.
+
+---
+
+## 1. What "watch stream" means here
+
+Periscope's resource list pages (Pods, Events, ReplicaSets, Jobs)
+need to update in near-real-time. The naive answer is "poll every 5s
+and diff in the client." We do better:
+
+1. The browser opens an `EventSource` to `/api/clusters/{cluster}/{kind}/watch`.
+2. The server runs a single **list-then-watch** loop against the
+   apiserver under the impersonated user's identity.
+3. The server emits SSE frames: one `Snapshot` event with the initial
+   list, then `Added` / `Modified` / `Deleted` deltas as the apiserver
+   reports them.
+4. The frontend's React Query cache patches itself from the deltas —
+   no full re-fetch.
+5. On disconnect the browser's `EventSource` reconnects automatically;
+   the server uses `Last-Event-ID` to resume from the last
+   `resourceVersion` without re-emitting the full snapshot.
+
+When watch is disabled (or the kind isn't supported), the SPA falls
+back to a polling `useResource` query. Both code paths return the
+same DTO shape, so feature parity is automatic.
+
+---
+
+## 2. The four shipped kinds
+
+| Kind | Path | DTO | Code |
+|---|---|---|---|
+| Pods | `/api/clusters/{cluster}/pods/watch` | `Pod` | `internal/k8s/watch.go: WatchPods` |
+| Events | `/api/clusters/{cluster}/events/watch` | `ClusterEvent` | `internal/k8s/watch.go: WatchEvents` |
+| ReplicaSets | `/api/clusters/{cluster}/replicasets/watch` | `ReplicaSet` | `internal/k8s/watch.go: WatchReplicaSets` |
+| Jobs | `/api/clusters/{cluster}/jobs/watch` | `Job` | `internal/k8s/watch.go: WatchJobs` |
+
+Each is a thin wrapper around the generic `watchKind[T, S]` primitive.
+
+---
+
+## 3. The `watchKind[T, S]` primitive
+
+```
+  T = the Kubernetes API type    (e.g. corev1.Pod)
+  S = the list-view DTO          (e.g. internal/k8s.Pod)
+```
+
+A `watchSpec[T, S]` carries the per-kind plumbing:
+
+```go
+type watchSpec[T any, S any] struct {
+    Kind     string
+    List     func(ctx, opts) ([]T, resourceVersion, error)
+    Watch    func(ctx, opts) (watch.Interface, error)
+    Summary  func(*T) S        // T → list-view DTO; same fn for snapshot and deltas
+    PostList func([]S) []S     // optional: sort/cap snapshot before sending
+}
+```
+
+`watchKind` runs the canonical lifecycle:
+
+1. **If `resumeFrom != ""`** (client reconnected with `Last-Event-ID`):
+   skip List, open Watch directly at that resourceVersion. **Do not
+   emit a Snapshot** — the client cache is preserved across the blip.
+2. **Else**: List → emit `Snapshot` → Watch from the list's RV.
+3. Handle apiserver events:
+   - `ADDED` / `MODIFIED` / `DELETED` → emit the corresponding SSE event.
+   - `BOOKMARK` → no emit; the next relist refreshes the RV.
+   - Status `410 Gone` → emit `Relist`, restart the loop.
+4. **Stale `Last-Event-ID`** that the apiserver rejects with `410 Gone`
+   on Watch open → fall through to a fresh List+Watch one time. Stale
+   resume IDs degrade gracefully; they never hard-fail the stream.
+5. ctx cancelled or `sink.Send` returned `false` (backpressure) →
+   return `nil`.
+
+The same `Summary` function projects T → S for both the snapshot and
+each delta, so the frontend's cache patcher always operates on
+shape-identical objects.
+
+---
+
+## 4. Why `PostList` exists (Events-shaped resources)
+
+For most resources, the snapshot is the apiserver's full list. Events
+are different: there are typically thousands of stale events, and the
+list page only shows the most recent ~200. The `PostList` hook lets
+`WatchEvents` sort newest-first and cap the snapshot to match
+`ListClusterEvents` (the polled path).
+
+Delta events bypass `PostList` — they're emitted raw, and the
+frontend's `patchRowInList` reconciler decides whether each delta
+fits the visible window. A `MODIFIED` for an event outside the top-N
+is treated as `ADDED` by the patcher (standard upsert semantics).
+
+When you add a new kind, leave `PostList` nil unless the snapshot
+needs a kind-specific sort or cap.
+
+---
+
+## 5. The handler layer (`resourceWatchHandler`)
+
+`cmd/periscope/main.go: resourceWatchHandler` is a generic SSE handler
+factored over the `Watch*` primitives. For a new kind, you don't
+write a fresh handler — you instantiate the generic one with:
+
+- the route path
+- a closure that calls your `Watch*` function
+- the per-kind authz pre-flight (e.g. `list pods` SAR)
+
+The handler takes care of:
+
+- WebSocket upgrade rejection on non-SSE clients
+- `Last-Event-ID` parsing and threading into `WatchArgs.ResumeFrom`
+- Heartbeat frames every 15s (keeps proxies from killing the socket)
+- Backpressure: if the client falls behind, `sink.Send` returns
+  `false` and the watch loop exits cleanly
+- Stream lifecycle: register with the per-actor limiter and the
+  `streamTracker`; deregister on close
+- Closing the stream on session expiry (the auth layer broadcasts
+  `event:server_shutdown` and per-session expiry signals)
+
+---
+
+## 6. Per-user concurrency cap
+
+`PERISCOPE_WATCH_PER_USER_LIMIT` (default 30) caps concurrent watch
+streams per OIDC subject across all clusters and kinds. Exceeding it
+returns HTTP 429. The cap exists to stop a runaway SPA bug from
+opening hundreds of EventSources and exhausting apiserver watch
+budget on the user's behalf.
+
+The 30-stream default reflects "10 list pages × 3 kinds at peak,"
+which is well above realistic usage. Tune via the env var if your
+deployment pattern is unusual.
+
+---
+
+## 7. `/debug/streams`
+
+`GET /debug/streams` returns a JSON snapshot of every active watch
+stream:
+
+```json
+[
+  {
+    "id": 17,
+    "actor": "auth0|alice",
+    "cluster": "prod-eu-west-1",
+    "kind": "pods",
+    "namespace": "default",
+    "openedAt": "2026-05-03T16:21:00Z"
+  }
+]
+```
+
+The endpoint is gated by the same authz that gates `/api/audit` (the
+admin scope). It exists for operator visibility — "is the per-user
+cap close to limit?", "which kinds dominate stream count?", "is a
+specific actor leaking streams?" — and as a debugging aid when stream
+counts look wrong.
+
+---
+
+## 8. Adding a new kind
+
+The minimal recipe to add `Foos`:
+
+### 8.1 The DTO
+
+In `internal/k8s/foos.go`, define the list-view DTO and a `fooSummary`
+function:
+
+```go
+type Foo struct {
+    Namespace string `json:"namespace"`
+    Name      string `json:"name"`
+    UID       string `json:"uid"`
+    // … only the fields the list page renders
+}
+
+func fooSummary(f *foosv1.Foo) Foo {
+    return Foo{
+        Namespace: f.Namespace,
+        Name:      f.Name,
+        UID:       string(f.UID),
+        // …
+    }
+}
+```
+
+The DTO must be **stable** — the SSE delta and the polled list both
+emit it; changing field names is a breaking change for the SPA cache.
+
+### 8.2 `WatchFoos`
+
+In `internal/k8s/watch.go`, add a thin wrapper:
+
+```go
+func WatchFoos(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {
+    cs, err := newClientFn(ctx, p, args.Cluster)
+    if err != nil {
+        return fmt.Errorf("build clientset: %w", err)
+    }
+    return watchKind(ctx, watchSpec[foosv1.Foo, Foo]{
+        Kind: "foos",
+        List: func(ctx context.Context, opts metav1.ListOptions) ([]foosv1.Foo, string, error) {
+            list, err := cs.FoosV1().Foos(args.Namespace).List(ctx, opts)
+            if err != nil { return nil, "", err }
+            return list.Items, list.ResourceVersion, nil
+        },
+        Watch: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+            return cs.FoosV1().Foos(args.Namespace).Watch(ctx, opts)
+        },
+        Summary: fooSummary,
+    }, args.ResumeFrom, sink)
+}
+```
+
+If the snapshot needs sorting or capping, add a `PostList` field. If
+not, leave it nil.
+
+### 8.3 The route
+
+In `cmd/periscope/main.go`, instantiate the generic handler:
+
+```go
+router.Get("/api/clusters/{cluster}/foos/watch",
+    resourceWatchHandler("foos", k8s.WatchFoos))
+```
+
+The handler takes care of authz, limiter, tracker, heartbeat, resume,
+and shutdown.
+
+### 8.4 The feature flag
+
+Append `foos` to `/api/features` in `cmd/periscope/main.go` so the
+SPA knows the kind is supported. Frontends use this to choose
+`useResourceStream` vs `useResource` per kind.
+
+### 8.5 The test
+
+Add a `TestWatchFoos_*` block in `internal/k8s/watch_test.go`. The
+existing tests cover the generic primitive (snapshot, deltas, ctx
+cancellation, backpressure) — your job is to confirm the
+`fooSummary` projection is correct and the wrapper plumbing works.
+
+---
+
+## 9. Backpressure model
+
+`WatchSink.Send` returns `bool`:
+
+- `true` → the consumer accepted the event; loop continues.
+- `false` → backpressure detected (the SSE buffer is full because the
+  client fell behind). Loop exits cleanly with `nil`.
+
+The SSE handler implements `Send` with a bounded channel; if the
+channel is full, it returns `false` rather than block. The browser
+sees the connection close and reconnects with `Last-Event-ID`, which
+either resumes from the last RV or falls through to a fresh List.
+
+Watch loops **must not** block on slow consumers. The whole point of
+the SSE primitive is to scale to many concurrent slow clients without
+pinning watcher goroutines.
+
+---
+
+## 10. Auth integration
+
+Watch streams close cleanly on:
+
+- Session expiry (`event:auth_expired` broadcast from the auth layer)
+- Server shutdown (`event:server_shutdown`, sent before the binary's
+  graceful-shutdown deadline expires)
+- ctx cancellation (the request's HTTP context)
+
+The frontend listens for these and either prompts re-auth
+(`auth_expired`) or marks the stream `disconnected` and falls back to
+polling (`server_shutdown`). New kinds inherit this for free — the
+auth layer broadcasts to every registered stream.
+
+---
+
+## 11. What's intentionally not here
+
+- **No write semantics.** Watch streams are read-only; the dynamic
+  PATCH / DELETE handlers are separate.
+- **No per-cluster watch budget.** Apiserver watch budget is a
+  cluster-level concern that Periscope can't enforce — we cap per
+  user instead, which is what the apiserver actually meters.
+- **No batching of deltas.** Deltas emit as-is; the frontend's React
+  Query cache patcher is fast enough that batching server-side
+  doesn't help for the kinds we ship. Revisit if a future kind has
+  pathological churn.
+- **No stream multiplexing.** One EventSource per kind per page. We
+  considered a single multiplexed socket; the complexity didn't pay
+  off for v1.
+
+---
+
+## 12. Related code
+
+- `internal/k8s/watch.go` — `watchKind`, `watchSpec`, the four
+  `Watch*` wrappers
+- `internal/k8s/watch_test.go` — generic primitive tests
+- `internal/sse/` — SSE writer, heartbeat, last-event-id parsing
+- `cmd/periscope/main.go` — `resourceWatchHandler`, `streamTracker`,
+  `userStreamLimiter`, `/debug/streams`, `/api/features`
+- `web/src/hooks/useResourceStream.ts` — frontend SSE consumer
+- `web/src/components/StreamHealthBadge.tsx` — stream lifecycle UI

--- a/docs/architecture/watch-streams.md
+++ b/docs/architecture/watch-streams.md
@@ -2,13 +2,9 @@
 
 This is a **contributor / architecture** doc. The audience is someone
 extending Periscope's real-time list updates to a new resource kind,
-or debugging an existing one. Operator-facing config (the
-`watchStreams:` helm block — `kinds` opt-out and `perUserLimit`) is
-documented inline in
-[`deploy/helm/periscope/values.yaml`](../../deploy/helm/periscope/values.yaml).
-Watch streams are on by default for all four shipped kinds; the
-helm block is for opting out (e.g. behind a proxy that mishandles
-long-lived connections) or restricting to a subset.
+or debugging an existing one. For the **operator** view — the
+`watchStreams:` helm block, when to opt out, troubleshooting — see
+[`docs/setup/watch-streams.md`](../setup/watch-streams.md).
 
 For the SSE plumbing on the frontend (`useResourceStream`,
 `StreamHealthBadge`, drop-in dispatch into React Query), see the
@@ -138,17 +134,14 @@ The handler takes care of:
 
 ## 6. Per-user concurrency cap
 
-`PERISCOPE_WATCH_PER_USER_LIMIT` (helm: `watchStreams.perUserLimit`,
-default 30) caps concurrent watch streams per OIDC subject across
-all clusters and kinds. Exceeding it returns HTTP 429. The cap
-exists to stop a runaway SPA bug from opening hundreds of
-EventSources and exhausting apiserver watch budget on the user's
-behalf.
+`PERISCOPE_WATCH_PER_USER_LIMIT` (default 30) caps concurrent watch
+streams per OIDC subject across all clusters and kinds. Exceeding it
+returns HTTP 429. The cap exists to stop a runaway SPA bug from
+opening hundreds of EventSources and exhausting apiserver watch
+budget on the user's behalf.
 
 The 30-stream default reflects "10 list pages × 3 kinds at peak,"
-which is well above realistic usage. Tune via the helm value if
-your deployment pattern is unusual; setting it to `0` disables the
-cap entirely (not recommended).
+which is well above realistic usage.
 
 ---
 

--- a/docs/setup/audit.md
+++ b/docs/setup/audit.md
@@ -43,6 +43,25 @@ The default is `false` — opt-in. When off:
   container logs to a SIEM, that's your source of truth and you can
   legitimately leave persistence off.
 
+### Helm values ↔ env var mapping
+
+The chart templates each `audit.*` value to a `PERISCOPE_AUDIT_*`
+env var on the pod. Useful when debugging what's actually applied:
+
+| Helm value | Env var | Required when `audit.enabled=true` |
+|---|---|---|
+| `audit.enabled` | `PERISCOPE_AUDIT_ENABLED=true` | — (gates the rest) |
+| (fixed) | `PERISCOPE_AUDIT_DB_PATH=/var/lib/periscope/audit/audit.db` | always |
+| `audit.retentionDays` | `PERISCOPE_AUDIT_RETENTION_DAYS` | optional (default `30`) |
+| `audit.maxSizeMB` | `PERISCOPE_AUDIT_MAX_SIZE_MB` | optional (default `1024`) |
+| `audit.vacuumInterval` | `PERISCOPE_AUDIT_VACUUM_INTERVAL` | optional (default `24h`) |
+| `audit.storage.type` | (mount only — no env var) | required: `pvc` or `emptyDir` |
+| `audit.storage.size` | (PVC `spec.resources.requests.storage`) | required when `storage.type=pvc` |
+
+Setting both `retentionDays` and `maxSizeMB` to `0` is the
+unbounded-growth footgun. The startup validator emits a `slog.Warn`
+line — visible in pod logs but easy to miss; don't do it.
+
 ### Storage
 
 Two modes, both rendered in `templates/deployment.yaml`:
@@ -273,7 +292,10 @@ After enabling:
 # 1. PVC is bound (pvc mode):
 kubectl -n <ns> get pvc
 
-# 2. SQLite is open and the route is registered:
+# 2. SQLite is open and the route is registered. The port-forward maps
+#    a local port (8088 below — pick whatever's free) to the Service's
+#    8080. Use whichever local port suits you; the rest of this guide
+#    uses 8088 to keep examples copy-pasteable.
 kubectl -n <ns> port-forward svc/<release>-periscope 8088:8080
 curl -s http://localhost:8088/api/whoami    # {"actor":"...","auditEnabled":true,"auditScope":"self"}
 curl -s http://localhost:8088/api/audit     # {"items":[],"total":0,...}
@@ -292,6 +314,12 @@ curl -s -i http://localhost:8088/api/audit | grep X-Audit-Scope
 **`/api/audit` returns 404**
 → `audit.enabled=false` in your values, OR the SQLite sink failed to
 open. Check pod logs for `audit: sqlite disabled (open failed)`.
+Note that the binary **fails open** by design: a stuck PVC or schema
+migration error logs at `slog.Warn` and continues with stdout-only
+audit. The pod stays Ready, the SPA hides the audit nav (because
+`/api/whoami` reports `auditEnabled: false`), and the warning is
+easy to miss in a noisy log stream. When debugging, grep
+specifically for `audit:` lines around startup time.
 
 **X-Audit-Scope is always `self` even for an admin**
 → Your `auditAdminGroups` list doesn't match the user's actual IdP

--- a/docs/setup/cluster-rbac.md
+++ b/docs/setup/cluster-rbac.md
@@ -362,3 +362,150 @@ but the rest of the deployment is unchanged.
 - **Drift after chart upgrade.** Chart bumped `periscope-triage` to add
   a verb; your cluster still has the old version. Re-render and apply:
   `helm template ... --show-only templates/cluster-rbac.yaml | kubectl apply -f -`.
+
+---
+
+## Helm release browser RBAC
+
+Periscope ships a read-only Helm release browser
+([`docs/setup/helm-releases.md`](./helm-releases.md)). Releases live
+in K8s storage objects — Secrets by default, ConfigMaps as a
+fallback — under the impersonated user's identity. To see releases
+in the SPA, the user's resolved K8s identity needs `get` and `list`
+on whichever storage kind the cluster uses, scoped to the namespaces
+where releases live (or cluster-wide for the auto-probe to populate
+the SPA's "all releases" list).
+
+The shipped tier ClusterRoles cover the common cases:
+
+| Tier | Secret-driver releases | ConfigMap-driver releases |
+|---|---|---|
+| `read` (`view`) | ❌ — `view` excludes Secret reads | ✅ — `view` covers ConfigMaps |
+| `triage` (custom) | ❌ — no secrets verbs | ✅ — covers ConfigMaps |
+| `write` (`edit`) | ✅ | ✅ |
+| `maintain` (custom) | ✅ | ✅ |
+| `admin` (`cluster-admin`) | ✅ | ✅ |
+
+If you want **read-tier users** to see secret-driver releases (the
+common case — Helm 3 defaults to Secrets), apply this binding to
+each managed cluster:
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: periscope-helm-browser
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: []                # bound by label selector via the API at read time
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: periscope-helm-browser-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: periscope-helm-browser
+subjects:
+  - kind: Group
+    name: periscope-tier:read
+    apiGroup: rbac.authorization.k8s.io
+```
+
+This is **opt-in** because granting `secrets: list` cluster-wide is a
+significant escalation from `view`'s defaults — `view` deliberately
+excludes Secret reads to keep "read-only" from leaking credentials.
+Only add the binding if your team's threat model accepts that
+read-tier users will see Helm release storage payloads (which
+include the chart's rendered manifest and merged values, but not
+arbitrary cluster secrets).
+
+For tighter scoping, narrow the binding to a `RoleBinding` in
+specific namespaces — the helm browser then shows only the releases
+in those namespaces for that tier.
+
+---
+
+## Appendix: tier ClusterRole verbs
+
+The chart's `templates/cluster-rbac.yaml` ships the `triage` and
+`maintain` ClusterRoles inline. The other three tiers (`read`,
+`write`, `admin`) bind to the K8s built-ins `view`, `edit`, and
+`cluster-admin` — refer to the upstream K8s docs for those.
+
+This appendix documents what's in the shipped custom roles so you
+can audit or customize them without reading template YAML. If the
+chart bumps these roles, this appendix should be updated alongside.
+
+### `periscope-triage`
+
+**Reads (mirrors `view`):**
+
+| API group | Resources |
+|---|---|
+| `""` (core) | `bindings`, `configmaps`, `endpoints`, `events`, `limitranges`, `namespaces` (+`/status`), `persistentvolumeclaims` (+`/status`), `pods` (+`/log`, `/status`), `replicationcontrollers` (+`/scale`, `/status`), `resourcequotas` (+`/status`), `serviceaccounts`, `services` (+`/status`) |
+| `apps` | `controllerrevisions`, `daemonsets` (+`/status`), `deployments` (+`/scale`, `/status`), `replicasets` (+`/scale`, `/status`), `statefulsets` (+`/scale`, `/status`) |
+| `batch` | `cronjobs` (+`/status`), `jobs` (+`/status`) |
+| `networking.k8s.io` | `ingresses` (+`/status`), `networkpolicies` |
+| `autoscaling` | `horizontalpodautoscalers` (+`/status`) |
+| `policy` | `poddisruptionbudgets` (+`/status`) |
+| `discovery.k8s.io` | `endpointslices` |
+
+Verbs: `get`, `list`, `watch`.
+
+**Debug verbs (the triage-specific gap-filler):**
+
+| Resource | Verb | Purpose |
+|---|---|---|
+| `pods/exec` | `create` | Open Shell |
+| `pods/portforward` | `create` | Port-forward UI |
+| `pods/eviction` | `create` | Evict a stuck pod |
+| `pods` | `delete` | Restart pod (controller recreates) |
+| `apps/deployments/scale`, `apps/statefulsets/scale`, `apps/replicasets/scale` | `update`, `patch` | Scale workloads |
+| `apps/deployments`, `apps/statefulsets`, `apps/daemonsets` | `patch` | Rollout restart (annotation bump) |
+
+**What's NOT in triage:** spec edits (no `pods: patch` for the spec
+itself, no full `deployments: update`), Secret reads, RBAC, anything
+cluster-scoped except via the inherited `view` rules. Triage is
+"diagnose + nudge", not "redeploy".
+
+### `periscope-maintain`
+
+**Reads:** `*` on `*` for `get`, `list`, `watch` (everything
+readable). Cluster-scoped reads explicitly: `nodes` (+`/status`),
+`namespaces`, `persistentvolumes`, storage classes, CSI drivers/nodes,
+volume attachments, priority classes.
+
+**Mutate (namespaced):**
+
+| API group | Resources | Verbs |
+|---|---|---|
+| `""` (core) | `configmaps`, `events`, `persistentvolumeclaims`, `pods` (+`/exec`, `/log`, `/portforward`), `replicationcontrollers` (+`/scale`), `secrets`, `serviceaccounts`, `services` | `*` |
+| `apps` | `*` | `*` |
+| `batch` | `*` | `*` |
+| `networking.k8s.io` | `*` | `*` |
+| `autoscaling` | `*` | `*` |
+| `policy` | `*` | `*` |
+| `rbac.authorization.k8s.io` | `roles`, `rolebindings` | `*` |
+
+**What's intentionally NOT in maintain:** `clusterroles`,
+`clusterrolebindings`, anything CRD-related (apply per cluster if
+needed), workload identity APIs. Granting cluster-level RBAC mutate
+is the line between `maintain` and `admin`.
+
+### Customization
+
+Both roles are operator-tunable. After applying:
+
+```sh
+kubectl --context <cluster> edit clusterrole periscope-triage
+```
+
+Drift between the shipped role (chart `appVersion`) and the cluster
+is the operator's responsibility. The chart's `NOTES.txt` prints the
+shipped-role version on each `helm install` / `helm upgrade` so you
+can pin and re-apply when the chart bumps a verb.

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -407,10 +407,10 @@ clusters are registered.
 ### 10.5 Real-time list updates (watch streams)
 
 Periscope's pod, event, replicaset, and job list pages update in
-real time via SSE. The SPA falls back to polling when the
-EventSource fails. **All four kinds are on by default** — set
-`watchStreams.kinds: "off"` to disable everywhere, or list a subset
-to restrict it:
+real time via SSE. **All four kinds are on by default**; the SPA
+falls back to polling when the EventSource fails. The `watchStreams:`
+helm block lets operators opt out (e.g. behind a proxy that
+mishandles long-lived connections) or restrict to a subset:
 
 ```yaml
 watchStreams:
@@ -418,12 +418,10 @@ watchStreams:
   perUserLimit: 30    # concurrent SSE streams per OIDC subject
 ```
 
-The opt-out exists for environments behind HTTP proxies / load
-balancers that buffer responses or kill idle connections under ~30s,
-which can break SSE in ways the in-browser fallback can't always
-paper over.
-
-Architecture / contributor guide:
+Full operator guide:
+[`docs/setup/watch-streams.md`](./watch-streams.md). Contributor /
+architecture view (the `watchKind[T,S]` primitive, how to add a
+kind):
 [`docs/architecture/watch-streams.md`](../architecture/watch-streams.md).
 
 ### 10.6 NetworkPolicy

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -329,7 +329,112 @@ Notes:
 - **Login bounces forever.** Your IdP's allowed callback URL doesn't
   match `auth.oidc.redirectURL` exactly (trailing slashes, scheme,
   port). Both the IdP and `auth.yaml` must agree.
-- **`AssumeRole denied`** when adding clusters in PR-B. The per-cluster
-  role's trust policy doesn't allow `periscope-base` to assume it, or
-  the EKS Access Entry isn't in place. See the per-cluster setup guide
-  (forthcoming with PR-B).
+- **`AssumeRole denied`** when adding a cluster. The per-cluster role's
+  trust policy doesn't allow `periscope-base` to assume it, or the EKS
+  Access Entry isn't in place. The per-cluster RBAC walkthrough lives
+  in [`docs/setup/cluster-rbac.md`](./cluster-rbac.md).
+
+---
+
+## 10. Feature configuration
+
+The minimum values file in 3 only covers auth, clusters, and
+secrets. The chart also exposes pod exec, audit, NetworkPolicy, and
+PDB knobs — each has its own dedicated guide, summarised here.
+
+### 10.1 Pod exec
+
+Pod exec is on by default for every cluster. Tune the global
+defaults under `exec:` (idle/heartbeat/cap settings) and override
+per-cluster under `clusters[].exec:`. To disable exec on a specific
+cluster, set `clusters[<i>].exec.enabled: false`. There is no global
+"off" switch by design.
+
+```yaml
+exec:
+  serverIdleSeconds: 600       # 10 min
+  maxSessionsPerUser: 5
+  probeClustersOnBoot: false   # pre-warm cold clusters
+
+clusters:
+  - name: prod
+    backend: eks
+    arn: arn:aws:eks:us-east-1:111:cluster/prod
+    exec:
+      serverIdleSeconds: 1800  # 30 min for prod debugging
+```
+
+Full operator guide: [`docs/setup/pod-exec.md`](./pod-exec.md).
+
+### 10.2 Audit log persistence
+
+Off by default — events go to stdout (one JSON line per privileged
+action). Turn on persistence to enable the in-app audit query view
+at `GET /api/audit`:
+
+```yaml
+audit:
+  enabled: true
+  retentionDays: 30
+  maxSizeMB: 1024
+  storage:
+    type: pvc        # or emptyDir for kind/minikube
+    size: 5Gi
+```
+
+Full operator guide: [`docs/setup/audit.md`](./audit.md).
+
+### 10.3 Helm release browser
+
+The chart deploys a read-only Helm release browser. No values to set
+— the SPA shows it under each cluster's "Helm" sidebar group. RBAC
+follows the impersonated user (the browser auto-detects whether the
+cluster uses the `secret` or `configmap` storage driver).
+
+Full guide: [`docs/setup/helm-releases.md`](./helm-releases.md).
+
+### 10.4 Multi-cluster fleet view
+
+`GET /api/fleet` aggregates per-cluster status (nodes ready, pods by
+phase, hot signals) across every registered cluster. The home page
+uses it to render a fleet card grid. The endpoint runs each cluster
+under the user's impersonation in parallel; per-cluster failures
+become per-card error states without breaking the whole page.
+
+There is no helm config for the fleet endpoint — it's automatic once
+clusters are registered.
+
+### 10.5 Real-time list updates (watch streams)
+
+Periscope's pod, event, replicaset, and job list pages update in
+real time via SSE. The SPA falls back to polling when the
+EventSource fails. Both code paths are on by default; no helm config.
+Concurrency is capped per OIDC subject (default 30 streams) to
+prevent runaway-SPA scenarios from exhausting apiserver watch budget.
+
+Architecture / contributor guide:
+[`docs/architecture/watch-streams.md`](../architecture/watch-streams.md).
+
+### 10.6 NetworkPolicy
+
+Off by default. Every cluster has different ingress controller
+plumbing and IdP egress targets, so a templated default would either
+be too loose or too tight to use anywhere. Enable when you know your
+environment:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    fromNamespaces:
+      - kubernetes.io/metadata.name: ingress-nginx
+```
+
+Full guide: [`docs/setup/networkpolicy.md`](./networkpolicy.md).
+
+### 10.7 Pod Disruption Budget
+
+On by default with `maxUnavailable: 1` (single-replica v1 topology;
+the PDB makes the drain semantics explicit in cluster audit). Set
+`pdb.enabled: false` to skip. When HA support lands in v1.x, switch
+to `minAvailable` per `replicaCount`.

--- a/docs/setup/helm-releases.md
+++ b/docs/setup/helm-releases.md
@@ -1,0 +1,191 @@
+# Helm release browser
+
+Periscope ships a **read-only Helm release browser** as part of the
+core binary. It surfaces the helm releases installed on each managed
+cluster — list, detail (manifest + values), revision history, and
+diff between any two revisions — under the SPA's "Helm" sidebar
+group and the API path `/api/clusters/{cluster}/helm/...`.
+
+There is no chart configuration to enable it; the routes are always
+registered. Visibility is governed entirely by the impersonated
+user's RBAC on the storage objects Helm uses (Secrets by default,
+ConfigMaps as a fallback).
+
+This page covers the operational surface: what's there, what RBAC
+is required, the limits that bound the responses, and how cache
+behavior affects what you see in the UI.
+
+---
+
+## 1. Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/clusters/{cluster}/helm/releases` | List releases on the cluster (current revision per release). |
+| `GET` | `/api/clusters/{cluster}/helm/releases/{namespace}/{name}` | Release detail: values, rendered manifest, parsed resources, metadata. |
+| `GET` | `/api/clusters/{cluster}/helm/releases/{namespace}/{name}/history` | Revision history (newest first). |
+| `GET` | `/api/clusters/{cluster}/helm/releases/{namespace}/{name}/diff?from=N&to=M` | Structured diff (values + manifest) between revisions N and M. |
+
+All endpoints run under the requesting user's impersonated identity.
+A user who can't read the underlying storage objects gets a clean
+403 from the apiserver, which Periscope forwards.
+
+---
+
+## 2. Storage driver auto-probe
+
+Helm 3 stores releases in **Secrets** (the default driver) or
+**ConfigMaps**. Periscope auto-detects which driver the cluster uses:
+
+1. Try listing `Secrets` cluster-wide with the helm `owner=helm`
+   label. If any are returned, lock to the **secret** driver.
+2. Otherwise, try the same against `ConfigMaps`. If any are returned,
+   lock to the **configmap** driver.
+3. Otherwise, default to the **secret** driver — downstream LIST
+   calls will surface the real distinction (403 vs empty) cleanly.
+
+The probe result is cached per-cluster for 5 minutes. The `sql`
+driver is **not supported** (it's rare in practice and would require
+managing a connection pool to an external DB the operator
+configured).
+
+---
+
+## 3. RBAC requirements
+
+The impersonated user needs:
+
+| Driver | Verbs needed |
+|---|---|
+| `secret` (default) | `get`, `list` on `secrets` in the release namespaces |
+| `configmap` | `get`, `list` on `configmaps` in the release namespaces |
+
+For the auto-probe to succeed cluster-wide (so the SPA's "Releases"
+list is populated across namespaces), `list` on the storage kind
+should be cluster-scoped. A namespace-scoped binding works for
+single-namespace use but the cluster-wide list returns empty in that
+case.
+
+The shipped tier ClusterRoles cover this:
+
+- `read` (`view`) — gets `secrets:get` and `configmaps:get`/`list`,
+  enough for the configmap driver only. Helm releases stored as
+  Secrets aren't readable from the `view` ClusterRole alone (Secret
+  reads are intentionally privileged in the upstream `view` role).
+- `triage`, `write`, `maintain`, `admin` — all cover both drivers.
+
+If you want **read-tier users** to also see secret-driver releases,
+add a ClusterRoleBinding that grants them `get`/`list` on Secrets in
+the relevant namespaces — see the
+[cluster-rbac.md helm browser appendix](./cluster-rbac.md#helm-release-browser-rbac)
+for a copy-pasteable sample.
+
+---
+
+## 4. Response caps and truncation
+
+Three constants bound the responses to keep payloads predictable
+under impersonation:
+
+| Cap | Value | Where |
+|---|---|---|
+| Release list | **200 releases** | `cmd/periscope/helm_handler.go: helmListCap` |
+| Detail / diff payload | **5 MiB** | `cmd/periscope/helm_handler.go: helmDetailMaxBytes` |
+| History default | **10 revisions** | `internal/k8s/helm.go` (override with `?limit=N`) |
+
+When the list cap binds, the response carries `truncated: true` and
+the SPA shows a "showing first 200 of N" banner. The 200-cap reflects
+realistic helm fleet sizes (most clusters run < 50 releases); past
+that, a search-by-name UX is the right answer rather than scrolling
+a thousand-row list.
+
+The 5 MiB detail cap is generous (a real-world chart's manifest +
+values rarely exceeds 200 KiB) but exists to defend against
+accidentally-huge releases (a chart inlining a binary blob in
+`values.yaml`, for example).
+
+---
+
+## 5. Caching
+
+The list endpoint caches per `(actor, cluster, impersonation
+groups)` for **30 seconds**. Subsequent navigations across the SPA's
+Helm tab feel instant; a release just-installed by `helm install`
+appears within ~30s of the install completing.
+
+Detail, history, and diff endpoints are **not cached** — each
+request hits the apiserver. These pages are rarer-clicked and the
+freshness signal matters more (an operator looking at "what
+happened in revision 7" wants the live answer).
+
+To force a list refresh, the SPA's Helm tab has a "refresh" button
+that bypasses the cache.
+
+---
+
+## 6. What's read, what's not
+
+The browser surfaces:
+
+- Release name, namespace, revision, status, chart name + version,
+  app version, last-updated timestamp.
+- Rendered manifest (parsed into a structured resource list per
+  revision).
+- Computed values (`helm get values --all` equivalent — chart
+  defaults merged with user overrides).
+- Release notes (`NOTES.txt` output).
+- Revision history with status transitions.
+- Side-by-side diff between any two revisions: values diff +
+  manifest diff.
+
+It does **not** support:
+
+- `helm install` / `helm upgrade` / `helm uninstall` (write
+  operations are explicitly out of scope for v1; SAR fan-out per
+  rendered resource is planned for v2).
+- Chart catalog browsing.
+- Repository management.
+- The `sql` storage driver.
+
+The Helm release browser is a debugging / observability surface, not
+a deployment tool. For deploys, your existing GitOps (ArgoCD, Flux)
+or pipeline tooling stays the source of truth.
+
+---
+
+## 7. Verifying
+
+After install:
+
+```sh
+# 1. Route is registered (will 401 if you're not authenticated):
+kubectl -n periscope port-forward svc/periscope 8080:8080
+curl -i http://localhost:8080/api/clusters/<cluster>/helm/releases
+
+# 2. The SPA shows the "Helm" group in the sidebar (under any
+#    cluster). Clicking it lists releases.
+
+# 3. RBAC sanity:
+kubectl --context <cluster> auth can-i list secrets \
+  --as=auth0\|alice \
+  --as-group=periscope-tier:write
+# yes
+```
+
+If the list is empty but you know there are releases on the cluster,
+check (a) the user's impersonated groups have `list` on the storage
+kind cluster-wide, (b) the auto-probe locked onto the right driver
+(check pod logs for `helm: driver auto-detected driver=...`).
+
+---
+
+## 8. Related docs
+
+- [`docs/setup/cluster-rbac.md`](./cluster-rbac.md) — RBAC modes,
+  tier verbs, helm browser sample binding.
+- [`docs/setup/audit.md`](./audit.md) — read-side observability for
+  privileged actions (helm browser reads aren't audited; only
+  privileged mutations are).
+- `internal/k8s/helm.go` — the storage decoder and auto-probe.
+- `cmd/periscope/helm_handler.go` — list/detail/history/diff handlers.
+- `cmd/periscope/helm_cache.go` — the per-actor list cache.

--- a/docs/setup/networkpolicy.md
+++ b/docs/setup/networkpolicy.md
@@ -59,6 +59,27 @@ template a stable rule from chart values. Operators typically either:
 Option 2 is the right answer for regulated environments; option 1 is the
 common starting point.
 
+## Egress for Periscope's other features
+
+The newer features added since v1's first cut don't need additional
+egress rules beyond what's already in your minimum policy. Quick
+sanity check:
+
+| Feature | Egress needed? |
+|---|---|
+| **Pod exec (WebSocket / SPDY)** | EKS API server endpoint (TCP/443). Same target your control plane already needs — no new rule. |
+| **Watch streams (SSE)** | None outbound. The SSE socket is *inbound* to the Periscope pod from the browser; the pod's outbound is the existing apiserver watch connection. |
+| **Helm release browser** | None new. Reads K8s storage objects via the apiserver. |
+| **Fleet endpoint (`/api/fleet`)** | None new. Per-cluster apiserver calls under impersonation. |
+| **Audit query (`/api/audit`)** | None — local SQLite read. |
+| **Audit stdout shipping** | Whatever your log-aggregator agent (Fluent Bit, Vector, etc.) needs — that runs alongside Periscope, not inside it. |
+| **OIDC / IdP** | TCP/443 to the issuer host. Already in the minimum policy above. |
+| **AWS STS / EKS DescribeCluster** | TCP/443 to `sts.amazonaws.com` and the regional EKS endpoints. Already needed for cluster auth. |
+
+In short: the only outbound traffic Periscope generates is to (a) the
+IdP, (b) AWS STS / EKS, and (c) each managed cluster's apiserver.
+The new features all ride those existing channels.
+
 ## Verifying
 
 After enabling:

--- a/docs/setup/pod-exec.md
+++ b/docs/setup/pod-exec.md
@@ -1,0 +1,279 @@
+# Pod exec
+
+Periscope ships an interactive shell into containers — the "Open Shell"
+button on a pod's detail page upgrades the page to a WebSocket and the
+binary streams stdin / stdout / stderr from the kube-apiserver under
+the user's impersonated identity.
+
+This page is the operator guide: when it's enabled, how to tune
+timeouts and caps, how the WebSocket-vs-SPDY transport selection
+works, and what to do when things misbehave. The design is in
+[RFC 0001](../rfcs/0001-pod-exec.md).
+
+---
+
+## 1. Default behavior
+
+Pod exec is **on by default for every cluster** in the registry. The
+helm chart unconditionally registers the route; per-cluster opt-out
+is the only kill switch. There is intentionally no global
+`exec.enabled` toggle — disabling means setting it false on each
+cluster you want to lock down.
+
+### Per-cluster opt-out
+
+```yaml
+clusters:
+  - name: prod-eu-west-1
+    backend: eks
+    region: eu-west-1
+    arn: arn:aws:eks:eu-west-1:222222222222:cluster/prod-eu-west-1
+  - name: locked-down
+    backend: eks
+    region: us-west-2
+    arn: arn:aws:eks:us-west-2:333333333333:cluster/locked
+    exec:
+      enabled: false
+```
+
+When `exec.enabled: false` for a cluster:
+
+- The SPA hides the **Open Shell** action on that cluster's pods.
+- A direct WebSocket request to `/api/clusters/locked-down/pods/.../exec`
+  returns HTTP 403 with body `{"error": "E_EXEC_DISABLED"}`.
+- The cluster summary surfaces `execEnabled: false` for SPA gating.
+
+### Required RBAC
+
+The impersonated user must hold `create` on the `pods/exec`
+subresource in the pod's namespace. The shipped tier ClusterRoles
+grant this by default for `triage`, `write`, `maintain`, and `admin`;
+`read` does not include it (see
+[`docs/setup/cluster-rbac.md`](./cluster-rbac.md) for the verb
+appendix).
+
+---
+
+## 2. Tuning the global defaults
+
+Helm exposes the global timing and cap defaults under `exec:`:
+
+```yaml
+exec:
+  serverIdleSeconds: 600   # tear-down after this much stdin/stdout silence
+  idleWarnSeconds: 30      # browser warning lead before the cut
+  heartbeatSeconds: 20     # WebSocket ping interval
+  maxSessionsPerUser: 5    # concurrent sessions per OIDC subject
+  maxSessionsTotal: 50     # concurrent sessions per cluster, total
+  probeClustersOnBoot: false
+```
+
+Each value renders to a `PERISCOPE_EXEC_*` environment variable on the
+Periscope pod (or `PERISCOPE_PROBE_CLUSTERS_ON_BOOT=1` for the boot
+probe). The mapping:
+
+| Helm value | Env var | Code default |
+|---|---|---|
+| `exec.serverIdleSeconds` | `PERISCOPE_EXEC_IDLE_SECONDS` | `600` (10 min) |
+| `exec.idleWarnSeconds` | `PERISCOPE_EXEC_IDLE_WARN_SECONDS` | `30` |
+| `exec.heartbeatSeconds` | `PERISCOPE_EXEC_HEARTBEAT_SECONDS` | `20` |
+| `exec.maxSessionsPerUser` | `PERISCOPE_EXEC_MAX_SESSIONS_PER_USER` | `5` |
+| `exec.maxSessionsTotal` | `PERISCOPE_EXEC_MAX_SESSIONS_TOTAL` | `50` |
+| `exec.probeClustersOnBoot` | `PERISCOPE_PROBE_CLUSTERS_ON_BOOT` (`1`) | off |
+
+---
+
+## 3. Per-cluster overrides
+
+Each cluster entry in `clusters[]` may override any of the global
+defaults. Overrides are **partial** — list only the fields that
+differ; everything else falls through to the global default.
+
+```yaml
+exec:
+  serverIdleSeconds: 600
+  maxSessionsPerUser: 5
+
+clusters:
+  - name: prod
+    backend: eks
+    region: us-east-1
+    arn: arn:aws:eks:us-east-1:111111111111:cluster/prod
+    exec:
+      # Long-running prod incident response: 30-min idle, 10 sessions/user.
+      serverIdleSeconds: 1800
+      maxSessionsPerUser: 10
+
+  - name: dev
+    backend: eks
+    region: us-east-1
+    arn: arn:aws:eks:us-east-1:111111111111:cluster/dev
+    # No exec block → uses globals (10 min idle, 5 sessions/user).
+```
+
+The available per-cluster keys are:
+
+| Key | Type | Notes |
+|---|---|---|
+| `enabled` | bool | `false` disables exec entirely on this cluster |
+| `serverIdleSeconds` | int | overrides global idle timeout |
+| `idleWarnSeconds` | int | overrides global warning lead |
+| `heartbeatSeconds` | int | overrides global heartbeat |
+| `maxSessionsPerUser` | int | overrides global per-user cap |
+| `maxSessionsTotal` | int | overrides global per-cluster cap |
+
+A non-positive override is treated as "operator typo, ignore" — the
+global default stays in effect.
+
+---
+
+## 4. Transports: WebSocket v5 + SPDY fallback
+
+Periscope prefers **WebSocket v5** (Kubernetes 1.30+, subprotocol
+`v5.channel.k8s.io`) and falls back to **SPDY** for older clusters.
+Per-cluster selection is automatic.
+
+A **circuit breaker** sits in front of the transport pick: if WebSocket
+upgrade fails 3 times in a row for a given cluster, the transport pins
+to SPDY for 30 minutes and self-heals afterward. This is invisible to
+end users — sessions just keep working.
+
+### Boot-time probe (optional)
+
+Set `exec.probeClustersOnBoot: true` to pre-warm each cluster's
+credentials and exec policy at startup. First-exec latency on a cold
+cluster (cold IAM cache + Access Entry resolution + transport probe)
+is typically 3–5 seconds; the boot probe trades that latency for
+slightly slower pod startup. Off by default.
+
+---
+
+## 5. Concurrency caps
+
+Two caps gate every WebSocket upgrade:
+
+- **Per-user** (default 5): concurrent sessions per OIDC subject,
+  across every cluster they have access to. Hitting the cap returns
+  HTTP 429 with body `{"error":"E_CAP_USER","activeSessions":[...]}`.
+- **Per-cluster total** (default 50): concurrent sessions per cluster
+  regardless of user. Hitting the cap returns HTTP 429 with
+  `{"error":"E_CAP_CLUSTER",...}`.
+
+The active-sessions list in the 429 body lets the SPA render a
+"You're already exec'd into …, close one to start a new session" UI.
+
+Each session pins ~1 MiB of stdin/stdout buffers in the Periscope pod
+plus one apiserver watch connection. Cap the total at a number you
+have memory + apiserver-connection budget for.
+
+---
+
+## 6. Lifecycle: idle, heartbeat, warn, close
+
+Per session, four timers run concurrently:
+
+| Timer | Default | Trigger |
+|---|---|---|
+| Heartbeat | 20s | Server sends WebSocket ping. Keeps proxies (NLB, ALB, ingress) from silently dropping the socket. |
+| Server idle | 600s | No stdin or stdout activity for this long → server tears the session down. |
+| Idle warn | 30s | Browser shows a "session ending soon" banner this many seconds before the server idle cut. |
+| Client hidden | 300s | Browser tab hidden + no activity → SPA closes the session client-side. Tunable in the SPA, not in helm. |
+
+Any keystroke or output frame resets the idle timer.
+
+---
+
+## 7. Audit
+
+Each session emits two records to the audit pipeline (stdout + the
+SQLite sink when `audit.enabled=true`):
+
+| Event | When | Useful fields |
+|---|---|---|
+| `pod.exec.session_start` | Upgrade succeeds | `session_id`, `actor.sub`, `cluster`, `namespace`, `pod`, `container`, `tty`, `transport` (`ws` / `spdy`), `k8s_identity` |
+| `pod.exec.session_end` | Server tears down or client closes | adds `duration_ms`, `exit_code`, `bytes_stdin`, `bytes_stdout`, `close_reason` (`client_close` / `server_idle` / `forced_close`) |
+
+Query history with `GET /api/audit?verb=pod.exec.session_start` (when
+audit persistence is on; see [`audit.md`](./audit.md)).
+
+---
+
+## 8. Troubleshooting
+
+### "Open Shell" button is missing
+
+Pod is on a cluster with `exec.enabled: false`, **or** the user lacks
+`pods/exec` create permission in that namespace. Confirm with
+`POST /api/clusters/{cluster}/can-i` for `{verb: "create",
+resource: "pods/exec", namespace: "<ns>"}`.
+
+### WebSocket upgrade fails (instant disconnect)
+
+Most common causes, in order:
+
+1. **TLS-termination strips the `Connection: upgrade` header.** Check
+   your ingress controller / NLB; the path `/api/clusters/.../exec`
+   needs WebSocket support enabled.
+2. **`Origin` header rejection.** Some load balancers attach an Origin
+   the WebSocket library doesn't recognise. The Periscope handler
+   accepts same-origin only.
+3. **Cluster requires SPDY but k8s client picked WebSocket** → wait
+   30 minutes and the circuit breaker pins to SPDY automatically; or
+   restart the pod to reset the breaker.
+
+Pod logs (`kubectl -n periscope logs deploy/periscope`) carry a
+structured line per upgrade attempt with `transport=ws|spdy`,
+`upgrade_error=…`, and `circuit_breaker_state=…`.
+
+### "No shell in container" (E_NO_SHELL)
+
+The container's image has no `/bin/sh` (distroless, scratch). Periscope
+can't pick a shell for you in that case — exec needs an existing
+binary in the image. Use `kubectl debug` semantics (ephemeral debug
+container) instead; that's a v1.x feature.
+
+### HTTP 429 with `activeSessions`
+
+User hit `maxSessionsPerUser` (or cluster hit `maxSessionsTotal`). The
+response body lists the active sessions; close one or bump the cap.
+Both caps support per-cluster overrides if a single cluster is the
+hot spot.
+
+### Session disconnects every ~minute
+
+Heartbeat isn't reaching the browser through your proxy chain. Set
+`exec.heartbeatSeconds: 10` (or even 5) so pings hit before the
+proxy's idle-socket timeout. ALB defaults to 60s, NLB to 350s, NGINX
+to 60s.
+
+### Session times out unexpectedly during long compiles
+
+Bump `exec.serverIdleSeconds` for the affected cluster — long-running
+build / debug sessions need a higher ceiling. A common pattern is
+`global = 600s` (good default) with `prod-debug` cluster overridden
+to `1800s`.
+
+### Circuit breaker pinned to SPDY indefinitely
+
+The breaker self-heals after 30 min. To force-reset, restart the
+Periscope pod. There's no operator-facing knob for this — pinning
+that long means real WebSocket failure that needs investigation
+upstream of Periscope.
+
+---
+
+## 9. Observability
+
+Per-pod metrics surface through the structured log lines:
+
+- `exec.session.start` / `exec.session.end` — every session boundary.
+- `exec.cap.hit` — 429 responses, with `cap=user|cluster` and counts.
+- `exec.transport.choice` — `transport=ws|spdy`,
+  `circuit_breaker=open|closed`.
+- `exec.upgrade.error` — failed WebSocket upgrades.
+
+Tail with `kubectl -n periscope logs deploy/periscope -f | grep exec`.
+
+For audit-grade history (who exec'd into what, when, for how long),
+turn on the SQLite sink and query `/api/audit?verb=pod.exec.session_start`
+— see [`audit.md`](./audit.md).

--- a/docs/setup/watch-streams.md
+++ b/docs/setup/watch-streams.md
@@ -1,0 +1,225 @@
+# Watch streams (real-time list updates)
+
+Periscope's pod, event, replicaset, and job list pages update in
+real time via Server-Sent Events (SSE) instead of polling. The SPA
+falls back to polling for any kind whose stream cannot be opened,
+so the bad case is graceful degradation rather than a hard failure.
+
+This page is the operator guide: when watch streams are on, how to
+opt out, how to restrict to a subset of kinds, the per-user
+concurrency cap, and what to do when streams misbehave behind your
+ingress / load balancer.
+
+For the **contributor / architecture** view — how the
+`watchKind[T,S]` primitive works, how to add a new kind, the
+list-then-watch lifecycle — see
+[`docs/architecture/watch-streams.md`](../architecture/watch-streams.md).
+
+---
+
+## 1. Default behavior
+
+**On by default for all four shipped kinds:** pods, events,
+replicasets, jobs. With no helm config, each list page in the SPA
+opens an `EventSource` to `/api/clusters/{cluster}/{kind}/watch` and
+reconciles deltas into the React Query cache as they arrive.
+
+When a stream fails (404, network error, server tear-down), the SPA
+automatically falls back to a polling `useResource` query for that
+kind on that page. Both code paths return the same DTO shape, so
+feature parity is automatic and a partial failure (e.g. only
+`replicasets` 404s) doesn't break the rest of the page.
+
+---
+
+## 2. Helm configuration
+
+```yaml
+watchStreams:
+  # Empty / "all" / "off" / "none" / comma-separated subset.
+  # Leave empty to inherit the server default ("all on").
+  kinds: ""
+
+  # Concurrent SSE streams per OIDC subject. 0 disables the cap
+  # entirely (not recommended).
+  perUserLimit: 30
+```
+
+The `kinds` value accepts:
+
+| Value | Meaning |
+|---|---|
+| `""` (unset) | Server default — all four kinds enabled |
+| `"all"` | Same as unset; explicit form |
+| `"off"` | Disable all SSE routes; UI uses polling everywhere |
+| `"none"` | Same as `"off"` |
+| `"pods,events"` | Comma-separated subset (any of: `pods`, `events`, `replicasets`, `jobs`) |
+
+The schema rejects misspellings (`banana,pods` won't pass `helm
+template`), so a typo fails at deploy time rather than silently
+disabling a kind at runtime.
+
+### Helm values ↔ env var mapping
+
+The chart templates each `watchStreams.*` value to an env var on
+the pod. Useful when debugging what's actually applied:
+
+| Helm value | Env var | Notes |
+|---|---|---|
+| `watchStreams.kinds` | `PERISCOPE_WATCH_STREAMS` | Only rendered when non-empty (server default is "all on" when env is unset) |
+| `watchStreams.perUserLimit` | `PERISCOPE_WATCH_PER_USER_LIMIT` | Only rendered when non-zero |
+
+---
+
+## 3. When to opt out
+
+The opt-out exists for environments where SSE doesn't survive the
+network path. Common triggers:
+
+- **Buffering proxies.** An HTTP proxy / load balancer in front of
+  Periscope that buffers responses (waiting for end-of-stream
+  before forwarding) breaks SSE — events arrive in batches, or not
+  at all. ALB and NLB are fine; some corporate forward-proxies are
+  not.
+- **Aggressive idle-connection timeouts.** A proxy that kills idle
+  HTTP connections under ~30s. Periscope sends a heartbeat every
+  15s on watch streams, but if the proxy ignores keep-alives or
+  has a sub-15s ceiling, disconnects look like flapping streams.
+- **WebSocket / SSE not allowed by policy.** Some regulated
+  environments terminate long-lived connections by policy. The SPA
+  copes by polling; opt out so the page state stays stable.
+
+In each case, `watchStreams.kinds: "off"` is the right answer: the
+SPA polls cleanly without the constant reconnect storm.
+
+To restrict instead of disable (say, your proxy is fine for pods
+but mangles event streams):
+
+```yaml
+watchStreams:
+  kinds: "pods,replicasets,jobs"
+```
+
+---
+
+## 4. Per-user concurrency cap
+
+`watchStreams.perUserLimit` (default 30) caps concurrent SSE
+streams per OIDC subject across all clusters and kinds. The cap
+exists to stop a runaway SPA bug from opening hundreds of
+EventSources and exhausting your apiservers' watch budget on the
+user's behalf.
+
+When a user hits the cap, the next watch request returns HTTP 429
+and the SPA falls back to polling for the affected page. The 30
+default reflects "10 list pages × 3 kinds at peak," which is well
+above realistic usage.
+
+Tune up if your team genuinely keeps lots of tabs open; tune down
+if a misbehaving SPA build is hammering your apiservers and you
+need a tighter circuit breaker. Setting it to `0` disables the cap
+entirely (not recommended).
+
+---
+
+## 5. NetworkPolicy
+
+Watch streams are entirely intra-cluster:
+
+- **Inbound** to the Periscope pod from the SPA (browser → ingress
+  → Periscope) — already covered by your ingress rules.
+- **Outbound** from Periscope to each managed cluster's apiserver —
+  the same TCP/443 you already need for non-watch reads.
+
+No new egress rules. See
+[`docs/setup/networkpolicy.md`](./networkpolicy.md) for the full
+egress table.
+
+---
+
+## 6. Verifying
+
+```sh
+kubectl -n periscope port-forward svc/periscope 8080:8080
+
+# 1. Stream is live for a kind:
+curl -i -N http://localhost:8080/api/clusters/<cluster>/pods/watch
+# expects: HTTP/1.1 200, Content-Type: text/event-stream, then a
+# stream of `event: snapshot` followed by `event: added` / etc.
+
+# 2. Stream is disabled for a kind (kinds: "off" or kind not in subset):
+curl -i http://localhost:8080/api/clusters/<cluster>/replicasets/watch
+# expects: HTTP/1.1 404 — the route literally doesn't exist; the SPA
+# downgrades cleanly to polling.
+
+# 3. Per-user cap is in effect:
+curl -i http://localhost:8080/debug/streams
+# JSON snapshot of every active stream this pod is serving;
+# count rows for your actor to compare against perUserLimit.
+
+# 4. Server-side defaults (kinds is unset):
+kubectl -n periscope logs deploy/periscope | grep "watch streams"
+# `watch streams enabled: pods=true events=true replicasets=true jobs=true`
+```
+
+---
+
+## 7. Troubleshooting
+
+### SSE connections drop every ~minute
+
+Your proxy is killing idle connections faster than Periscope's
+heartbeat. Two options:
+
+1. **Tune the proxy.** ALB defaults to 60s idle timeout; bump it to
+   300s+ for the Periscope target group. NLB defaults to 350s
+   (fine). NGINX `proxy_read_timeout` defaults to 60s; bump to
+   `1h` on the Periscope location block. The browser's reconnect
+   keeps things working but the constant churn is wasteful.
+2. **Opt out.** `watchStreams.kinds: "off"` and let polling carry
+   the SPA. The fallback is tested and the UX difference at a 15s
+   poll is small.
+
+### Stream returns 404 immediately
+
+The kind isn't enabled. Check `watchStreams.kinds` — is it `"off"`,
+or a subset that doesn't include this kind? The SPA's behavior
+here is correct (downgrade to polling); the 404 is by design when
+a kind is gated off.
+
+### `/debug/streams` shows the user at the cap
+
+User has more than `perUserLimit` concurrent streams. Likely
+causes: lots of open browser tabs, or a SPA build with a leak that
+opens streams without closing them. Check whether the cap is
+actually wrong for your deployment shape, or whether to file a SPA
+bug.
+
+### "Watch streams enabled: …=false" at startup despite leaving `kinds: ""`
+
+Something else is setting `PERISCOPE_WATCH_STREAMS` (the `env:`
+extra-env array, an operator-injected var, etc.). The helm
+template only renders the var when `watchStreams.kinds` is
+non-empty — but if another mechanism set it earlier, that wins.
+Check `kubectl -n periscope describe pod` to see the resolved env.
+
+### Page works but updates feel "polled" not "live"
+
+EventSource opens, but the SPA never receives deltas. Most likely
+a **buffering proxy** silently sitting on chunked responses. Check
+your ingress controller config for response buffering / chunked
+transfer support. Curl-test directly against the Service
+(`kubectl port-forward`) to bypass the ingress and see if the
+stream flows there — if it does, the ingress is the culprit.
+
+---
+
+## 8. Related docs
+
+- [`docs/architecture/watch-streams.md`](../architecture/watch-streams.md) —
+  contributor / architecture view: `watchKind[T,S]` primitive,
+  list-then-watch lifecycle, adding a new kind.
+- [`docs/setup/networkpolicy.md`](./networkpolicy.md) — egress
+  table including watch-stream impact (none).
+- [`docs/setup/deploy.md`](./deploy.md) §10.5 — feature summary in
+  the deploy walkthrough.


### PR DESCRIPTION
This PR adds comprehensive operator-facing documentation for three major Periscope features, along with corresponding helm chart updates to expose their configuration.

## Summary

Adds three new documentation files covering pod exec, watch streams (real-time list updates), and the Helm release browser, plus updates to existing docs and helm values to surface their configuration options. These docs explain the operational surface, tuning knobs, troubleshooting, and RBAC requirements for each feature.

## Key changes

**New documentation:**
- `docs/architecture/watch-streams.md` — Architecture guide for real-time list updates via SSE, including the generic `watchKind` primitive, the four shipped kinds (Pods, Events, ReplicaSets, Jobs), per-user concurrency caps, and a recipe for adding new kinds
- `docs/setup/pod-exec.md` — Operator guide for interactive shell into containers, covering WebSocket/SPDY transport selection, circuit breaker, concurrency caps, idle/heartbeat timers, audit events, and troubleshooting
- `docs/setup/helm-releases.md` — Operator guide for the read-only Helm release browser, including storage driver auto-probe, RBAC requirements, response caps, caching behavior, and verification steps

**Updated documentation:**
- `docs/setup/cluster-rbac.md` — Added "Helm release browser RBAC" section with sample ClusterRole/ClusterRoleBinding for read-tier users to see secret-driver releases, plus "Appendix: tier ClusterRole verbs" documenting the shipped `periscope-triage` and `periscope-maintain` roles
- `docs/setup/deploy.md` — Added section 10 "Feature configuration" summarizing pod exec, audit, Helm browser, fleet view, watch streams, NetworkPolicy, and PDB with links to detailed guides
- `docs/setup/audit.md` — Added "Helm values ↔ env var mapping" table
- `docs/setup/networkpolicy.md` — Added "Egress for Periscope's other features" table clarifying that pod exec, watch streams, and Helm browser don't require additional egress rules
- `deploy/helm/periscope/README.md` — Added sections on pod exec and Helm release browser configuration

**Helm chart updates:**
- `deploy/helm/periscope/values.yaml` — Added comprehensive `exec:` block with global defaults (serverIdleSeconds, idleWarnSeconds, heartbeatSeconds, maxSessionsPerUser, maxSessionsTotal, probeClustersOnBoot) and documented per-cluster override examples in the `clusters:` section
- `deploy/helm/periscope/values.schema.json` — Added schema for `exec` block and per-cluster `exec` overrides
- `deploy/helm/periscope/templates/deployment.yaml` — Added environment variable templating for all `exec.*` values (PERISCOPE_EXEC_IDLE_SECONDS, etc.)

## Notable details

- The watch streams doc explains the `watchKind[T, S]` generic primitive and provides a minimal recipe for adding new kinds (DTO, wrapper function, route, feature flag, test)
- Pod exec doc covers the WebSocket v5 + SPDY fallback with circuit breaker, per-user and per-cluster concurrency caps, and the four concurrent timers (heartbeat, idle, warn, client-hidden)
- Helm browser doc explains the storage driver auto-probe (Secrets vs ConfigMaps) and the three response caps (200 releases, 5 MiB detail, 10 revisions default)
- All three features inherit auth integration (session expiry, server shutdown) for free from the existing auth layer
- RBAC appendix documents the shipped tier ClusterRoles so operators can audit or customize them without reading template YAML

https://claude.ai/code/session_01WMxdGSNVhh5kcFid2hJuvi