### PR TITLE
Add EndpointSlices list-view page

### DIFF
--- a/web/src/components/detail/describe/EndpointSliceDescribe.tsx
+++ b/web/src/components/detail/describe/EndpointSliceDescribe.tsx
@@ -1,0 +1,146 @@
+import { Link, useParams } from "react-router-dom";
+import { useEndpointSliceDetail } from "../../../hooks/useResource";
+import { ageFrom } from "../../../lib/format";
+import type {
+  EndpointSliceEndpoint,
+  EndpointSlicePort,
+} from "../../../lib/types";
+import { DetailError, DetailLoading } from "../states";
+import { KV, MetaPills, SectionTitle, StatStrip } from "./shared";
+
+export function EndpointSliceDescribe({
+  cluster,
+  ns,
+  name,
+}: {
+  cluster: string;
+  ns: string;
+  name: string;
+}) {
+  const params = useParams<{ cluster?: string }>();
+  const clusterName = params.cluster ?? cluster;
+  const { data, isLoading, isError, error } = useEndpointSliceDetail(cluster, ns, name);
+
+  if (isLoading) return <DetailLoading />;
+  if (isError) return <DetailError message={(error as Error)?.message ?? "unknown"} />;
+  if (!data) return null;
+
+  const serviceLink = data.serviceName ? (
+    // ServicesPage uses ?ns=<namespace>&sel=<name> for selection. Linking
+    // straight in opens the parent service's detail panel without a
+    // round-trip through the list page.
+    <Link
+      to={`/clusters/${encodeURIComponent(clusterName)}/services?ns=${encodeURIComponent(data.namespace)}&sel=${encodeURIComponent(data.serviceName)}&selNs=${encodeURIComponent(data.namespace)}&tab=describe`}
+      className="text-accent hover:underline"
+    >
+      {data.serviceName}
+    </Link>
+  ) : null;
+
+  return (
+    <div>
+      <StatStrip
+        stats={[
+          { label: "Address Type", value: data.addressType },
+          { label: "Endpoints", value: `${data.readyCount}/${data.totalCount} ready` },
+          { label: "Age", value: ageFrom(data.createdAt), tone: "muted" },
+        ]}
+      />
+      <div className="px-5 py-4">
+        <dl className="space-y-2">
+          {serviceLink && <KV label="Service">{serviceLink}</KV>}
+        </dl>
+
+        {data.ports.length > 0 && (
+          <>
+            <SectionTitle>Ports</SectionTitle>
+            <PortsTable ports={data.ports} />
+          </>
+        )}
+
+        {data.endpoints && data.endpoints.length > 0 && (
+          <>
+            <SectionTitle>Endpoints</SectionTitle>
+            <EndpointsTable endpoints={data.endpoints} />
+          </>
+        )}
+
+        <SectionTitle>Labels</SectionTitle>
+        <MetaPills map={data.labels} />
+
+        <SectionTitle>Annotations</SectionTitle>
+        <MetaPills map={data.annotations} />
+      </div>
+    </div>
+  );
+}
+
+function PortsTable({ ports }: { ports: EndpointSlicePort[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-[11.5px]">
+        <thead>
+          <tr className="border-b border-border text-left text-[10px] font-medium uppercase tracking-[0.08em] text-ink-faint">
+            <th className="pb-1.5 pr-4">Name</th>
+            <th className="pb-1.5 pr-4">Port</th>
+            <th className="pb-1.5 pr-4">Protocol</th>
+            <th className="pb-1.5">App Protocol</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {ports.map((p, i) => (
+            <tr key={i} className="align-top">
+              <td className="py-1.5 pr-4 font-mono text-ink-muted">{p.name || "—"}</td>
+              <td className="py-1.5 pr-4 font-mono text-ink-muted">{p.port}</td>
+              <td className="py-1.5 pr-4 font-mono text-ink-muted">{p.protocol || "—"}</td>
+              <td className="py-1.5 font-mono text-ink-muted">{p.appProtocol || "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EndpointsTable({ endpoints }: { endpoints: EndpointSliceEndpoint[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-[11.5px]">
+        <thead>
+          <tr className="border-b border-border text-left text-[10px] font-medium uppercase tracking-[0.08em] text-ink-faint">
+            <th className="pb-1.5 pr-4">Address</th>
+            <th className="pb-1.5 pr-4">Conditions</th>
+            <th className="pb-1.5 pr-4">Target</th>
+            <th className="pb-1.5 pr-4">Node</th>
+            <th className="pb-1.5">Zone</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {endpoints.map((e, i) => {
+            const conds: string[] = [];
+            if (e.ready) conds.push("ready");
+            if (e.serving) conds.push("serving");
+            if (e.terminating) conds.push("terminating");
+            const target = e.targetRef
+              ? `${e.targetRef.kind}/${e.targetRef.name}`
+              : "—";
+            return (
+              <tr key={i} className="align-top">
+                <td className="py-1.5 pr-4 font-mono text-ink-muted">
+                  {e.addresses.join(", ")}
+                  {e.hostname ? <span className="ml-1 text-ink-faint">({e.hostname})</span> : null}
+                </td>
+                <td className="py-1.5 pr-4 font-mono text-ink-muted">
+                  {conds.length > 0 ? conds.join(" + ") : "—"}
+                </td>
+                <td className="py-1.5 pr-4 font-mono text-ink-muted">{target}</td>
+                <td className="py-1.5 pr-4 font-mono text-ink-muted">{e.nodeName || "—"}</td>
+                <td className="py-1.5 font-mono text-ink-muted">{e.zone || "—"}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/lib/k8sKinds.ts
+++ b/web/src/lib/k8sKinds.ts
@@ -50,6 +50,9 @@ export const KIND_REGISTRY: Record<YamlKind, KindMeta> = {
   ingressclasses:       { group: "networking.k8s.io",      version: "v1",       resource: "ingressclasses",             kind: "IngressClass" },
   networkpolicies:      { group: "networking.k8s.io",      version: "v1",       resource: "networkpolicies",            kind: "NetworkPolicy" },
 
+  // discovery.k8s.io/v1
+  endpointslices:       { group: "discovery.k8s.io",       version: "v1",       resource: "endpointslices",             kind: "EndpointSlice" },
+
   // rbac.authorization.k8s.io/v1
   roles:                { group: "rbac.authorization.k8s.io", version: "v1",    resource: "roles",                      kind: "Role" },
   rolebindings:         { group: "rbac.authorization.k8s.io", version: "v1",    resource: "rolebindings",               kind: "RoleBinding" },

--- a/web/src/lib/listShape.ts
+++ b/web/src/lib/listShape.ts
@@ -50,6 +50,9 @@ export const LIST_ITEMS_KEY: Record<string, string> = {
   ingressclasses: "ingressClasses",
   networkpolicies: "networkPolicies",
 
+  // discovery.k8s.io/v1
+  endpointslices: "endpointSlices",
+
   // rbac.authorization.k8s.io/v1
   roles: "roles",
   rolebindings: "roleBindings",

--- a/web/src/lib/resources.ts
+++ b/web/src/lib/resources.ts
@@ -34,6 +34,7 @@ export const RESOURCES: ResourceMeta[] = [
   { id: "poddisruptionbudgets",     label: "PodDisruptionBudgets",     group: "Workloads",  ready: true  },
   { id: "services",     label: "Services",     group: "Networking", ready: true  },
   { id: "ingresses",    label: "Ingresses",    group: "Networking", ready: true  },
+  { id: "endpointslices",   label: "EndpointSlices",   group: "Networking", ready: true  },
   { id: "networkpolicies",  label: "NetworkPolicies",  group: "Networking", ready: true  },
   { id: "ingressclasses",   label: "IngressClasses",   group: "Networking", ready: true  },
   { id: "configmaps",    label: "ConfigMaps",    group: "Config",   ready: true  },

--- a/web/src/pages/EndpointSlicesPage.tsx
+++ b/web/src/pages/EndpointSlicesPage.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useResource } from "../hooks/useResource";
+import type { EndpointSlice, EndpointSliceList } from "../lib/types";
+import { ageFrom, nameMatches } from "../lib/format";
+import { PageHeader } from "../components/page/PageHeader";
+import { FilterStrip } from "../components/page/FilterStrip";
+import { SplitPane } from "../components/page/SplitPane";
+import { DataTable, type Column } from "../components/table/DataTable";
+import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
+import { isForbidden } from "../components/table/isForbidden";
+import { DetailPane } from "../components/detail/DetailPane";
+import { EndpointSliceDescribe } from "../components/detail/describe/EndpointSliceDescribe";
+import { YamlView } from "../components/detail/YamlView";
+import { useEditorDirty } from "../hooks/useEditorDirty";
+import { useConfirmDiscard } from "../hooks/useConfirmDiscard";
+import { ResourceActions } from "../components/edit/ResourceActions";
+import { EventsView } from "../components/detail/EventsView";
+import { NamespacePicker } from "../components/shell/NamespacePicker";
+
+export function EndpointSlicesPage({ cluster }: { cluster: string }) {
+  const [params, setParams] = useSearchParams();
+  const namespace = params.get("ns");
+  const search = params.get("q") ?? "";
+  const selectedNs = params.get("selNs");
+  const selectedName = params.get("sel");
+  const activeTab = params.get("tab") ?? "describe";
+
+  const setParam = (key: string, value: string | null) => {
+    const next = new URLSearchParams(params);
+    if (value === null || value === "") next.delete(key);
+    else next.set(key, value);
+    setParams(next, { replace: true });
+  };
+
+  const setMany = (updates: Record<string, string | null>) => {
+    const next = new URLSearchParams(params);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === "") next.delete(key);
+      else next.set(key, value);
+    }
+    setParams(next, { replace: true });
+  };
+
+  const query = useResource({ cluster, resource: "endpointslices", namespace: namespace ?? undefined });
+  const all = useMemo<EndpointSlice[]>(
+    () => (query.data as EndpointSliceList | undefined)?.endpointSlices ?? [],
+    [query.data],
+  );
+  const filtered = useMemo(
+    () => (search ? all.filter((r) => nameMatches(r.name, search)) : all),
+    [all, search],
+  );
+
+  const formatPorts = (es: EndpointSlice) => {
+    if (es.ports.length === 0) return "—";
+    return es.ports
+      .map((p) => {
+        const proto = p.protocol ?? "TCP";
+        return p.name ? `${p.name}:${p.port}/${proto}` : `${p.port}/${proto}`;
+      })
+      .join(", ");
+  };
+
+  const columns: Column<EndpointSlice>[] = [
+    { key: "name", header: "name", weight: 3, cellClassName: "font-mono text-ink", accessor: (r) => r.name },
+    { key: "namespace", header: "namespace", weight: 2, cellClassName: "font-mono text-ink-muted", accessor: (r) => r.namespace },
+    { key: "service", header: "service", weight: 2, cellClassName: "font-mono text-ink-muted", accessor: (r) => r.serviceName || "—" },
+    { key: "addressType", header: "addr type", weight: 1, cellClassName: "font-mono text-ink-muted", accessor: (r) => r.addressType },
+    { key: "ports", header: "ports", weight: 2, cellClassName: "font-mono text-ink-muted", accessor: formatPorts },
+    {
+      key: "endpoints",
+      header: "endpoints",
+      weight: 1.2,
+      align: "right",
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (r) => `${r.readyCount}/${r.totalCount}`,
+    },
+    { key: "age", header: "age", weight: 0.8, align: "right", cellClassName: "font-mono text-ink-muted", accessor: (r) => ageFrom(r.createdAt) },
+  ];
+
+  const selectedKey = selectedNs && selectedName ? `${selectedNs}/${selectedName}` : null;
+
+  const editFlag = useEditorDirty(cluster, "endpointslices", selectedNs ?? undefined, selectedName);
+  const confirmDiscard = useConfirmDiscard(editFlag.dirty);
+
+  const detail =
+    selectedNs && selectedName ? (
+      <DetailPane
+        title={selectedName}
+        subtitle={selectedNs}
+        activeTab={activeTab}
+        onTabChange={(id) => confirmDiscard(() => setParam("tab", id))}
+        onClose={() => confirmDiscard(() => setMany({ sel: null, selNs: null, tab: null }))}
+        tabs={[
+          { id: "describe", label: "describe", ready: true, content: <EndpointSliceDescribe cluster={cluster} ns={selectedNs} name={selectedName} /> },
+          { id: "yaml", label: "yaml", ready: true, content: <YamlView cluster={cluster} source={{ kind: "builtin", yamlKind: "endpointslices" }} ns={selectedNs} name={selectedName} />, dirty: editFlag.dirty },
+          { id: "events", label: "events", ready: true, content: <EventsView cluster={cluster} kind="endpointslices" ns={selectedNs} name={selectedName} /> },
+        ]}
+        actions={
+          <ResourceActions
+            cluster={cluster}
+            source={{ kind: "builtin", yamlKind: "endpointslices" }}
+            namespace={selectedNs}
+            name={selectedName}
+            onDeleted={() => setParam("sel", null)}
+          />
+        }
+      />
+    ) : null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="EndpointSlices"
+        subtitle={query.isSuccess ? `${all.length} ${all.length === 1 ? "endpointslice" : "endpointslices"}${namespace ? ` in ${namespace}` : ""}` : undefined}
+        trailing={<NamespacePicker />}
+      />
+      <FilterStrip search={search} onSearch={(v) => setParam("q", v)} resultCount={filtered.length} totalCount={all.length} />
+      <SplitPane
+        storageKey="periscope.detailWidth.v4"
+        left={
+          query.isLoading ? <LoadingState resource="endpointslices" /> :
+          query.isError ? isForbidden(query.error) ? <ForbiddenState resource="endpointslices" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
+          filtered.length === 0 ? <EmptyState resource="endpointslices" namespace={namespace} /> :
+          <DataTable<EndpointSlice>
+            columns={columns}
+            rows={filtered}
+            rowKey={(r) => `${r.namespace}/${r.name}`}
+            onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
+            selectedKey={selectedKey}
+          />
+        }
+        right={detail}
+      />
+    </div>
+  );
+}

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -60,6 +60,7 @@ const HorizontalPodAutoscalersPage = lazyNamed(() => import("./pages/HorizontalP
 const PodDisruptionBudgetsPage = lazyNamed(() => import("./pages/PodDisruptionBudgetsPage"), "PodDisruptionBudgetsPage");
 const ReplicaSetsPage = lazyNamed(() => import("./pages/ReplicaSetsPage"), "ReplicaSetsPage");
 const NetworkPoliciesPage = lazyNamed(() => import("./pages/NetworkPoliciesPage"), "NetworkPoliciesPage");
+const EndpointSlicesPage = lazyNamed(() => import("./pages/EndpointSlicesPage"), "EndpointSlicesPage");
 const IngressClassesPage = lazyNamed(() => import("./pages/IngressClassesPage"), "IngressClassesPage");
 const ResourceQuotasPage = lazyNamed(() => import("./pages/ResourceQuotasPage"), "ResourceQuotasPage");
 const LimitRangesPage = lazyNamed(() => import("./pages/LimitRangesPage"), "LimitRangesPage");
@@ -106,6 +107,7 @@ export const router = createBrowserRouter(
         <Route path="poddisruptionbudgets" element={<WithCluster Page={PodDisruptionBudgetsPage} />} />
         <Route path="replicasets" element={<WithCluster Page={ReplicaSetsPage} />} />
         <Route path="networkpolicies" element={<WithCluster Page={NetworkPoliciesPage} />} />
+        <Route path="endpointslices" element={<WithCluster Page={EndpointSlicesPage} />} />
         <Route path="ingressclasses" element={<WithCluster Page={IngressClassesPage} />} />
         <Route path="resourcequotas" element={<WithCluster Page={ResourceQuotasPage} />} />
         <Route path="limitranges" element={<WithCluster Page={LimitRangesPage} />} />


### PR DESCRIPTION
Follow-up to #28. Adds the SPA-side surface for EndpointSlices so the resource appears in the Networking nav and gets its own list page + describe panel. The backend support (LIST/DETAIL/YAML/EVENTS routes, types, watch primitive, summary projection) already landed in #28, so this PR is pure frontend wiring.

## What's included

- **`EndpointSlicesPage`** — list view showing parent service (derived from the `kubernetes.io/service-name` label), address type (IPv4 / IPv6 / FQDN), ports, and ready/total endpoint counts. Hits `/api/clusters/{c}/endpointslices` (already exposed in #28). Polling cadence is 15s (set in `LIST_REFETCH_INTERVAL` in #28) since slices churn fast during rollouts.
- **`EndpointSliceDescribe`** — detail panel that enumerates each endpoint with conditions (ready / serving / terminating), target ref, node name, and zone. Wired into the standard detail-panel pipeline.
- **`KIND_REGISTRY`** entry: `discovery.k8s.io/v1` `EndpointSlice` — so the YAML editor + describe machinery resolve the kind.
- **`LIST_ITEMS_KEY`** entry mapping `endpointslices` → `endpointSlices` for the list-shape contract.
- **`RESOURCES`** catalog entry under `group: Networking, ready: true`.
- **Router**: lazy-loaded route at `/clusters/:cluster/endpointslices`.

## Why this was split out

In the original #16, the page UI rode along with the backend EndpointSlices work without being mentioned in the PR description. Splitting it out gives this UI feature its own focused review/revert window without slowing down the watch-streams refactor that #28 carried.

## Verification

- `npx tsc --noEmit` clean in `web/`
- `npm run lint` clean in `web/`
- `npm run build` clean in `web/`
- Manual smoke: list view renders, ready/total counts populate, click-through to detail shows endpoint conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)