### PR TITLE
docs: switch install path to OCI, add Artifact Hub + Release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![CI](https://github.com/gnana997/periscope/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/gnana997/periscope/actions/workflows/ci.yaml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/gnana997/periscope?include_prereleases&sort=semver)](https://github.com/gnana997/periscope/releases/latest)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/periscope)](https://artifacthub.io/packages/search?repo=periscope)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8.svg)](https://go.dev/)
 [![Node](https://img.shields.io/badge/Node-22-339933.svg)](https://nodejs.org/)
 
@@ -39,11 +41,28 @@ Open <http://localhost:5173>.
 
 A Helm chart lives at [`deploy/helm/periscope/`](deploy/helm/periscope/). Full walkthrough including OIDC client setup and Pod Identity / IRSA wiring: [`docs/setup/deploy.md`](docs/setup/deploy.md).
 
+
 ```sh
-helm repo add periscope https://gnana997.github.io/periscope
-helm install periscope periscope/periscope \
+# Pin to a specific version. Find the latest at
+# https://artifacthub.io/packages/helm/periscope/periscope
+helm install periscope \
+  oci://ghcr.io/gnana997/charts/periscope \
+  --version <VERSION> \
   --namespace periscope --create-namespace
 ```
+
+For CI / scripts that always want the latest stable, resolve the tag from the GitHub API:
+
+```sh
+LATEST=$(curl -s https://api.github.com/repos/gnana997/periscope/releases/latest \
+  | jq -r .tag_name | sed 's/^v//')
+helm install periscope \
+  oci://ghcr.io/gnana997/charts/periscope \
+  --version "$LATEST" \
+  --namespace periscope --create-namespace
+```
+
+Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifacthub.io/packages/helm/periscope/periscope). To verify the chart signature before install, see the verification snippet in [`docs/RELEASING.md`](docs/RELEASING.md).
 
 ## Features
 

--- a/deploy/helm/periscope/Chart.yaml
+++ b/deploy/helm/periscope/Chart.yaml
@@ -20,7 +20,6 @@ sources:
   - https://github.com/gnana997/periscope
 maintainers:
   - name: gnana997
-icon: https://periscopehq.dev/icon.png
 annotations:
   # Artifact Hub renders these in the chart's listing page. See
   # https://artifacthub.io/docs/topics/annotations/helm/ for the

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -24,29 +24,51 @@ For IdP setup that produces the `auth.*` values, see
 
 ## 2. Quickstart
 
+### Option A — install from the OCI registry (recommended)
+
+The chart is published to ghcr.io as an OCI artifact and signed with cosign. No `helm repo add` step needed.
+
 ```sh
-# 1. Pull (or vendor) the chart
-git clone https://github.com/gnana997/periscope
-cd periscope
+# 1. Write a values file (see section 3 below for the minimum shape)
+$EDITOR my-values.yaml
 
-# 2. Write a values file (see 3)
-cp examples/config/auth.yaml.auth0 my-auth.yaml   # for reference
-$EDITOR my-values.yaml                             # paste in & adapt
-
-# 3. Apply your OIDC client secret (default secrets.mode=existing)
+# 2. Apply your OIDC client secret (default secrets.mode=existing)
 kubectl create namespace periscope
 kubectl -n periscope create secret generic periscope-oidc \
   --from-literal=OIDC_CLIENT_SECRET='<the-secret-from-your-IdP>'
 
-# 4. Install
-helm install periscope ./deploy/helm/periscope \
+# 3. Install (find the latest version at
+#    https://artifacthub.io/packages/helm/periscope/periscope)
+helm install periscope \
+  oci://ghcr.io/gnana997/charts/periscope \
+  --version <VERSION> \
   --namespace periscope \
   --values my-values.yaml
 
-# 5. Reach it
+# 4. Reach it
 kubectl -n periscope port-forward svc/periscope 8080:8080
 open http://localhost:8080/
 ```
+
+To verify the chart signature before install:
+
+```sh
+cosign verify oci://ghcr.io/gnana997/charts/periscope:<VERSION> \
+  --certificate-identity-regexp=https://github.com/gnana997/periscope \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+### Option B — install from a local clone (development)
+
+```sh
+git clone https://github.com/gnana997/periscope
+cd periscope
+helm install periscope ./deploy/helm/periscope \
+  --namespace periscope \
+  --values my-values.yaml
+```
+
+Use this when you're iterating on the chart itself or want to test unreleased changes.
 
 ---
 


### PR DESCRIPTION
OCI publishing went live with the v0.5.0-rc1 release workflow,
so the install instructions in README and docs/setup/deploy.md
are updated to use `oci://ghcr.io/gnana997/charts/periscope`
instead of the never-existed `gnana997.github.io/periscope` repo
the previous snippet referenced.

README:
  - adds [Latest Release] badge (auto-tracks the most recent tag)
  - adds [Artifact Hub] badge (auto-tracks chart count + push date)
  - replaces install snippet with two patterns: explicit version
    pinning (recommended for first-time installers) and
    curl-resolves-latest (for CI / scripts)
  - mentions cosign keyless signing + points at docs/RELEASING.md
    for the full verify command

docs/setup/deploy.md:
  - section 2 Quickstart restructured: "Option A — OCI registry
    (recommended)" as primary install path with cosign verify
    command inline, "Option B — local clone (development)" as
    the alternative for chart development
  - the local-clone path is preserved verbatim from before

Chart.yaml:
  - drops the icon: https://periscopehq.dev/icon.png line
    (the URL doesn't resolve — we never shipped an icon). Helm
    lint emits an informational notice but no error. Restore
    when a real mark is designed.