### PR TITLE
Replace panics with error returns in auth randomness functions

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -25,8 +25,18 @@ func LoginHandler(client *OIDCClient, cfg Config) http.HandlerFunc {
 			http.Redirect(w, r, "/", http.StatusFound)
 			return
 		}
-		state := NewState()
-		verifier := NewPKCEVerifier()
+		state, err := NewState()
+		if err != nil {
+			slog.ErrorContext(r.Context(), "auth.login_failed", "reason", "rand_failed", "err", err)
+			http.Error(w, "couldn't start login", http.StatusInternalServerError)
+			return
+		}
+		verifier, err := NewPKCEVerifier()
+		if err != nil {
+			slog.ErrorContext(r.Context(), "auth.login_failed", "reason", "rand_failed", "err", err)
+			http.Error(w, "couldn't start login", http.StatusInternalServerError)
+			return
+		}
 
 		// Encode state + verifier into a single value so they
 		// share a cookie. State is short, verifier is the secret.
@@ -91,7 +101,12 @@ func CallbackHandler(client *OIDCClient, store SessionStore, cfg Config) http.Ha
 			return
 		}
 
-		sessID := NewSessionID()
+		sessID, err := NewSessionID()
+		if err != nil {
+			slog.ErrorContext(r.Context(), "auth.login_failed", "reason", "rand_failed", "err", err)
+			http.Error(w, "couldn't complete login", http.StatusInternalServerError)
+			return
+		}
 		s, err := client.Exchange(r.Context(), code, verifier, sessID, cfg.Session.AbsoluteTimeout)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "auth.login_failed",

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -200,21 +200,21 @@ func pkceChallenge(verifier string) string {
 
 // NewPKCEVerifier returns a 64-char URL-safe-base64 random string,
 // suitable as a PKCE code_verifier.
-func NewPKCEVerifier() string {
+func NewPKCEVerifier() (string, error) {
 	b := make([]byte, 48)
 	if _, err := rand.Read(b); err != nil {
-		panic("auth: rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("auth: rand.Read failed: %w", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // NewState returns a 128-bit random string for the state parameter.
-func NewState() string {
+func NewState() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		panic("auth: rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("auth: rand.Read failed: %w", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // decodeJWTPayload splits the JWT and base64-decodes the middle

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -128,12 +129,10 @@ func (errNotFound) Error() string { return "session not found" }
 
 // NewSessionID returns a 256-bit random session identifier encoded as
 // URL-safe base64 (no padding).
-func NewSessionID() string {
+func NewSessionID() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		// crypto/rand should not fail in practice; if it does, the
-		// process is in no shape to issue sessions.
-		panic("auth: rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("auth: rand.Read failed: %w", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }


### PR DESCRIPTION
## Summary
This PR replaces panic calls with proper error handling in authentication functions that depend on random number generation. Instead of panicking when `rand.Read` fails, these functions now return errors that are handled gracefully by callers.

## Key Changes
- **NewState()**: Changed from returning `string` to `(string, error)`. Now returns an error instead of panicking when random generation fails.
- **NewPKCEVerifier()**: Changed from returning `string` to `(string, error)`. Now returns an error instead of panicking when random generation fails.
- **NewSessionID()**: Changed from returning `string` to `(string, error)`. Now returns an error instead of panicking when random generation fails.
- **LoginHandler**: Added error handling for `NewState()` and `NewPKCEVerifier()` calls with appropriate logging and HTTP 500 responses.
- **CallbackHandler**: Added error handling for `NewSessionID()` call with appropriate logging and HTTP 500 response.

## Implementation Details
- All three functions now use `fmt.Errorf` with error wrapping (`%w`) for consistent error reporting
- Callers log errors using `slog.ErrorContext` with reason "rand_failed" before returning HTTP 500 responses
- Error messages are user-friendly ("couldn't start login", "couldn't complete login") while detailed errors are logged server-side
- This improves observability and allows graceful degradation instead of process crashes

https://claude.ai/code/session_018zZ5jupV4RuubMEt2cCH5G