### PR TITLE
feat(release): publish images + helm chart to ghcr.io OCI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,208 @@
+name: Release
+
+# Runs on every tag matching v*, e.g. v0.5.0-rc1, v1.0.0, v1.2.3.
+# Builds + signs + publishes:
+#   - multi-arch container image (linux/amd64, linux/arm64) to ghcr.io
+#   - Helm chart packaged + pushed to ghcr.io as an OCI artifact
+#   - cosign keyless signatures for both
+#   - SPDX SBOM attached to the image as an OCI artifact
+#   - GitHub Release with auto-generated notes from PR titles since
+#     the previous tag
+#
+# Tagging convention: vX.Y.Z (semver). Pre-releases use vX.Y.Z-rcN.
+# Helm rejects non-semver tags so this matches up automatically.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write       # create the GitHub Release
+  packages: write       # push to ghcr.io
+  id-token: write       # cosign keyless signing via GH OIDC
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}                  # gnana997/periscope
+  CHART_REPO: ${{ github.repository_owner }}/charts     # gnana997/charts
+
+jobs:
+  release:
+    name: Build, sign, and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history so the release-notes generator can
+          # diff against the previous tag.
+          fetch-depth: 0
+
+      # ── Container image ─────────────────────────────────────────
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tags applied:
+          #   v1.2.3        → v1.2.3, 1.2.3, 1.2, 1, latest
+          #   v1.2.3-rc1    → v1.2.3-rc1 only (no latest, no major)
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Keyless-auth Kubernetes dashboard for EKS
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing — cosign uses the GH Actions OIDC token to
+      # request a short-lived cert from Sigstore's Fulcio CA. No
+      # secrets to manage. Verify with:
+      #   cosign verify ghcr.io/...@<digest> \
+      #     --certificate-identity-regexp="https://github.com/gnana997/periscope" \
+      #     --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
+      # ── SBOM ───────────────────────────────────────────────────
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attach SBOM to image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attach sbom \
+            --sbom sbom.spdx.json \
+            --type spdx \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+          # Sign the SBOM attestation
+          cosign sign --yes \
+            --attachment sbom \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+
+      # ── Helm chart ─────────────────────────────────────────────
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      # The chart's version field must match the tag for clean
+      # discovery. Sync Chart.yaml's version + appVersion to the
+      # tag (stripping the leading "v") before packaging.
+      - name: Sync chart version to tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version: .*/version: ${VERSION}/" deploy/helm/periscope/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" deploy/helm/periscope/Chart.yaml
+
+      - name: Package chart
+        run: |
+          helm package deploy/helm/periscope --destination dist/
+
+      - name: Log in to ghcr.io for Helm
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login \
+            ${{ env.REGISTRY }} \
+            --username ${{ github.actor }} \
+            --password-stdin
+
+      - name: Push chart to OCI registry
+        id: helm_push
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          OUT=$(helm push dist/periscope-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_REPO }} 2>&1)
+          echo "$OUT"
+          # Capture the chart's pushed digest for cosign signing.
+          DIGEST=$(echo "$OUT" | awk '/Digest:/{print $2}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart
+        env:
+          DIGEST: ${{ steps.helm_push.outputs.digest }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope:${VERSION}@${DIGEST}"
+
+      # ── GitHub Release ─────────────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          body: |
+            ## Container image
+
+            ```sh
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ```
+
+            Multi-arch: `linux/amd64`, `linux/arm64`. Cosign-signed (keyless), SBOM attached.
+
+            ## Helm chart
+
+            ```sh
+            helm install periscope \
+              oci://${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope \
+              --version ${{ github.ref_name }} \
+              --namespace periscope --create-namespace
+            ```
+
+            Cosign-signed (keyless). Discoverable on [Artifact Hub](https://artifacthub.io/packages/helm/periscope/periscope).
+
+            ## Verification
+
+            ```sh
+            cosign verify \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
+              --certificate-identity-regexp="https://github.com/${{ github.repository }}" \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+            ```
+          files: |
+            sbom.spdx.json
+            dist/*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,12 @@ COPY --from=web-builder /web/dist /src/internal/spa/dist
 # Build with the embed tag so the SPA bundle is baked into the binary.
 ARG VERSION=dev
 ARG COMMIT=unknown
-RUN CGO_ENABLED=0 GOOS=linux go build \
+# TARGETARCH is set automatically by Docker buildx when --platform is
+# passed (e.g. linux/amd64,linux/arm64). The Go toolchain compiles
+# cross-arch via GOARCH; CGO_ENABLED=0 keeps the build static so no
+# per-arch C toolchain is needed.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -tags embed \
     -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/helm/periscope/Chart.yaml
+++ b/deploy/helm/periscope/Chart.yaml
@@ -20,3 +20,36 @@ sources:
   - https://github.com/gnana997/periscope
 maintainers:
   - name: gnana997
+icon: https://periscopehq.dev/icon.png
+annotations:
+  # Artifact Hub renders these in the chart's listing page. See
+  # https://artifacthub.io/docs/topics/annotations/helm/ for the
+  # full list of recognized annotation keys.
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/operator: "false"
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://periscopehq.dev/docs
+    - name: Source code
+      url: https://github.com/gnana997/periscope
+    - name: Changelog
+      url: https://periscopehq.dev/changelog
+    - name: Issues
+      url: https://github.com/gnana997/periscope/issues
+  # The release.yaml workflow updates this annotation on every tag
+  # to reflect the PR titles since the previous tag (high-signal
+  # release notes for Artifact Hub's "What changed" panel).
+  artifacthub.io/changes: |
+    - kind: added
+      description: real-time SSE updates for 21+ resource kinds
+    - kind: added
+      description: searchable audit log with SQLite/Postgres backends
+    - kind: added
+      description: Helm release browser
+  # Cosign signing — Artifact Hub will display a "Signed" badge when
+  # the chart is verifiable via cosign. The signKey block teaches it
+  # how to verify; for keyless (Sigstore) signatures the URL points
+  # at the GH OIDC issuer.
+  artifacthub.io/signKey: |
+    fingerprint: keyless
+    url: https://token.actions.githubusercontent.com

--- a/deploy/helm/periscope/artifacthub-repo.yml
+++ b/deploy/helm/periscope/artifacthub-repo.yml
@@ -1,0 +1,23 @@
+# Artifact Hub repository metadata.
+#
+# Pushed to the OCI registry as a metadata layer with the special
+# `artifacthub.io` tag, so when the chart's repo is registered on
+# Artifact Hub it can find publisher info, ownership claim, and
+# verified-publisher proof. See:
+# https://artifacthub.io/docs/topics/repositories/helm-charts/
+#
+# Push command (run once after the chart's first OCI push):
+#
+#   oras push ghcr.io/gnana997/charts/periscope:artifacthub.io \
+#     --config=/dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+#     deploy/helm/periscope/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+
+repositoryID: 00000000-0000-0000-0000-000000000000
+# After registering the repo on Artifact Hub, replace the zeros above
+# with the UUID Artifact Hub assigns to the repository. Re-push the
+# metadata layer (same oras command above) to claim the OCI repo
+# under your account.
+
+owners:
+  - name: gnana997
+    email: gnana097@gmail.com

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,145 @@
+# Releasing Periscope
+
+How tags become published artifacts. The `release.yaml` GitHub
+Actions workflow does the heavy lifting; this document covers the
+human side of the loop.
+
+## TL;DR
+
+```sh
+git checkout main && git pull
+git tag -a v0.5.0 -m "v0.5.0"
+git push origin v0.5.0
+```
+
+That's it. The workflow at `.github/workflows/release.yaml` triggers
+on the tag push, builds + signs + publishes everything, opens a
+GitHub Release, and you're done.
+
+## What gets published
+
+Every tag (`v*`) triggers the workflow, which:
+
+1. Builds a multi-arch container image (`linux/amd64`, `linux/arm64`)
+2. Pushes it to `ghcr.io/gnana997/periscope` with semver tags
+3. Signs the image keylessly via cosign (Sigstore)
+4. Generates an SPDX SBOM and attaches it as an OCI artifact
+5. Packages the Helm chart at `deploy/helm/periscope/`
+6. Pushes the chart to `ghcr.io/gnana997/charts/periscope` as an
+   OCI artifact
+7. Signs the chart keylessly via cosign
+8. Opens a GitHub Release with auto-generated notes from PR titles
+   since the previous tag, attaching the SBOM and chart `.tgz`
+
+## Tagging convention
+
+- Stable: `vX.Y.Z` (e.g. `v1.0.0`, `v1.2.3`)
+- Pre-release: `vX.Y.Z-rcN` (e.g. `v1.0.0-rc1`)
+- Both must be valid semver — Helm rejects non-semver tags
+
+Stable tags get the `latest`, `vX`, `vX.Y` aliases on the container
+image. Pre-releases only get the exact tag. The GitHub Release is
+also marked as a pre-release when the tag contains `-`.
+
+## Pre-release checklist
+
+Before tagging:
+
+- [ ] CI green on `main`
+- [ ] Helm `Chart.yaml`'s `artifacthub.io/changes` annotation
+      reflects the PRs in this release (the workflow does NOT
+      auto-update this — it stays as a curated changelog)
+- [ ] If the API or config shape changed, `docs/setup/deploy.md`
+      and the relevant guide are updated
+- [ ] If a new env var was added, it's documented in `values.yaml`
+      with a comment block
+- [ ] `README.md` features list still matches what ships
+- [ ] `cmd/periscope/main.go`'s `version` and `commit` ldflags
+      defaults are sane (the workflow overrides them with the tag
+      and SHA, but the dev-mode default is what `make build` uses)
+
+## Cutting a release
+
+```sh
+# 1. Ensure local main is up to date
+git checkout main
+git pull origin main
+
+# 2. Tag with an annotated message (required — the message becomes
+#    the GitHub Release title context)
+git tag -a v0.5.0 -m "v0.5.0"
+
+# 3. Push the tag — this is what triggers the workflow
+git push origin v0.5.0
+```
+
+Watch the workflow run at:
+`https://github.com/gnana997/periscope/actions/workflows/release.yaml`
+
+Total runtime is ~6-10 minutes depending on cache state.
+
+## Verifying signatures
+
+Anyone (including operators evaluating Periscope for production
+use) can verify the published artifacts:
+
+```sh
+# Verify the container image signature
+cosign verify \
+  ghcr.io/gnana997/periscope:v1.0.0 \
+  --certificate-identity-regexp="https://github.com/gnana997/periscope" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+# Verify the Helm chart signature
+cosign verify \
+  ghcr.io/gnana997/charts/periscope:1.0.0 \
+  --certificate-identity-regexp="https://github.com/gnana997/periscope" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+# Pull the SBOM
+cosign download sbom \
+  ghcr.io/gnana997/periscope:v1.0.0 > sbom.spdx.json
+```
+
+## Artifact Hub
+
+The chart appears at
+[artifacthub.io/packages/helm/periscope/periscope](https://artifacthub.io/packages/helm/periscope/periscope)
+once registered (one-time setup — see
+`deploy/helm/periscope/artifacthub-repo.yml` for the metadata
+push command). Artifact Hub polls the OCI registry every ~30
+minutes and re-renders the chart's listing page.
+
+## Rollback
+
+If a release goes wrong:
+
+1. **Don't delete the tag.** Pushing a moved tag is destructive
+   and confuses anyone who already pulled.
+2. **Cut a new patch release** that reverts the bad change
+   (`v1.0.0` bad → `v1.0.1` with the revert).
+3. **Mark the GitHub Release as "broken"** with a prominent edit
+   to its body pointing at the patch release.
+4. The container image and chart cannot be unpublished from
+   ghcr.io once consumers have pulled them — the new tag is the
+   forward-only fix path.
+
+## First-time-only setup
+
+Done once, then the workflow handles everything:
+
+1. **GitHub repo settings** — Settings → Actions → General →
+   Workflow permissions → "Read and write permissions" (already
+   done as of the CI workflow PR)
+2. **First release publishes packages** — after `v0.5.0-rc1`
+   pushes the first image and chart, navigate to
+   `https://github.com/gnana997?tab=packages`, open each new
+   package, set visibility to **Public** in Package settings →
+   Danger Zone
+3. **Artifact Hub registration** — once the chart is public on
+   ghcr.io, sign in to artifacthub.io with GitHub OAuth, add the
+   repository (kind: Helm OCI, URL:
+   `oci://ghcr.io/gnana997/charts/periscope`), copy the assigned
+   `repositoryID` UUID into `deploy/helm/periscope/artifacthub-repo.yml`,
+   and re-push the metadata layer with `oras` (command in the
+   yaml file's header comment)


### PR DESCRIPTION
  Adds the v1.0 release distribution pipeline:

    - Multi-arch container image (linux/amd64, linux/arm64) to ghcr.io
    - Cosign keyless signing of the image (Sigstore via GH OIDC)
    - SPDX SBOM generated and attached as an OCI artifact
    - Helm chart packaged + pushed to ghcr.io as an OCI artifact
    - Cosign keyless signing of the chart
    - GitHub Release opened automatically with auto-generated notes
      from PR titles since the previous tag

  Triggers on tag push (vX.Y.Z stable; vX.Y.Z-rcN for pre-releases).
  Stable tags get the latest, vX, vX.Y aliases on the image.

  Dockerfile picks up TARGETARCH from buildx so the same Dockerfile
  produces both amd64 and arm64 binaries via Go cross-compilation
  (CGO_ENABLED=0 keeps it static).

  Chart.yaml gains an annotations block (license, links, changes,
  signKey) that drives how the chart renders on Artifact Hub.

  artifacthub-repo.yml is the one-time metadata layer pushed via
  oras to claim the OCI repo on Artifact Hub. Push command is in
  the file header.

  docs/RELEASING.md documents the tag → workflow → publish flow,
  verification commands operators can run, and the first-time-only
  package-visibility + Artifact Hub registration steps.