### PR TITLE
fix(auth): update SameSite cookie policy and enhance unauthorized response handling

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -252,6 +252,12 @@ func WhoamiHandler(store SessionStore, cfg Config, resolver *authz.Resolver, aud
 
 // --- cookie helpers ---
 
+// SameSite=Lax (not Strict) so the cookie is sent on the `/` request
+// that follows the Auth0 → /api/auth/callback → / redirect chain.
+// Strict suppresses the cookie on cross-site-initiated top-level
+// navigations, which the post-callback redirect counts as. The cookie
+// is HttpOnly and the API only mutates state via XHR, so Lax keeps the
+// CSRF posture intact.
 func setSessionCookie(w http.ResponseWriter, r *http.Request, cfg SessionConfig, value string, exp time.Time) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     cfg.CookieName,
@@ -260,7 +266,7 @@ func setSessionCookie(w http.ResponseWriter, r *http.Request, cfg SessionConfig,
 		Domain:   cfg.CookieDomain,
 		HttpOnly: true,
 		Secure:   isHTTPS(r),
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		Expires:  exp,
 	})
 }
@@ -273,7 +279,7 @@ func clearSessionCookie(w http.ResponseWriter, r *http.Request, cfg SessionConfi
 		Domain:   cfg.CookieDomain,
 		HttpOnly: true,
 		Secure:   isHTTPS(r),
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
 	})

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -71,12 +71,12 @@ func Middleware(client *OIDCClient, store SessionStore, cfg Config) func(http.Ha
 			}
 			c, err := r.Cookie(cfg.Session.CookieName)
 			if err != nil || c.Value == "" {
-				unauthorized(w)
+				unauthorized(w, r)
 				return
 			}
 			s, ok := store.Get(c.Value)
 			if !ok {
-				unauthorized(w)
+				unauthorized(w, r)
 				return
 			}
 			now := time.Now()
@@ -84,14 +84,14 @@ func Middleware(client *OIDCClient, store SessionStore, cfg Config) func(http.Ha
 				_ = store.Delete(s.ID)
 				slog.InfoContext(r.Context(), "auth.session_expired",
 					"subject", s.Subject, "kind", "absolute")
-				unauthorized(w)
+				unauthorized(w, r)
 				return
 			}
 			if cfg.Session.IdleTimeout > 0 && now.Sub(s.LastActivity) > cfg.Session.IdleTimeout {
 				_ = store.Delete(s.ID)
 				slog.InfoContext(r.Context(), "auth.session_expired",
 					"subject", s.Subject, "kind", "idle")
-				unauthorized(w)
+				unauthorized(w, r)
 				return
 			}
 
@@ -104,7 +104,7 @@ func Middleware(client *OIDCClient, store SessionStore, cfg Config) func(http.Ha
 					_ = store.Delete(s.ID)
 					slog.WarnContext(r.Context(), "auth.session_expired",
 						"subject", s.Subject, "kind", "refresh_failed", "err", err)
-					unauthorized(w)
+					unauthorized(w, r)
 					return
 				}
 				s = refreshed
@@ -139,11 +139,39 @@ func DevMiddleware(cfg Config) func(http.Handler) http.Handler {
 	}
 }
 
-func unauthorized(w http.ResponseWriter) {
+// unauthorized writes the standard 401 for API/XHR clients but
+// redirects browser navigations to the login endpoint so users
+// get the OIDC flow instead of a plain-text dead-end. The SPA
+// fetches with `Accept: application/json`, so checking for
+// text/html in Accept reliably distinguishes the two.
+func unauthorized(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet && acceptsHTML(r) {
+		http.Redirect(w, r, "/api/auth/login", http.StatusFound)
+		return
+	}
 	w.Header().Set("WWW-Authenticate", `Cookie realm="periscope"`)
 	http.Error(w, "unauthenticated", http.StatusUnauthorized)
 }
 
+// acceptsHTML returns true when the client signaled a preference
+// for an HTML response — i.e. a browser top-level navigation.
+// Tolerant of the q-value form (e.g. `text/html;q=0.9`).
+func acceptsHTML(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return false
+	}
+	for _, part := range strings.Split(accept, ",") {
+		media := strings.TrimSpace(part)
+		if i := strings.Index(media, ";"); i >= 0 {
+			media = media[:i]
+		}
+		if strings.EqualFold(strings.TrimSpace(media), "text/html") {
+			return true
+		}
+	}
+	return false
+}
 // SessionValid reports whether the request's session cookie still
 // resolves to a non-expired, non-idle session. Side-effect-free: does
 // not update LastActivity, refresh tokens, or hit the OIDC provider.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -120,3 +120,76 @@ func TestSessionValid_IdleDisabled(t *testing.T) {
 		t.Fatal("idle disabled should ignore LastActivity")
 	}
 }
+
+func TestUnauthorized_BrowserNavigationRedirectsToLogin(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	w := httptest.NewRecorder()
+	unauthorized(w, r)
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/api/auth/login" {
+		t.Fatalf("Location = %q, want /api/auth/login", loc)
+	}
+}
+
+func TestUnauthorized_XHRReturnsPlain401(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/me", nil)
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	unauthorized(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Fatalf("Location = %q, want empty (no redirect for XHR)", loc)
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got == "" {
+		t.Fatal("WWW-Authenticate header missing on 401")
+	}
+}
+
+func TestUnauthorized_NonGETReturns401(t *testing.T) {
+	// POST with text/html accept (curious case) shouldn't redirect —
+	// redirecting a state-changing request is wrong.
+	r := httptest.NewRequest("POST", "/api/clusters/x/pods", nil)
+	r.Header.Set("Accept", "text/html")
+	w := httptest.NewRecorder()
+	unauthorized(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthorized_NoAcceptHeaderReturns401(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/foo", nil)
+	w := httptest.NewRecorder()
+	unauthorized(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestAcceptsHTML(t *testing.T) {
+	cases := []struct {
+		accept string
+		want   bool
+	}{
+		{"text/html,application/xhtml+xml,application/xml;q=0.9", true},
+		{"text/html;q=0.9", true},
+		{"application/json", false},
+		{"*/*", false},
+		{"", false},
+		{"  text/html  ", true},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest("GET", "/", nil)
+		if tc.accept != "" {
+			r.Header.Set("Accept", tc.accept)
+		}
+		if got := acceptsHTML(r); got != tc.want {
+			t.Errorf("acceptsHTML(%q) = %v, want %v", tc.accept, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Two papercuts in the post-OIDC sign-in UX:

1. Session cookie was SameSite=Strict, which suppresses the cookie on
   the `/` request that follows the Auth0 → /api/auth/callback → /
   redirect chain (browsers treat the whole chain as cross-site). User
   landed on `/` immediately after sign-in and saw "unauthenticated"
   until they refreshed. Cookie is HttpOnly and the API only mutates
   state via XHR, so dropping to Lax keeps the CSRF posture intact.

2. Browser navigations to `/` (or any deep link) without a session
   returned plain text `401 unauthenticated` instead of starting the
   OIDC flow. The middleware's `unauthorized()` helper now branches:
   GET + Accept: text/html → 302 /api/auth/login; everything else
   keeps the existing 401 (the SPA fetches with Accept: application/
   json so XHR behavior is unchanged).

Adds 5 unit tests covering the redirect, the XHR path, the non-GET
path, missing-Accept, and the Accept-header parser.

Closes #37 