### PR TITLE
feat(clusters): add in-cluster backend + relax empty-registry error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ web/.vite/
 # Local-only filled auth config (template is my-auth.yaml.template)
 my-auth.yaml
 my-clusters.yaml
+/my-values.yaml

--- a/cmd/periscope/exec_handler.go
+++ b/cmd/periscope/exec_handler.go
@@ -334,6 +334,8 @@ func k8sIdentityLabel(c clusters.Cluster) string {
 	switch c.Backend {
 	case clusters.BackendKubeconfig:
 		return "kubeconfig:" + c.Name
+	case clusters.BackendInCluster:
+		return "in-cluster:" + c.Name
 	default:
 		return "shared-irsa-v1"
 	}

--- a/deploy/helm/periscope/templates/cluster-rbac.yaml
+++ b/deploy/helm/periscope/templates/cluster-rbac.yaml
@@ -1,4 +1,16 @@
-{{- if .Values.clusterRBAC.enabled -}}
+{{- /*
+  Auto-detect in-cluster mode: if any registered cluster has
+  backend: in-cluster, the chart's own SA needs the impersonator
+  role on this cluster — render the same tier bindings too so the
+  impersonated users have RBAC to actually do anything.
+*/}}
+{{- $hasInCluster := false -}}
+{{- range .Values.clusters }}
+  {{- if eq .backend "in-cluster" }}
+    {{- $hasInCluster = true -}}
+  {{- end }}
+{{- end }}
+{{- if or .Values.clusterRBAC.enabled $hasInCluster -}}
 {{- /*
   cluster-rbac.yaml — per-cluster RBAC manifests for tier-mode
   impersonation (RFC 0002 7.6). When tier mode is active, apply this
@@ -52,6 +64,14 @@ subjects:
   - kind: Group
     name: {{ .Values.clusterRBAC.bridgeGroup | default "periscope-bridge" }}
     apiGroup: rbac.authorization.k8s.io
+  {{- if $hasInCluster }}
+  # In-cluster mode — the chart's own SA needs impersonate so it can
+  # pass the OIDC user identity to the apiserver. Auto-rendered when
+  # any clusters[].backend == "in-cluster".
+  - kind: ServiceAccount
+    name: {{ include "periscope.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+  {{- end }}
 
 ---
 # 2. Built-in tiers — bind to K8s standard ClusterRoles.

--- a/deploy/helm/periscope/values.schema.json
+++ b/deploy/helm/periscope/values.schema.json
@@ -191,7 +191,7 @@
         "type": "object",
         "properties": {
           "name":    { "type": "string", "minLength": 1 },
-          "backend": { "type": "string", "enum": ["eks", "kubeconfig"] },
+          "backend": { "type": "string", "enum": ["eks", "kubeconfig", "in-cluster"] },
           "exec": {
             "type": "object",
             "description": "Per-cluster pod-exec overrides. Partial overrides are fine — omitted fields fall back to the global .exec defaults.",

--- a/deploy/helm/periscope/values.yaml
+++ b/deploy/helm/periscope/values.yaml
@@ -144,10 +144,31 @@ auth:
 #       enabled: false
 # -----------------------------------------------------------------------------
 clusters: []
+#
+# Three backends supported:
+#
+# 1. eks — managed EKS clusters reached via IRSA / Pod Identity. The
+#    "default" backend (omit `backend:` to get this).
 # - name: prod-eu-west-1
 #   backend: eks
 #   region: eu-west-1
 #   arn: arn:aws:eks:eu-west-1:222222222222:cluster/prod-eu-west-1
+#
+# 2. kubeconfig — non-EKS clusters reached via a kubeconfig file at a
+#    path on the pod's filesystem. Useful for static credentials or
+#    cross-provider clusters.
+# - name: gke-staging
+#   backend: kubeconfig
+#   kubeconfigPath: /etc/periscope/gke-kubeconfig.yaml
+#   kubeconfigContext: staging
+#
+# 3. in-cluster — the cluster periscope is itself running in. Uses the
+#    in-pod ServiceAccount token (rest.InClusterConfig). The chart's
+#    cluster-rbac.yaml automatically binds the periscope SA to the
+#    impersonator role when this backend is in the registry. The most
+#    common single-cluster install pattern.
+# - name: in-cluster
+#   backend: in-cluster
 
 # -----------------------------------------------------------------------------
 # Secrets — how the OIDC client secret reaches the pod.

--- a/docs/setup/cluster-rbac.md
+++ b/docs/setup/cluster-rbac.md
@@ -509,3 +509,64 @@ Drift between the shipped role (chart `appVersion`) and the cluster
 is the operator's responsibility. The chart's `NOTES.txt` prints the
 shipped-role version on each `helm install` / `helm upgrade` so you
 can pin and re-apply when the chart bumps a verb.
+
+---
+
+## Mode: `in-cluster` (single-cluster install)
+
+When Periscope is deployed into the same cluster it manages (the most common single-cluster install pattern — kind, minikube, single-cluster prod), register that cluster with `backend: in-cluster`:
+
+```yaml
+# my-values.yaml
+clusters:
+  - name: in-cluster
+    backend: in-cluster
+```
+
+The pod uses its own ServiceAccount token (mounted at `/var/run/secrets/kubernetes.io/serviceaccount/`) as the underlying credentials, then layers per-user impersonation on top via `Impersonate-User` / `Impersonate-Group` headers — same model as `eks` and `kubeconfig`, just with a different credential source.
+
+### Auto-rendered RBAC
+
+The chart's `cluster-rbac.yaml` auto-detects in-cluster mode and renders the impersonator binding with the chart's SA as a subject. No separate `kubectl apply` step needed — `helm install` does the whole thing.
+
+The rendered `ClusterRoleBinding` looks like:
+
+```yaml
+kind: ClusterRoleBinding
+metadata:
+  name: periscope-impersonator
+subjects:
+  - kind: Group                  # for tier-mode managed clusters (if enabled)
+    name: periscope-bridge
+  - kind: ServiceAccount         # auto-added when an in-cluster cluster is in the registry
+    name: <release-name>-periscope
+    namespace: <release-namespace>
+```
+
+### What the SA can and can't do
+
+The SA only ever holds the `impersonate` verb on `users` / `groups`. It cannot read or modify any resource directly. Every actual API call goes through impersonation, so the apiserver evaluates RBAC against the impersonated user (e.g. `alice@corp` in tier mode mapped to `periscope-tier:admin`).
+
+Net: the chart-rendered SA is a thin "proxy" with no standalone power. All real authorization is per-user, per the existing tier / shared / raw modes.
+
+### Combining with managed clusters
+
+In-cluster and the other backends compose. A common production setup:
+
+```yaml
+clusters:
+  # The cluster periscope itself runs in
+  - name: periscope-host
+    backend: in-cluster
+  # Managed EKS clusters reached via Pod Identity
+  - name: prod-eu-west-1
+    backend: eks
+    region: eu-west-1
+    arn: arn:aws:eks:eu-west-1:111111111111:cluster/prod-eu-west-1
+  - name: stg-us-east-1
+    backend: eks
+    region: us-east-1
+    arn: arn:aws:eks:us-east-1:111111111111:cluster/stg-us-east-1
+```
+
+Each cluster is independent. The same OIDC user identity flows to all of them via impersonation; per-cluster RBAC determines what the user can actually do where.

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -179,6 +179,35 @@ already runs.
 
 ---
 
+## 4.5. Single-cluster install (in-cluster backend)
+
+When Periscope is deployed into the same cluster it should manage — the most common single-cluster install (kind, minikube, single-cluster prod) — register that cluster with `backend: in-cluster`:
+
+```yaml
+# my-values.yaml
+clusters:
+  - name: in-cluster
+    backend: in-cluster
+```
+
+The chart auto-detects this and binds Periscope's ServiceAccount to the impersonator role on the cluster — no separate `kubectl apply` step. See [`cluster-rbac.md`](./cluster-rbac.md#mode-in-cluster-single-cluster-install) for the rendered RBAC details and how impersonation flows through.
+
+Skips the AWS / Pod Identity / IRSA path entirely (in-cluster auth uses the SA token mounted by the kubelet). Skip section 4 above when this is your only cluster.
+
+Combining `in-cluster` with managed `eks` clusters in the same registry works — each cluster is independent. Common pattern:
+
+```yaml
+clusters:
+  - name: periscope-host
+    backend: in-cluster
+  - name: prod-eu-west-1
+    backend: eks
+    region: eu-west-1
+    arn: arn:aws:eks:eu-west-1:111111111111:cluster/prod-eu-west-1
+```
+
+---
+
 ## 5. Secret modes
 
 Pick the row that matches how you already manage secrets in the cluster.

--- a/internal/clusters/cluster.go
+++ b/internal/clusters/cluster.go
@@ -7,17 +7,26 @@ package clusters
 
 import "strings"
 
-// Cluster backend identifiers. EKS clusters authenticate via the
-// dashboard's Provider (AWS IAM); kubeconfig clusters authenticate via
-// a kubeconfig file (useful for local dev — KIND, minikube — and for
-// non-AWS clusters).
+// Cluster backend identifiers.
 //
-// Note: kubeconfig-backed clusters do not participate in v2's per-user
-// identity pass-through. The kubeconfig is one identity, applied to all
-// users of the dashboard.
+// All three backends do per-user identity pass-through via K8s
+// impersonation: the underlying credentials (AWS IAM token / kubeconfig
+// user / in-cluster SA token) are one identity that asserts "do this
+// as alice" via the Impersonate-User / Impersonate-Group headers,
+// so the apiserver evaluates RBAC under the user, not the dashboard.
+//
+//   eks         AWS IAM token via the Provider; for EKS clusters managed
+//               from a periscope deployed elsewhere.
+//   kubeconfig  Identity loaded from a kubeconfig file at a path on the
+//               pod's filesystem; useful for local dev (kind, minikube)
+//               or non-AWS clusters reached via a static kubeconfig.
+//   in-cluster  In-pod ServiceAccount token (rest.InClusterConfig());
+//               used when periscope manages the cluster it's running
+//               in. The single-cluster install pattern.
 const (
 	BackendEKS        = "eks"
 	BackendKubeconfig = "kubeconfig"
+	BackendInCluster  = "in-cluster"
 )
 
 // Cluster identifies a Kubernetes cluster the dashboard can talk to.

--- a/internal/clusters/registry.go
+++ b/internal/clusters/registry.go
@@ -1,7 +1,6 @@
 package clusters
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -42,7 +41,10 @@ func LoadFromFile(path string) (*Registry, error) {
 	}
 
 	if len(f.Clusters) == 0 {
-		return nil, errors.New("registry contains no clusters")
+		// Empty registry is OK — the dashboard boots, the SPA renders
+		// a friendly "no clusters configured" state. Fatal-on-empty
+		// was the wrong default; it blocked first-install smoke tests.
+		return Empty(), nil
 	}
 
 	byName := make(map[string]Cluster, len(f.Clusters))
@@ -70,9 +72,13 @@ func LoadFromFile(path string) (*Registry, error) {
 			if c.KubeconfigPath == "" {
 				return nil, fmt.Errorf("cluster %q (kubeconfig): empty kubeconfigPath", c.Name)
 			}
+		case BackendInCluster:
+			// No required fields. The credential source is the pod's
+			// in-cluster ServiceAccount, mounted by the kubelet at
+			// /var/run/secrets/kubernetes.io/serviceaccount/.
 		default:
-			return nil, fmt.Errorf("cluster %q: unknown backend %q (must be %q or %q)",
-				c.Name, c.Backend, BackendEKS, BackendKubeconfig)
+			return nil, fmt.Errorf("cluster %q: unknown backend %q (must be %q, %q, or %q)",
+				c.Name, c.Backend, BackendEKS, BackendKubeconfig, BackendInCluster)
 		}
 
 		if _, dup := byName[c.Name]; dup {

--- a/internal/clusters/registry_test.go
+++ b/internal/clusters/registry_test.go
@@ -144,7 +144,6 @@ func TestLoadFromFile_errors(t *testing.T) {
 		name string
 		body string
 	}{
-		{"empty cluster list", `clusters: []`},
 		{"missing name", "clusters:\n  - arn: arn:aws:eks:us-east-1:1:cluster/a\n    region: us-east-1\n"},
 		{"eks: missing arn", "clusters:\n  - name: a\n    region: us-east-1\n"},
 		{"eks: missing region", "clusters:\n  - name: a\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n"},
@@ -245,5 +244,45 @@ clusters:
 	}
 	if dev.Tags != nil && len(dev.Tags) != 0 {
 		t.Errorf("dev.Tags = %v, want nil/empty", dev.Tags)
+	}
+}
+
+func TestLoadFromFile_inClusterBackend(t *testing.T) {
+	p := writeTempFile(t, `
+clusters:
+  - name: in-cluster
+    backend: in-cluster
+`)
+	r, err := LoadFromFile(p)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	c, ok := r.ByName("in-cluster")
+	if !ok {
+		t.Fatal("ByName(in-cluster) not found")
+	}
+	if c.Backend != BackendInCluster {
+		t.Errorf("Backend = %q, want %q", c.Backend, BackendInCluster)
+	}
+	// in-cluster needs no extra fields — kubeconfig path / ARN / region
+	// must all be empty.
+	if c.KubeconfigPath != "" || c.ARN != "" || c.Region != "" {
+		t.Errorf("unexpected non-empty fields on in-cluster: kubeconfigPath=%q arn=%q region=%q",
+			c.KubeconfigPath, c.ARN, c.Region)
+	}
+}
+
+func TestLoadFromFile_emptyRegistryReturnsEmpty(t *testing.T) {
+	// Regression: empty cluster lists used to be a fatal error
+	// (`registry contains no clusters`), which crashed the pod on
+	// first install before clusters were configured. Now it returns
+	// an empty registry and the SPA renders the no-clusters state.
+	p := writeTempFile(t, `clusters: []`)
+	r, err := LoadFromFile(p)
+	if err != nil {
+		t.Fatalf("LoadFromFile: empty list should NOT error: %v", err)
+	}
+	if got := len(r.List()); got != 0 {
+		t.Errorf("List() len = %d, want 0", got)
 	}
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -60,6 +60,8 @@ func buildRestConfig(ctx context.Context, p credentials.Provider, c clusters.Clu
 	switch c.Backend {
 	case clusters.BackendKubeconfig:
 		return buildKubeconfigRestConfig(p, c)
+	case clusters.BackendInCluster:
+		return buildInClusterRestConfig(p, c)
 	case clusters.BackendEKS, "":
 		return buildEKSRestConfig(ctx, p, c)
 	default:
@@ -112,6 +114,25 @@ func buildKubeconfigRestConfig(p credentials.Provider, c clusters.Cluster) (*res
 	).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("load kubeconfig %q: %w", c.KubeconfigPath, err)
+	}
+	applyImpersonation(cfg, p)
+	return cfg, nil
+}
+
+// buildInClusterRestConfig produces a *rest.Config from the in-pod
+// ServiceAccount via rest.InClusterConfig. The CA cert and bearer token
+// are auto-loaded from /var/run/secrets/kubernetes.io/serviceaccount/.
+// Per-user impersonation is then layered on top so the apiserver sees
+// the user (alice@corp), not the SA.
+//
+// The SA itself only needs `impersonate` permission on users + groups;
+// the actual resource RBAC is evaluated against the impersonated user.
+// The Helm chart's cluster-rbac.yaml renders that ClusterRoleBinding
+// when an in-cluster cluster is in the registry.
+func buildInClusterRestConfig(p credentials.Provider, c clusters.Cluster) (*rest.Config, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load in-cluster config for %q: %w", c.Name, err)
 	}
 	applyImpersonation(cfg, p)
 	return cfg, nil

--- a/internal/k8s/summary.go
+++ b/internal/k8s/summary.go
@@ -592,6 +592,8 @@ func providerLabel(backend string) string {
 	switch strings.ToLower(backend) {
 	case clusters.BackendKubeconfig:
 		return "Kubeconfig"
+	case clusters.BackendInCluster:
+		return "In-cluster"
 	default:
 		return "EKS"
 	}


### PR DESCRIPTION
Closes #34 

Adds a third cluster backend, "in-cluster", which uses the in-pod
ServiceAccount token (rest.InClusterConfig) for credentials. Per-
user identity still flows through via K8s impersonation — same
model as eks and kubeconfig, just with a different credential
source.

Surface (no required fields):
```yaml
  clusters:
    - name: in-cluster
      backend: in-cluster
```

The chart's cluster-rbac.yaml auto-detects in-cluster mode and
adds the chart's ServiceAccount as an additional subject on the
impersonator ClusterRoleBinding — no separate kubectl apply step
needed for the most common single-cluster install pattern (kind,
minikube, single-cluster prod).

Also relaxes the empty-cluster-registry startup error to a
no-op: empty clusters: [] now returns an Empty() registry and
the SPA renders the friendly "no clusters configured" state.
The fatal exit was the wrong default — it blocked first-install
smoke tests before clusters were configured.

New tests cover:
  - in-cluster backend parsing (no required fields)
  - empty registry returning Empty (regression on the error path)

Helm chart updates:
  - cluster-rbac.yaml: auto-detect $hasInCluster, render the SA as
    impersonator subject when present
  - values.schema.json: accept "in-cluster" as a valid backend
  - values.yaml: documented all three backends with examples

Docs:
  - cluster-rbac.md: new "Mode: in-cluster" section explaining
    the auto-rendered RBAC + composing with managed clusters
  - deploy.md: new section 4.5 with the single-cluster recipe