### PR TITLE
docs: Add v1.0 API reference, audit RFC, and environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to Periscope are tracked here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+the public HTTP API, the OIDC / cluster-registry config shape, and Helm
+chart values are the surfaces covered by semver.
+
+For per-release container images and signed Helm charts, see the
+[GitHub Releases](https://github.com/gnana997/periscope/releases) page;
+its auto-generated notes complement this file with the full PR list per
+tag.
+
+## [Unreleased]
+
+## [1.0.0]
+
+Initial stable release.
+
+### Added
+
+- **Authentication & access**
+  - OIDC user authentication (Auth0 and Okta tested) with PKCE,
+    state validation, and HttpOnly / Secure / SameSite session
+    cookies.
+  - Per-cluster RBAC enforced via `Impersonate-User` /
+    `Impersonate-Group` headers — every K8s call carries the human
+    user's identity.
+  - Three authorization modes: `shared`, `tier`, `raw` — operator
+    chooses how IdP groups map to in-cluster identity.
+  - Pre-flight RBAC checks (SAR / SSRR) so disabled actions in the
+    UI explain themselves instead of failing on click.
+  - Pod Identity / IRSA factory for AWS access — no static AWS
+    credentials on the pod.
+
+- **Multi-cluster**
+  - Fleet view aggregator at `/` over every registered cluster.
+  - Cluster rail (left bar) for context switching.
+  - Per-cluster scoping for every resource view.
+
+- **Browsing & inspection**
+  - List, detail, describe, events, and YAML for the common
+    workload, networking, storage, RBAC, and config kinds.
+  - Full Custom Resource catalog driven by `/openapi/v3`.
+  - Live pod logs with follow + filtering.
+  - In-browser pod shell (`exec`) with reconnect on transient
+    disconnects, audited open / close events.
+  - `Cmd+K` palette for cluster-wide name search.
+
+- **Real-time updates (watch streams)**
+  - 21+ resource kinds streamed over SSE (workloads, networking,
+    storage, cluster-scoped) with a polling fallback.
+  - `Last-Event-ID` resume on transient disconnects.
+  - Per-user concurrency cap (`PERISCOPE_WATCH_PER_USER_LIMIT`,
+    default 60) to protect apiserver watch quota.
+  - Operator opt-out via Helm: subset, group aliases (`workloads`,
+    `networking`, `storage`, `cluster`, `core`), or full disable.
+
+- **Editing**
+  - Inline Monaco YAML editor for built-in kinds and CRDs.
+  - Schema-aware autocomplete and validation against the cluster's
+    `/openapi/v3`.
+  - Server-side apply with minimal diffs and field-ownership glyphs.
+  - Per-field conflict resolution and live drift detection.
+  - Unsaved-changes guards on refresh / nav / row-click.
+
+- **Helm**
+  - Read-only release browser per cluster — values, manifest,
+    history, and `dyff`-based diff between revisions.
+  - Auto-probes Secret vs ConfigMap storage drivers per cluster.
+  - Bounded TTL cache for release listings.
+
+- **Audit & observability**
+  - Persistent SQLite audit sink with retention / size caps and
+    a fail-open boot path (warn, continue with stdout-only).
+  - First-class in-app audit view with filters by actor, verb,
+    outcome, time range, namespace, request id; density timeline.
+  - Tier-mode audit-admin groups see every actor's rows; everyone
+    else sees their own.
+  - Structured JSON events also stream to stdout for shipping to
+    CloudWatch / Loki / OpenSearch / Datadog.
+
+- **Packaging & supply chain**
+  - Multi-arch container image (`linux/amd64`, `linux/arm64`)
+    published to `ghcr.io/gnana997/periscope`.
+  - Helm chart published to `ghcr.io/gnana997/charts/periscope`
+    as an OCI artifact, discoverable on Artifact Hub.
+  - Cosign keyless signatures (Sigstore) for both the image and
+    the chart; SPDX SBOM attached to the image.
+  - Distroless static base, non-root UID 65532, read-only root
+    filesystem, all capabilities dropped, `RuntimeDefault`
+    seccomp profile in the Helm chart.
+
+[Unreleased]: https://github.com/gnana997/periscope/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/gnana997/periscope/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ tag.
   schema, retention algorithm, `/api/audit` read-side RBAC, semver
   coverage, and the v1.0 security model (operator-trust now;
   hash-chain signing in v2).
+- Added [`docs/api.md`](docs/api.md) — HTTP API reference with
+  three stability tiers (Tier 1 stable, Tier 2 SPA-coupled,
+  Tier 3 live channels), authentication / cookie / session
+  contract, error-code enum, and the `/api/v1/...` versioning
+  policy for v2 onward.
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,24 +13,7 @@ tag.
 
 ## [Unreleased]
 
-### Documentation
-
-- Added [RFC 0003 — Audit log: schema and retention semantics](docs/rfcs/0003-audit-log.md),
-  formalizing the verb taxonomy, wire-stable event shape, SQLite
-  schema, retention algorithm, `/api/audit` read-side RBAC, semver
-  coverage, and the v1.0 security model (operator-trust now;
-  hash-chain signing in v2).
-- Added [`docs/api.md`](docs/api.md) — HTTP API reference with
-  three stability tiers (Tier 1 stable, Tier 2 SPA-coupled,
-  Tier 3 live channels), authentication / cookie / session
-  contract, error-code enum, and the `/api/v1/...` versioning
-  policy for v2 onward.
-- Added [`docs/setup/environment-variables.md`](docs/setup/environment-variables.md) —
-  centralized reference for every `PERISCOPE_*` env var (and
-  `PORT`) the binary reads, with defaults, Helm-value mapping,
-  and the semver coverage rules for the configuration surface.
-- Fixed stale `PERISCOPE_WATCH_PER_USER_LIMIT` default in
-  `docs/architecture/watch-streams.md` (was 30, code is 60).
+_Nothing yet._
 
 ## [1.0.0]
 
@@ -56,6 +39,10 @@ Initial stable release.
   - Fleet view aggregator at `/` over every registered cluster.
   - Cluster rail (left bar) for context switching.
   - Per-cluster scoping for every resource view.
+  - In-cluster cluster backend for self-managed deployments — the
+    chart auto-binds the periscope ServiceAccount to the
+    impersonator role when a cluster is registered with
+    `backend: in-cluster`.
 
 - **Browsing & inspection**
   - List, detail, describe, events, and YAML for the common
@@ -110,6 +97,16 @@ Initial stable release.
     filesystem, all capabilities dropped, `RuntimeDefault`
     seccomp profile in the Helm chart.
 
+### Fixed
+
+- Auth: `periscope_session` cookie is now `SameSite=Lax` (was
+  `Strict`). Strict suppressed the cookie on the post-OIDC-callback
+  redirect to `/`, so first-time sign-in landed on the
+  unauthenticated page until the user manually refreshed (#37).
+- Auth: browser navigations to `/` (or any deep link) without a
+  session now `302` to `/api/auth/login` instead of returning plain
+  `401 unauthenticated` — XHR callers still get the 401 (#37).
+
 ### Security
 
 - OIDC session and PKCE/state generation now propagate `crypto/rand`
@@ -117,6 +114,25 @@ Initial stable release.
   callbacks return 500 on the (vanishingly rare) RNG failure path
   rather than crashing the process and dropping every active
   session on the same replica.
+
+### Documentation
+
+- Added [RFC 0003 — Audit log: schema and retention semantics](docs/rfcs/0003-audit-log.md),
+  formalizing the verb taxonomy, wire-stable event shape, SQLite
+  schema, retention algorithm, `/api/audit` read-side RBAC, semver
+  coverage, and the v1.0 security model (operator-trust now;
+  hash-chain signing in v2).
+- Added [`docs/api.md`](docs/api.md) — HTTP API reference with
+  three stability tiers (Tier 1 stable, Tier 2 SPA-coupled,
+  Tier 3 live channels), authentication / cookie / session
+  contract, error-code enum, CSRF posture, and the
+  `/api/v2/...` versioning policy for future majors.
+- Added [`docs/setup/environment-variables.md`](docs/setup/environment-variables.md) —
+  centralized reference for every `PERISCOPE_*` env var (and
+  `PORT`) the binary reads, with defaults, Helm-value mapping,
+  and the semver coverage rules for the configuration surface.
+- Fixed stale `PERISCOPE_WATCH_PER_USER_LIMIT` default in
+  `docs/architecture/watch-streams.md` (was 30, code is 60).
 
 [Unreleased]: https://github.com/gnana997/periscope/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/gnana997/periscope/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ tag.
   Tier 3 live channels), authentication / cookie / session
   contract, error-code enum, and the `/api/v1/...` versioning
   policy for v2 onward.
+- Added [`docs/setup/environment-variables.md`](docs/setup/environment-variables.md) —
+  centralized reference for every `PERISCOPE_*` env var (and
+  `PORT`) the binary reads, with defaults, Helm-value mapping,
+  and the semver coverage rules for the configuration surface.
+- Fixed stale `PERISCOPE_WATCH_PER_USER_LIMIT` default in
+  `docs/architecture/watch-streams.md` (was 30, code is 60).
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ tag.
 
 ## [Unreleased]
 
+### Documentation
+
+- Added [RFC 0003 — Audit log: schema and retention semantics](docs/rfcs/0003-audit-log.md),
+  formalizing the verb taxonomy, wire-stable event shape, SQLite
+  schema, retention algorithm, `/api/audit` read-side RBAC, semver
+  coverage, and the v1.0 security model (operator-trust now;
+  hash-chain signing in v2).
+
 ## [1.0.0]
 
 Initial stable release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,5 +91,13 @@ Initial stable release.
     filesystem, all capabilities dropped, `RuntimeDefault`
     seccomp profile in the Helm chart.
 
+### Security
+
+- OIDC session and PKCE/state generation now propagate `crypto/rand`
+  failures as errors instead of panicking the pod (#35). Login
+  callbacks return 500 on the (vanishingly rare) RNG failure path
+  rather than crashing the process and dropping every active
+  session on the same replica.
+
 [Unreleased]: https://github.com/gnana997/periscope/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/gnana997/periscope/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ Examples:
 feat(watch-streams): add Tier-A workload-controller SSE feeds
 fix(k8s): handle compact-list YAML in stripForEdit
 refactor(web): unify YAML editor on EditorSource
-docs(setup): refresh deploy.md §10.5 for the expanded watch-streams kinds
+docs(setup): refresh deploy.md 10.5 for the expanded watch-streams kinds
 chore(helm): relax watchStreams.kinds schema regex
 ci: add helm-lint job
 ```

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ CI: every push and PR runs `golangci-lint`, `go test`, `npm run lint`, `npm test
 
 ## Roadmap
 
-Planning is tracked in [GitHub Issues](https://github.com/gnana997/periscope/issues). Notable post-v1.0 items: HA-friendly audit backend (Postgres), expanded write paths in the Helm release browser (rollback / upgrade), and richer per-cluster RBAC introspection.
+Planning is tracked in [GitHub Issues](https://github.com/gnana997/periscope/issues). Notable post-v1.0 items: expanded write paths in the Helm release browser (rollback / upgrade) and richer per-cluster RBAC introspection.
 
 ## Community & support
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8.svg)](https://go.dev/)
 [![Node](https://img.shields.io/badge/Node-22-339933.svg)](https://nodejs.org/)
 
-> **Status — early development.** Core flows (multi-cluster auth, resource browsing, pod exec, logs, YAML editing, audit log, real-time watch streams) work, but APIs, configuration, and UI are still changing. Expect breaking changes until a tagged release.
+> **Status — v1.0 stable.** Public HTTP API, configuration shape, and Helm values are covered by semver: breaking changes will land in a future major (v2). Bugfixes and additive features land on minor / patch tags off `main`. See [`CHANGELOG.md`](CHANGELOG.md) for what shipped per release.
 
 ## What is Periscope
 
@@ -20,7 +20,7 @@ Periscope is a self-hosted, multi-cluster Kubernetes console focused on EKS envi
 - **No long-lived AWS keys.** Cluster access is obtained on demand via Pod Identity or IRSA. Nothing static lives on the console pod.
 - **Real human in every audit row.** Every K8s call carries the user's OIDC identity via impersonation, so the audit log shows `alice@corp` — never `periscope-bot`.
 - **OIDC-gated user identity.** Auth0 and Okta tested. Authorization by IdP group, with configurable tiers.
-- **Searchable audit log.** SQLite or Postgres. First-class in-app view, time-filterable, retention-bounded — compliance reviews stop being a log-grep exercise.
+- **Searchable audit log.** SQLite-backed, with a first-class in-app view, time-filterable and retention-bounded — compliance reviews stop being a log-grep exercise.
 - **Live, not polled.** 21+ resource list pages stream over SSE for real-time updates, with a tested polling fallback for restrictive proxies.
 - **Schema-aware YAML editor.** Built-in kinds and Custom Resources. Server-side apply, field-ownership glyphs, conflict resolution, live drift detection while editing.
 
@@ -105,7 +105,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 
 **Audit & observability**
 - Every privileged action signed by the human user — apply, delete, exec, secret reveal, log open, cronjob trigger
-- Persistent audit log: SQLite (single-replica) or Postgres (HA), with retention and size caps
+- Persistent audit log: SQLite (single-replica), with retention and size caps
 - First-class in-app audit view with filters by actor, verb, outcome, time range, namespace, request id
 - Density timeline strip surfaces denials and failures at a glance
 - Tier-mode audit-admin groups can see every actor's rows; everyone else sees their own
@@ -184,7 +184,7 @@ CI: every push and PR runs `golangci-lint`, `go test`, `npm run lint`, `npm test
 
 ## Roadmap
 
-Until the project tags its first release, planning is informal — see [GitHub Issues](https://github.com/gnana997/periscope/issues) for what's open. A structured roadmap will be published alongside the v0.1 release.
+Planning is tracked in [GitHub Issues](https://github.com/gnana997/periscope/issues). Notable post-v1.0 items: HA-friendly audit backend (Postgres), expanded write paths in the Helm release browser (rollback / upgrade), and richer per-cluster RBAC introspection.
 
 ## Community & support
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 
 **Setup**
 - [Configuration & deployment](docs/setup/deploy.md)
+- [Environment variables reference](docs/setup/environment-variables.md)
 - [OIDC setup — Auth0](docs/setup/auth0.md)
 - [OIDC setup — Okta](docs/setup/okta.md)
 - [In-cluster RBAC the backend needs](docs/setup/cluster-rbac.md)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 **Architecture**
 - [Watch streams — push model, fallback, RBAC](docs/architecture/watch-streams.md)
 
+**Reference**
+- [HTTP API reference (stability tiers, auth, conventions)](docs/api.md)
+
 **RFCs**
 - [RFC 0001 — Pod exec support](docs/rfcs/0001-pod-exec.md)
 - [RFC 0002 — Authentication (OIDC + per-user K8s authz)](docs/rfcs/0002-auth.md)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 **RFCs**
 - [RFC 0001 — Pod exec support](docs/rfcs/0001-pod-exec.md)
 - [RFC 0002 — Authentication (OIDC + per-user K8s authz)](docs/rfcs/0002-auth.md)
+- [RFC 0003 — Audit log: schema and retention semantics](docs/rfcs/0003-audit-log.md)
 
 ## Configuration
 

--- a/deploy/helm/periscope/Chart.yaml
+++ b/deploy/helm/periscope/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   AWS credentials in the pod, no kubeconfigs with embedded creds on the
   laptop.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 1.0.0
+appVersion: "1.0.0"
 keywords:
   - kubernetes
   - eks
@@ -40,11 +40,13 @@ annotations:
   # release notes for Artifact Hub's "What changed" panel).
   artifacthub.io/changes: |
     - kind: added
+      description: initial v1.0 stable release
+    - kind: added
       description: real-time SSE updates for 21+ resource kinds
     - kind: added
-      description: searchable audit log with SQLite/Postgres backends
+      description: searchable SQLite-backed audit log
     - kind: added
-      description: Helm release browser
+      description: read-only Helm release browser with revision diff
   # Cosign signing — Artifact Hub will display a "Signed" badge when
   # the chart is verifiable via cosign. The signKey block teaches it
   # how to verify; for keyless (Sigstore) signatures the URL points

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,12 +10,12 @@ near-identical entries.
 If you're looking for:
 
 - **Operator basics** — verifying a deployment, writing health checks,
-  granting audit-read access — the Tier 1 reference (§3) and the
-  authentication section (§2) are what you want.
+  granting audit-read access — the Tier 1 reference (3) and the
+  authentication section (2) are what you want.
 - **CLI / MCP integrators** — RFC 0001 (pod exec) and RFC 0002 (auth)
   describe the long-term contract those tools land against. Use this
   page to understand which HTTP surface is locked vs free to evolve.
-- **SPA contributors** — the patterns in §4 are the contract; the
+- **SPA contributors** — the patterns in 4 are the contract; the
   generated TypeScript types in `web/src/api/` are the canonical
   field-by-field shape for SPA-internal endpoints.
 
@@ -30,7 +30,7 @@ guarantees:
 | Tier | Coverage | Examples |
 |---|---|---|
 | **1 — Stable** | Path, method, request shape, response field names, and documented error classes are all covered by semver. Breaking changes require a major bump (v2). | `/healthz`, `/api/auth/*`, `/api/whoami`, `/api/features`, `/api/clusters`, `/api/fleet`, `/api/audit`, `/api/clusters/{c}/can-i` |
-| **2 — SPA-coupled** | Path and method are stable. Response field **shapes can evolve in minor versions** (additive fields, new optional flags). The patterns in §4 are stable; specific field-level shapes track what the SPA needs. | The 130+ resource list / detail / yaml / events / logs / dashboard / search / CRD / customresources / helm / apply / delete / trigger / meta / secrets-data / openapi-proxy routes |
+| **2 — SPA-coupled** | Path and method are stable. Response field **shapes can evolve in minor versions** (additive fields, new optional flags). The patterns in 4 are stable; specific field-level shapes track what the SPA needs. | The 130+ resource list / detail / yaml / events / logs / dashboard / search / CRD / customresources / helm / apply / delete / trigger / meta / secrets-data / openapi-proxy routes |
 | **3 — Live channels** | Stream wire formats are stable (frozen and tested against the SPA). Path, transport (SSE / WebSocket), event names, and frame shape are all covered. Documented separately. | Watch streams (SSE), pod exec (WebSocket), pod and workload logs (SSE) |
 
 **What is _not_ covered by semver in any tier:**
@@ -109,7 +109,7 @@ Endpoints:
 | Name | Lifetime | Path | HttpOnly | Secure | SameSite | Purpose |
 |---|---|---|---|---|---|---|
 | `periscope_login` | 10 min | `/` | ✓ | (when HTTPS) | Lax | One-shot OIDC `state` + PKCE verifier. Cleared on callback. |
-| `periscope_session` | configured (default 12 h) | `/` | ✓ | (when HTTPS) | **Strict** | Session id; lookup key into the in-memory session store. |
+| `periscope_session` | configured (default 12 h) | `/` | ✓ | (when HTTPS) | Lax | Session id; lookup key into the in-memory session store. |
 
 `Secure` is set automatically when the request reached the backend
 over TLS, including via `X-Forwarded-Proto: https` from a trusted
@@ -126,8 +126,7 @@ v1.0 keeps the session record in process memory. Restarting the
 pod **invalidates all sessions** — operators see a brief flash of
 the login screen on first request after a deploy. This is also why
 v1.0 supports a single replica when audit persistence is on (see
-RFC 0003 §3): session state has no shared store. A future
-`SessionStore` backed by Redis / PostgreSQL is post-v1.
+RFC 0003 3): session state has no shared store.
 
 ### Authorization on every API call
 
@@ -143,7 +142,7 @@ The `Provider` carries the user's `Impersonate-User` and
 `Impersonate-Group` headers; the apiserver evaluates RBAC against
 the human, not the pod. This is what lets a Kubernetes denial show
 up as `outcome: denied` in the audit log with the user's real
-subject (RFC 0003 §5).
+subject (RFC 0003 5).
 
 ### Bearer tokens / API keys
 
@@ -203,7 +202,7 @@ tooltips.
 | `authzMode` | `shared`, `tier`, or `raw`. See `docs/setup/cluster-rbac.md`. |
 | `tier` | Resolved tier name (tier mode only); empty otherwise. |
 | `auditEnabled` | Whether `/api/audit` is registered. |
-| `auditScope` | `self` or `all`. See RFC 0003 §11. Only present when `auditEnabled`. |
+| `auditScope` | `self` or `all`. See RFC 0003 11. Only present when `auditEnabled`. |
 | `expiresAt` | Unix seconds (UTC) of the session's absolute expiry. |
 
 `401 unauthenticated` if no valid session. There is also a
@@ -324,14 +323,14 @@ unmapped groups). Otherwise per-cluster errors are surfaced inline:
 Status enum (stable, additions are additive):
 `healthy` · `degraded` · `unreachable` · `unknown` · `denied`.
 
-Per-cluster error codes — the same enum used elsewhere (§6).
+Per-cluster error codes — the same enum used elsewhere (6).
 
 ### `GET /api/audit`
 
 Persisted audit query. **Registered only when SQLite is enabled and
 opened successfully** (otherwise 404). Full contract — request shape,
 response shape, retention semantics, RBAC, semver coverage — lives
-in [RFC 0003 §11](rfcs/0003-audit-log.md). One-line summary here:
+in [RFC 0003 11](rfcs/0003-audit-log.md). One-line summary here:
 
 ```
 GET /api/audit?
@@ -342,7 +341,7 @@ GET /api/audit?
 ```
 
 Returns `{ items, total, limit, offset }` with a stable `Row` shape
-documented in RFC 0003 §6. `X-Audit-Scope: self` or `all` header
+documented in RFC 0003 6. `X-Audit-Scope: self` or `all` header
 indicates whether the server hard-overrode the actor filter to the
 caller's own subject.
 
@@ -449,7 +448,7 @@ GET /api/clusters/{cluster}/pods/{ns}/{name}/logs?container=&follow=true&tailLin
 GET /api/clusters/{cluster}/{workload}/{ns}/{name}/logs?...
 ```
 
-Server-Sent Events stream. See §5 for the live-channel contract.
+Server-Sent Events stream. See 5 for the live-channel contract.
 `workload` ∈ `deployments`, `statefulsets`, `daemonsets`, `jobs`.
 
 ### Pattern: apply (Server-Side Apply)
@@ -582,7 +581,7 @@ when the client closes the connection; respects context-cancel.
 Workload-level routes auto-fan-out across the workload's child pods
 and tag each line with the source pod.
 
-A future `log_open` audit verb (RFC 0003 §4) will be emitted here;
+A future `log_open` audit verb (RFC 0003 4) will be emitted here;
 not yet wired.
 
 ### Pod exec (WebSocket)
@@ -604,7 +603,7 @@ context:
 - Two audit emissions per session: `exec_open` immediately after
   the apiserver accepts, `exec_close` once the stream returns. The
   `Reason` field carries the close disposition (`completed` /
-  `idle_timeout` / `abort` / `server_error`). See RFC 0003 §4.
+  `idle_timeout` / `abort` / `server_error`). See RFC 0003 4.
 - Concurrent sessions per user are bounded; the cap message lists
   active sessions with disconnect controls.
 - Stdin payloads never appear in logs or audit fields — only the
@@ -691,16 +690,31 @@ versions; existing codes are stable.
 
 ### CSRF
 
-Periscope relies on cookie `SameSite=Strict` for the session cookie
-to prevent cross-site state-changing requests. There is no
-double-submit token in v1.0. If you front Periscope with a proxy
-that strips `SameSite` (rare), evaluate your CSRF posture
-separately.
+Periscope's CSRF posture rests on three layers, not on a synchronizer
+token (none is issued in v1.0):
 
-`PATCH` (apply), `DELETE`, and `POST /trigger` are state-changing.
-The exec WebSocket handshake is also implicitly state-changing;
-its origin check (`PERISCOPE_DEV_ALLOW_ORIGINS` in dev mode;
-same-origin in prod) is the equivalent guard.
+1. **`periscope_session` is `SameSite=Lax`.** Cross-site `POST`,
+   `PATCH`, `DELETE`, and the WebSocket upgrade do *not* receive the
+   cookie at all, so a malicious page cannot drive a state-changing
+   request as the user. Lax (rather than Strict) is required so the
+   cookie is sent on the post-OIDC-callback redirect to `/`; Strict
+   would silently break sign-in. The cookie is also `HttpOnly`, so
+   it is unreadable from page JS even on same-origin contexts.
+2. **State-changing endpoints accept JSON or YAML only.** `apply` is
+   `application/yaml`; `trigger` and other POSTs are `application/json`.
+   The two body types a `<form>` can submit cross-site without a
+   preflight (`application/x-www-form-urlencoded` and
+   `multipart/form-data`) are not parsed by any state-changing handler.
+   A cross-site attacker would need to issue a true XHR, which is
+   blocked by CORS — Periscope sets no permissive
+   `Access-Control-Allow-Origin` headers.
+3. **The exec WebSocket checks `Origin`.** Same-origin in production;
+   `PERISCOPE_DEV_ALLOW_ORIGINS` widens the allowlist for local dev
+   (Vite proxy on `:5173` → backend on `:8088`).
+
+If you front Periscope with a proxy that strips `SameSite` or rewrites
+request bodies into form encoding, evaluate your CSRF posture
+separately.
 
 ### Pagination
 
@@ -732,11 +746,10 @@ These exist but are **not part of the API contract**:
 | When | What |
 |---|---|
 | v1.x | Helm write paths (rollback / upgrade) once the compound SAR layer lands. Additive: new methods on existing helm paths. |
-| v1.x | `log_open` audit emission for the SSE log streams. Additive: new audit verb (RFC 0003 §4 reserves it). |
-| v1.x | Postgres-backed session store and audit reader. No HTTP API change — same `/api/audit` shape, same cookies. |
+| v1.x | `log_open` audit emission for the SSE log streams. Additive: new audit verb (RFC 0003 4 reserves it). |
 | v1.x | `periscope-rbac` CLI (RFC 0002). Will use the existing `/api/clusters/*` and `/api/auth/whoami` surfaces. |
-| v2 | Anything that breaks the contracts in §3 or §4 (path moves, removed fields, renamed enums). Expect `/api/v2/...` alongside `/api/...` through one major's deprecation window. |
-| v3 | RFC 0001 §3 — MCP tool exposure. Will reuse the per-cluster typed function layer; HTTP API stays as the human-facing surface. |
+| v2 | Anything that breaks the contracts in 3 or 4 (path moves, removed fields, renamed enums). Expect `/api/v2/...` alongside `/api/...` through one major's deprecation window. |
+| v3 | RFC 0001 3 — MCP tool exposure. Will reuse the per-cluster typed function layer; HTTP API stays as the human-facing surface. |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,758 @@
+# API reference
+
+Periscope's HTTP API exists primarily to feed the embedded SPA. This
+page documents what's covered by the v1.0 semver promise and what
+isn't. It is **not** an exhaustive per-endpoint catalogue of every
+list / detail / yaml / events route — those follow a small set of
+patterns that this page documents once, rather than enumerating ~150
+near-identical entries.
+
+If you're looking for:
+
+- **Operator basics** — verifying a deployment, writing health checks,
+  granting audit-read access — the Tier 1 reference (§3) and the
+  authentication section (§2) are what you want.
+- **CLI / MCP integrators** — RFC 0001 (pod exec) and RFC 0002 (auth)
+  describe the long-term contract those tools land against. Use this
+  page to understand which HTTP surface is locked vs free to evolve.
+- **SPA contributors** — the patterns in §4 are the contract; the
+  generated TypeScript types in `web/src/api/` are the canonical
+  field-by-field shape for SPA-internal endpoints.
+
+---
+
+## 1. Stability tiers
+
+The v1.0 release promises semver on the HTTP API, but not every route
+is the same kind of contract. Three tiers, each with different
+guarantees:
+
+| Tier | Coverage | Examples |
+|---|---|---|
+| **1 — Stable** | Path, method, request shape, response field names, and documented error classes are all covered by semver. Breaking changes require a major bump (v2). | `/healthz`, `/api/auth/*`, `/api/whoami`, `/api/features`, `/api/clusters`, `/api/fleet`, `/api/audit`, `/api/clusters/{c}/can-i` |
+| **2 — SPA-coupled** | Path and method are stable. Response field **shapes can evolve in minor versions** (additive fields, new optional flags). The patterns in §4 are stable; specific field-level shapes track what the SPA needs. | The 130+ resource list / detail / yaml / events / logs / dashboard / search / CRD / customresources / helm / apply / delete / trigger / meta / secrets-data / openapi-proxy routes |
+| **3 — Live channels** | Stream wire formats are stable (frozen and tested against the SPA). Path, transport (SSE / WebSocket), event names, and frame shape are all covered. Documented separately. | Watch streams (SSE), pod exec (WebSocket), pod and workload logs (SSE) |
+
+**What is _not_ covered by semver in any tier:**
+
+- `slog` field ordering on stdout (Go's `slog` does not promise this).
+- Internal cache TTLs, fan-out concurrency, soft timeouts, retry
+  backoffs.
+- The `/debug/streams` page and any other path under `/debug/*`.
+- Specific error wording in the human-readable `reason` / `message`
+  fields. The error **classification** (HTTP status, code enum) is
+  stable; the prose isn't, since most of it is `err.Error()` from
+  `client-go`, which is upstream-defined.
+- Anything not under `/api/*` or `/healthz`.
+
+### URL versioning
+
+Periscope does **not** prefix paths with `/v1/`. v1.0 ships routes at
+`/api/...` directly. A future v2 with breaking changes will introduce
+`/api/v2/...` alongside the existing `/api/...` so both can coexist
+through a deprecation window. The unversioned form will keep working
+through one major; v3 may finally drop it.
+
+If you script against Periscope today, treat `/api/...` as "v1" and
+plan for an additive migration when v2 ships, not a swap.
+
+---
+
+## 2. Authentication and sessions
+
+### Modes
+
+Periscope runs in one of two modes, set at startup via the auth
+config file (`PERISCOPE_AUTH_FILE`):
+
+- **`oidc`** — production. Authorization Code + PKCE, BFF pattern.
+  The Go backend is the OAuth client; the SPA never sees a token.
+  Tested against Auth0 and Okta; should work with any compliant
+  IdP.
+- **`dev`** — local development. No login screen; every request
+  runs as a configured `dev.actor` identity. **Never enable in
+  production**; it will be obvious from `/api/auth/config` if you do.
+
+`GET /api/auth/config` is unauthenticated and returns just enough for
+the SPA to render the login screen:
+
+```json
+{ "authMode": "oidc", "providerName": "Auth0" }
+```
+
+### OIDC login flow
+
+```
+SPA  →  GET /api/auth/login
+     ←  302 → IdP /authorize (state + PKCE in short-lived periscope_login cookie)
+
+User authenticates at IdP
+
+IdP  →  GET /api/auth/callback?code=…&state=…
+     ←  302 → /  (sets long-lived periscope_session cookie)
+```
+
+Endpoints:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/auth/config` | Pre-auth config (mode, provider name). |
+| GET | `/api/auth/login` | Begin OIDC. Sets `periscope_login`, redirects to IdP. |
+| GET | `/api/auth/callback` | OIDC callback. Validates state + PKCE, exchanges code, sets `periscope_session`, redirects to `/`. |
+| GET | `/api/auth/whoami` | Session introspection (subject, email, groups, mode, tier, audit scope, expiry). |
+| GET | `/api/auth/logout` | Clear local session, redirect to IdP end-session. |
+| GET | `/api/auth/logout/everywhere` | Same as above plus revoke all sessions for the same subject. |
+| GET | `/api/auth/loggedout` | Post-IdP-logout landing page used by the SPA. |
+
+### Cookies
+
+| Name | Lifetime | Path | HttpOnly | Secure | SameSite | Purpose |
+|---|---|---|---|---|---|---|
+| `periscope_login` | 10 min | `/` | ✓ | (when HTTPS) | Lax | One-shot OIDC `state` + PKCE verifier. Cleared on callback. |
+| `periscope_session` | configured (default 12 h) | `/` | ✓ | (when HTTPS) | **Strict** | Session id; lookup key into the in-memory session store. |
+
+`Secure` is set automatically when the request reached the backend
+over TLS, including via `X-Forwarded-Proto: https` from a trusted
+reverse proxy. The cookie name is configurable; the default
+`periscope_session` is documented here for grep/debugging.
+
+The session value is a random opaque id, not a token. The store
+holds a per-sub record with subject, email, groups, refresh token,
+and absolute expiry; nothing sensitive lives in the cookie itself.
+
+### Sessions are server-side and in-memory
+
+v1.0 keeps the session record in process memory. Restarting the
+pod **invalidates all sessions** — operators see a brief flash of
+the login screen on first request after a deploy. This is also why
+v1.0 supports a single replica when audit persistence is on (see
+RFC 0003 §3): session state has no shared store. A future
+`SessionStore` backed by Redis / PostgreSQL is post-v1.
+
+### Authorization on every API call
+
+Every `/api/*` route except the seven `/api/auth/*` endpoints, the
+SPA proxy, and `/healthz` runs through the auth middleware. An
+unauthenticated request to a JSON endpoint gets `401 unauthenticated`
+as plain text; an HTML request gets a `302` to `/api/auth/login`
+(the SPA route guard relies on this).
+
+Per-cluster Kubernetes authorization happens **inside** each handler
+via the impersonating clientset built by `internal/credentials`.
+The `Provider` carries the user's `Impersonate-User` and
+`Impersonate-Group` headers; the apiserver evaluates RBAC against
+the human, not the pod. This is what lets a Kubernetes denial show
+up as `outcome: denied` in the audit log with the user's real
+subject (RFC 0003 §5).
+
+### Bearer tokens / API keys
+
+Not supported in v1.0. Periscope is a BFF: the SPA never holds a
+token, so there's nothing to swap for an API key on the way out.
+A future "service account" lane (machine identity + scoped
+permissions) is post-v1 and will land alongside the CLI mentioned
+in RFC 0002.
+
+---
+
+## 3. Tier 1 — stable endpoints
+
+Endpoint paths, methods, request bodies, response field names, and
+documented error classes are all covered by semver.
+
+### `GET /healthz`
+
+Liveness probe. Always returns `200 ok` once the server is accepting
+connections. Does **not** authenticate cluster reachability — it's
+a process liveness check, nothing more. Use the per-cluster
+`status` field on `/api/fleet` for cluster reachability.
+
+```
+$ curl -s localhost:8080/healthz
+ok
+```
+
+No request body. Plain-text response. No `Cache-Control`.
+
+### `GET /api/auth/whoami`
+
+Session introspection. The SPA calls this on first paint. Mirrors
+what's used to render the user menu, audit nav gating, and tier
+tooltips.
+
+```json
+{
+  "subject":      "auth0|123",
+  "email":        "alice@corp.example",
+  "groups":       ["periscope-users", "Sec-Team"],
+  "mode":         "oidc",
+  "authzMode":    "tier",
+  "tier":         "admin",
+  "auditEnabled": true,
+  "auditScope":   "all",
+  "expiresAt":    1731000000
+}
+```
+
+| Field | Notes |
+|---|---|
+| `subject` | OIDC `sub` claim. Stable across the user's lifetime at the IdP. |
+| `email` | OIDC `email` claim, may be empty if the IdP doesn't ship it. |
+| `groups` | Resolved IdP groups (config `authorization.groupsClaim`). |
+| `mode` | Auth mode: `oidc` or `dev`. |
+| `authzMode` | `shared`, `tier`, or `raw`. See `docs/setup/cluster-rbac.md`. |
+| `tier` | Resolved tier name (tier mode only); empty otherwise. |
+| `auditEnabled` | Whether `/api/audit` is registered. |
+| `auditScope` | `self` or `all`. See RFC 0003 §11. Only present when `auditEnabled`. |
+| `expiresAt` | Unix seconds (UTC) of the session's absolute expiry. |
+
+`401 unauthenticated` if no valid session. There is also a
+`/api/whoami` route (no `auth` prefix) that returns a smaller actor
+slice; both are stable, but the `/api/auth/whoami` form is
+recommended for anything that needs the audit / tier fields.
+
+### `GET /api/whoami`
+
+Identity slice keyed off the impersonated `Provider`:
+
+```json
+{
+  "actor":        "alice@corp.example",
+  "auditEnabled": true,
+  "auditScope":   "self",
+  "mode":         "tier",
+  "tier":         "triage"
+}
+```
+
+`actor` is the `Provider.Actor()` string — usually the email, falling
+back to the OIDC subject. Both forms exist for historical reasons;
+`/api/auth/whoami` is the richer payload and what the SPA uses.
+
+### `GET /api/features`
+
+Reports the operator-controlled feature set the SPA should enable.
+Used to gate UI without the SPA needing to know about
+`PERISCOPE_*` env vars.
+
+```json
+{
+  "watchStreams": ["pods", "events", "deployments", "..."]
+}
+```
+
+The `watchStreams` array lists kinds for which the SSE watch route
+is registered. The list is in registry order (stable across
+restarts) and is the single source of truth for what the SPA can
+subscribe to. Empty array means the operator opted out
+(`PERISCOPE_WATCH_STREAMS=off`).
+
+### `GET /api/clusters`
+
+The cluster registry as the SPA sees it. No fan-out, no apiserver
+reach — this is configuration introspection.
+
+```json
+{
+  "clusters": [
+    {
+      "name":           "prod-eu",
+      "backend":        "eks",
+      "arn":            "arn:aws:eks:eu-west-1:1234567890:cluster/prod-eu",
+      "region":         "eu-west-1",
+      "execEnabled":    true
+    },
+    {
+      "name":           "dev",
+      "backend":        "kubeconfig",
+      "kubeconfigPath": "/etc/periscope/kube/dev.yaml",
+      "kubeconfigContext": "dev-admin",
+      "execEnabled":    false
+    }
+  ]
+}
+```
+
+`execEnabled` is the per-cluster derived flag — `false` when an
+operator set `clusters[i].exec.enabled: false` in Helm values. The
+SPA hides the "Open Shell" action when it's false; the API returns
+`403 E_EXEC_DISABLED` if a client tries anyway.
+
+### `GET /api/fleet`
+
+Multi-cluster aggregator behind the home page. Fans out under the
+caller's identity (impersonated calls per cluster), 2 s per-cluster
+soft timeout, total budget capped at 8 s. 10 s server-side TTL
+cache keyed by actor + impersonation groups.
+
+Page-level `403` when the user has no tier at all (tier mode +
+unmapped groups). Otherwise per-cluster errors are surfaced inline:
+
+```json
+{
+  "rollup": {
+    "totalClusters": 4,
+    "byStatus":      { "healthy": 3, "unreachable": 1 },
+    "byEnvironment": { "prod": 2, "stage": 2 },
+    "generatedAt":   "2026-05-04T12:34:56Z"
+  },
+  "clusters": [
+    {
+      "name":        "prod-eu",
+      "backend":     "eks",
+      "region":      "eu-west-1",
+      "environment": "prod",
+      "status":      "healthy",
+      "lastContact": "2026-05-04T12:34:55Z",
+      "summary": {
+        "nodes":         { "ready": 18, "total": 20 },
+        "pods":          { "running": 412, "pending": 3, "failed": 0, "total": 415 },
+        "namespaces":    24,
+        "stuckOrFailed": 3
+      },
+      "hotSignals": [{ "kind": "ImagePullBackOff", "count": 2 }]
+    },
+    {
+      "name":   "prod-us",
+      "status": "unreachable",
+      "error":  { "code": "apiserver_unreachable", "message": "..." }
+    }
+  ]
+}
+```
+
+Status enum (stable, additions are additive):
+`healthy` · `degraded` · `unreachable` · `unknown` · `denied`.
+
+Per-cluster error codes — the same enum used elsewhere (§6).
+
+### `GET /api/audit`
+
+Persisted audit query. **Registered only when SQLite is enabled and
+opened successfully** (otherwise 404). Full contract — request shape,
+response shape, retention semantics, RBAC, semver coverage — lives
+in [RFC 0003 §11](rfcs/0003-audit-log.md). One-line summary here:
+
+```
+GET /api/audit?
+    actor=<sub>&verb=<v>&outcome=<o>&cluster=<c>
+    &namespace=<ns>&name=<n>&request_id=<id>
+    &from=<RFC3339Nano>&to=<RFC3339Nano>
+    &limit=1..500&offset=N
+```
+
+Returns `{ items, total, limit, offset }` with a stable `Row` shape
+documented in RFC 0003 §6. `X-Audit-Scope: self` or `all` header
+indicates whether the server hard-overrode the actor filter to the
+caller's own subject.
+
+### `POST /api/clusters/{cluster}/can-i`
+
+Pre-flight RBAC check. The SPA uses this to grey out actions the
+user cannot perform (replacing the click → 403 → red banner UX with
+a disabled button + tooltip). Hits `SelfSubjectAccessReview` /
+`SelfSubjectRulesReview` under the user's impersonated identity.
+
+```json
+POST /api/clusters/prod-eu/can-i
+{
+  "checks": [
+    { "verb": "delete", "group": "apps", "resource": "deployments", "namespace": "platform" },
+    { "verb": "create", "group": "",     "resource": "pods/exec",   "namespace": "platform", "subresource": "exec" }
+  ]
+}
+
+→ 200 OK
+{
+  "results": [
+    { "allowed": true,  "reason": "" },
+    { "allowed": false, "reason": "no RBAC rule grants \"create\" on \"pods/exec\"" }
+  ]
+}
+```
+
+`results[i]` corresponds positionally to `checks[i]`. Maximum 64
+checks per request (returns `400` if exceeded). 30 s per-actor TTL
+cache. Anonymous callers and apiserver errors fail closed
+(`allowed: false`).
+
+---
+
+## 4. Tier 2 — SPA-coupled patterns
+
+The remaining ~130 endpoints follow eight patterns. Specific
+field-level shapes track the SPA's needs and may gain additive
+fields in minor versions; the path patterns and verbs below are
+stable.
+
+### Pattern: list
+
+```
+GET /api/clusters/{cluster}/{plural}
+GET /api/clusters/{cluster}/{plural}?namespace={ns}
+```
+
+Where `{plural}` is one of: `nodes` · `namespaces` · `pods` ·
+`deployments` · `statefulsets` · `daemonsets` · `replicasets` ·
+`services` · `ingresses` · `configmaps` · `secrets` · `jobs` ·
+`cronjobs` · `pvcs` · `pvs` · `storageclasses` · `roles` ·
+`clusterroles` · `rolebindings` · `clusterrolebindings` ·
+`serviceaccounts` · `horizontalpodautoscalers` ·
+`poddisruptionbudgets` · `networkpolicies` · `endpointslices` ·
+`resourcequotas` · `limitranges` · `ingressclasses` ·
+`priorityclasses` · `runtimeclasses`.
+
+Cluster-scoped kinds (nodes, namespaces, pvs, storageclasses,
+clusterroles, clusterrolebindings, ingressclasses, priorityclasses,
+runtimeclasses) ignore the `?namespace=` query param.
+
+Response shape: `{ "items": [<DTO>...], ... }` where `<DTO>` is the
+trimmed projection of the corresponding kind. Field names are
+stable; new fields may be added in minor versions.
+
+### Pattern: detail
+
+```
+GET /api/clusters/{cluster}/{plural}/{ns}/{name}      # namespaced
+GET /api/clusters/{cluster}/{plural}/{name}           # cluster-scoped
+```
+
+Returns the same `<DTO>` shape as the list endpoint, possibly with
+extra detail fields the list doesn't carry. Use the list shape as
+the contract; detail-only fields are best-effort additions.
+
+### Pattern: yaml
+
+```
+GET /api/clusters/{cluster}/{plural}/{ns}/{name}/yaml
+```
+
+Returns `Content-Type: application/yaml` (raw YAML, not JSON-wrapped).
+Used by the Monaco editor as the canonical edit source. SSA
+field-ownership annotations are preserved.
+
+### Pattern: events
+
+```
+GET /api/clusters/{cluster}/{plural}/{ns}/{name}/events
+GET /api/clusters/{cluster}/events                      # cluster-wide
+```
+
+Returns `{ "items": [<ClusterEvent>...] }`. Each event carries a
+stable `uid` field for SPA cache identity (added in 1.x; pre-uid
+DTOs are not produced by v1.0+).
+
+### Pattern: logs (SSE)
+
+```
+GET /api/clusters/{cluster}/pods/{ns}/{name}/logs?container=&follow=true&tailLines=100
+GET /api/clusters/{cluster}/{workload}/{ns}/{name}/logs?...
+```
+
+Server-Sent Events stream. See §5 for the live-channel contract.
+`workload` ∈ `deployments`, `statefulsets`, `daemonsets`, `jobs`.
+
+### Pattern: apply (Server-Side Apply)
+
+```
+PATCH /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{ns}/{name}
+PATCH /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{name}    # cluster-scoped
+?dryRun=true&force=true
+```
+
+Body is YAML (`Content-Type: application/yaml`), sent through
+Kubernetes Server-Side Apply with `application/apply-patch+yaml`.
+Returns the applied object on success. `dryRun=true` validates
+without mutating; `force=true` claims field ownership over
+conflicts.
+
+Audit-emitted as verb `apply`. Conflicts return `409` with a
+`metav1.Status` body whose `details.causes[]` carries per-field
+conflict info — the SPA uses this for the conflict resolver.
+
+`group=core` is rewritten to the empty string server-side so
+core-API resources can use the same URL pattern.
+
+### Pattern: delete
+
+```
+DELETE /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{ns}/{name}
+DELETE /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{name}     # cluster-scoped
+```
+
+Audit-emitted as verb `delete`. `204` on success. `404` is treated
+as success at the API level (idempotent delete).
+
+### Pattern: meta
+
+```
+GET /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{ns}/{name}/meta
+GET /api/clusters/{cluster}/resources/{group}/{version}/{resource}/{name}/meta
+```
+
+Lightweight metadata-only fetch. Used by the SPA before opening the
+editor to populate field-ownership glyphs and conflict resolution
+without re-fetching the whole object.
+
+### One-off endpoints (Tier 2, not pattern)
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/clusters/{c}/dashboard` | Per-cluster summary (counts + hot signals). Same shape as `/api/fleet` per-cluster summary. |
+| GET | `/api/clusters/{c}/search?q=&kinds=&limit=` | Cmd+K palette. Returns up to N matches per kind. |
+| GET | `/api/clusters/{c}/crds` | List CRDs. |
+| GET | `/api/clusters/{c}/customresources/{group}/{version}/{plural}[/...]` | List / detail / yaml / events of CRs (mirrors built-in patterns). |
+| GET | `/api/clusters/{c}/secrets/{ns}/{name}/data/{key}` | Decoded secret value. Audit-emitted as `secret_reveal`. |
+| GET | `/api/clusters/{c}/openapi/v3` and `.../openapi/v3/*` | Proxy to apiserver `/openapi/v3` for the editor's schema-aware autocomplete. |
+| POST | `/api/clusters/{c}/cronjobs/{ns}/{name}/trigger` | One-shot Job from a CronJob. Audit-emitted as `trigger`. |
+| GET | `/api/clusters/{c}/nodes/{name}/metrics`, `/api/clusters/{c}/pods/{ns}/{name}/metrics` | metrics.k8s.io passthrough. |
+| GET | `/api/clusters/{c}/helm/releases` | List. `{ releases, truncated }`. Cap 200; `truncated: true` when the cluster has more. |
+| GET | `/api/clusters/{c}/helm/releases/{ns}/{name}?revision=N` | Per-revision detail (values, manifest, parsed resources). 5 MiB cap. |
+| GET | `/api/clusters/{c}/helm/releases/{ns}/{name}/history?max=N` | Revision metadata list. Default `max=10`, range `1..100`. |
+| GET | `/api/clusters/{c}/helm/releases/{ns}/{name}/diff?from=N&to=M` | `dyff`-based structured diff between revisions. |
+
+Helm write operations (rollback / upgrade / install / uninstall)
+are deliberately **not** in v1.0 — they need the compound SAR
+fan-out layer to land first. v1.x.
+
+---
+
+## 5. Tier 3 — live channels
+
+### Watch streams (SSE)
+
+```
+GET /api/clusters/{cluster}/{kind}/watch[?namespace={ns}][&Last-Event-ID=...]
+```
+
+Where `{kind}` is one of the names returned by
+`GET /api/features.watchStreams`. Wire format is **frozen** — the
+SPA depends on it:
+
+```
+event: snapshot
+id: <resourceVersion>
+data: {"resourceVersion":"<rv>","items":[<DTO>...]}
+
+event: added | modified | deleted
+id: <resourceVersion>
+data: {"object":<DTO>}
+
+event: relist
+data: {"reason":"gone_410"}
+
+event: backpressure
+data: {}
+
+event: server_shutdown | auth_expired
+data: {}
+
+event: error
+data: {"message":"..."}
+```
+
+`<DTO>` is the same shape returned by the matching list endpoint, so
+the SPA cache patches against type-identical objects.
+
+`Last-Event-ID` (standard SSE header, also accepted as a query
+param of the same name) lets a transient disconnect resume from the
+last seen `resourceVersion` rather than re-listing.
+
+A per-user concurrency cap (`PERISCOPE_WATCH_PER_USER_LIMIT`,
+default 60) bounds open streams per OIDC subject. When a user is
+at the cap, opening a 61st stream returns the `error` event with
+`{"message":"watch stream cap reached"}` and closes; the SPA falls
+back to polling for that view.
+
+Operator opt-out via `PERISCOPE_WATCH_STREAMS` (subset, group
+aliases, `off`). See `docs/setup/watch-streams.md` for the full
+operator guide and `docs/architecture/watch-streams.md` for the
+push-model design.
+
+### Pod logs (SSE)
+
+```
+GET /api/clusters/{c}/pods/{ns}/{name}/logs?container=&follow=true&tailLines=100&previous=false
+GET /api/clusters/{c}/{workload}/{ns}/{name}/logs?... (deployment/sts/ds/job)
+```
+
+SSE with `event: log` frames carrying timestamped lines. Aborts
+when the client closes the connection; respects context-cancel.
+
+Workload-level routes auto-fan-out across the workload's child pods
+and tag each line with the source pod.
+
+A future `log_open` audit verb (RFC 0003 §4) will be emitted here;
+not yet wired.
+
+### Pod exec (WebSocket)
+
+```
+GET /api/clusters/{c}/pods/{ns}/{name}/exec?container=&command=&tty=true
+   ↑ HTTP 101 Upgrade → WebSocket
+```
+
+Bidirectional WebSocket bridging the browser terminal to the
+apiserver `/exec` stream (`FallbackExecutor` — WebSocket v5 with
+SPDY fallback). Full protocol — frame schema, channel multiplexing,
+idle / visibility timers, reconnect semantics, audit shape — lives
+in [RFC 0001](rfcs/0001-pod-exec.md). One paragraph here for
+context:
+
+- Identity is per-user via impersonation. The audit row names the
+  human who opened the shell, not the pod identity.
+- Two audit emissions per session: `exec_open` immediately after
+  the apiserver accepts, `exec_close` once the stream returns. The
+  `Reason` field carries the close disposition (`completed` /
+  `idle_timeout` / `abort` / `server_error`). See RFC 0003 §4.
+- Concurrent sessions per user are bounded; the cap message lists
+  active sessions with disconnect controls.
+- Stdin payloads never appear in logs or audit fields — only the
+  byte counts (`bytes_stdin` / `bytes_stdout`).
+
+---
+
+## 6. Conventions
+
+### JSON
+
+`Content-Type: application/json; charset=utf-8` on all JSON
+responses. Field names use lowerCamelCase. Empty / absent optional
+fields are omitted (`omitempty`); arrays are emitted as `[]` rather
+than `null`.
+
+Times are RFC3339 with nanosecond precision in UTC
+(`2026-05-04T12:34:56.789Z`). The audit reader accepts the same
+format on `?from=` / `?to=`. Unix-second integers appear only on
+`/api/auth/whoami.expiresAt` for legacy reasons.
+
+### Request id
+
+Every request gets a chi-generated request id, returned in
+`X-Request-Id` and threaded into both access-log and audit-log
+lines. Clients may pass `X-Request-Id` to override; it's preserved
+end-to-end. The same id appears in audit rows under
+`requestId` / `request_id` so a user-visible error can be tied
+back to one persisted audit row.
+
+### Errors
+
+For Kubernetes errors, the response body is the upstream
+`metav1.Status` JSON shape:
+
+```json
+{
+  "kind":    "Status",
+  "status":  "Failure",
+  "message": "deployments.apps \"foo\" already exists",
+  "reason":  "AlreadyExists",
+  "details": {
+    "name":   "foo",
+    "group":  "apps",
+    "kind":   "deployments",
+    "causes": [ { "field": "spec.replicas", "message": "...", "reason": "..." } ]
+  },
+  "code":    409
+}
+```
+
+The `details.causes[]` array drives the apply-conflict resolver in
+the SPA (per-field "keep mine / take theirs"). Non-Kubernetes
+errors fall back to plain text.
+
+The HTTP status mapping (`cmd/periscope/errors.go::httpStatusFor`) is:
+
+| `client-go` classifier | HTTP status |
+|---|---|
+| `IsForbidden` | 403 |
+| `IsUnauthorized` | 401 |
+| `IsNotFound` | 404 |
+| `IsConflict` | 409 |
+| `IsTimeout` / `IsServerTimeout` | 504 |
+| `IsTooManyRequests` | 429 |
+| `IsBadRequest` | 400 |
+| _other_ | 500 |
+
+### Aggregator error codes
+
+`/api/fleet` (and any future aggregator) returns a stable enum on
+each per-cluster error rather than raw `client-go` strings:
+
+| Code | When |
+|---|---|
+| `denied` | Forbidden (403). |
+| `auth_failed` | Unauthorized (401) — typically the pod's IRSA / Pod Identity binding broken. |
+| `timeout` | Per-cluster soft timeout or `context deadline exceeded`. |
+| `apiserver_unreachable` | Network error, dial failure, generic 5xx. |
+| `unknown` | Anything else. |
+
+Treat the set as **additive**: new codes may be added in minor
+versions; existing codes are stable.
+
+### CSRF
+
+Periscope relies on cookie `SameSite=Strict` for the session cookie
+to prevent cross-site state-changing requests. There is no
+double-submit token in v1.0. If you front Periscope with a proxy
+that strips `SameSite` (rare), evaluate your CSRF posture
+separately.
+
+`PATCH` (apply), `DELETE`, and `POST /trigger` are state-changing.
+The exec WebSocket handshake is also implicitly state-changing;
+its origin check (`PERISCOPE_DEV_ALLOW_ORIGINS` in dev mode;
+same-origin in prod) is the equivalent guard.
+
+### Pagination
+
+Only `/api/audit` paginates today (`?limit=&offset=`). List endpoints
+return the full result set up to a server-side cap (200 helm
+releases; ~1000 namespace scopes for the cluster-wide search; full
+list otherwise — Kubernetes pagination is not yet exposed). A
+future minor version may add `?continue=` token pagination on list
+endpoints; that's additive and won't break callers that ignore it.
+
+---
+
+## 7. SPA, dev, and debug
+
+These exist but are **not part of the API contract**:
+
+- **SPA static assets** — `GET /` and any non-API path served by
+  `internal/spa.Handler()` when the embedded SPA is built in. May
+  be replaced with `index.html` on a SPA-native rewrite. Don't
+  script against any specific path; treat `/` as opaque.
+- **`GET /debug/streams`** — JSON snapshot of currently-open watch
+  streams. Useful for diagnosing "did this user blow the per-user
+  cap." Format may change between versions.
+
+---
+
+## 8. Forward roadmap
+
+| When | What |
+|---|---|
+| v1.x | Helm write paths (rollback / upgrade) once the compound SAR layer lands. Additive: new methods on existing helm paths. |
+| v1.x | `log_open` audit emission for the SSE log streams. Additive: new audit verb (RFC 0003 §4 reserves it). |
+| v1.x | Postgres-backed session store and audit reader. No HTTP API change — same `/api/audit` shape, same cookies. |
+| v1.x | `periscope-rbac` CLI (RFC 0002). Will use the existing `/api/clusters/*` and `/api/auth/whoami` surfaces. |
+| v2 | Anything that breaks the contracts in §3 or §4 (path moves, removed fields, renamed enums). Expect `/api/v2/...` alongside `/api/...` through one major's deprecation window. |
+| v3 | RFC 0001 §3 — MCP tool exposure. Will reuse the per-cluster typed function layer; HTTP API stays as the human-facing surface. |
+
+---
+
+## 9. References
+
+- [RFC 0001 — Pod exec support](rfcs/0001-pod-exec.md) — exec
+  WebSocket frame schema, identity propagation, acceptance criteria.
+- [RFC 0002 — Authentication (OIDC + per-user K8s authz)](rfcs/0002-auth.md) —
+  the three authz modes, group resolution, impersonation contract.
+- [RFC 0003 — Audit log: schema and retention semantics](rfcs/0003-audit-log.md) —
+  full `/api/audit` reference and event shape.
+- [`docs/setup/audit.md`](setup/audit.md) — operator-facing audit
+  configuration and RBAC.
+- [`docs/setup/watch-streams.md`](setup/watch-streams.md) — operator
+  guide for the SSE watch surface.
+- [`docs/setup/cluster-rbac.md`](setup/cluster-rbac.md) — in-cluster
+  RBAC the backend needs and the three authz modes.
+- [`docs/architecture/watch-streams.md`](architecture/watch-streams.md) —
+  push-model design behind Tier 3 watch streams.

--- a/docs/architecture/watch-streams.md
+++ b/docs/architecture/watch-streams.md
@@ -153,7 +153,7 @@ The handler takes care of:
 
 ## 6. Per-user concurrency cap
 
-`PERISCOPE_WATCH_PER_USER_LIMIT` (default 30) caps concurrent watch
+`PERISCOPE_WATCH_PER_USER_LIMIT` (default 60) caps concurrent watch
 streams per OIDC subject across all clusters and kinds. Exceeding it
 returns HTTP 429. The cap exists to stop a runaway SPA bug from
 opening hundreds of EventSources and exhausting apiserver watch

--- a/docs/rfcs/0002-auth.md
+++ b/docs/rfcs/0002-auth.md
@@ -17,7 +17,7 @@ Periscope ships with two orthogonal authentication layers wired into a single
 
 - **Layer A — user identity**: generic OIDC (tested with Auth0, Okta), Authorization
   Code + PKCE, BFF pattern. The Go backend is the OAuth client; the SPA never sees
-  a token. Session is an `httpOnly; Secure; SameSite=Strict` cookie bound to a
+  a token. Session is an `httpOnly; Secure; SameSite=Lax` cookie bound to a
   server-side session record. **Shipped in PR-A + PR-A.1.**
 
 - **Layer B — application authentication and per-user K8s authorization**: the
@@ -397,7 +397,7 @@ never leave the auth package.
 - `Value`: session ID (32 random bytes, base64)
 - `HttpOnly`: true
 - `Secure`: true on TLS / behind X-Forwarded-Proto=https
-- `SameSite`: Strict
+- `SameSite`: Lax (see CHANGELOG v1.0.0 — Strict broke the post-callback redirect; #37)
 - `Path`: `/`
 - `MaxAge`: matches absolute timeout (8 h)
 - `Domain`: configurable; default unset (host-only cookie)

--- a/docs/rfcs/0003-audit-log.md
+++ b/docs/rfcs/0003-audit-log.md
@@ -5,7 +5,7 @@
 | **Status** | Accepted (shipped in v1.0) |
 | **Owner** | @gnana997 |
 | **Started** | 2026-05-04 |
-| **Targets** | v1.0 (formalize what shipped), v1.x (Postgres backend), v2 (signing / external SIEM contract) |
+| **Targets** | v1.0 (formalize what shipped), v2 (signing / external SIEM contract) |
 | **Related** | RFC 0001 (pod exec — section 10 — audit-event shape), RFC 0002 (auth — actor identity) |
 
 ---
@@ -29,7 +29,7 @@ source of truth.
 The key claim is **schema stability** (the verb set and field names are
 covered by semver) paired with an **explicit non-claim around tamper
 resistance** (v1.0 is operator-trust, not cryptographic). v1.x narrows the
-non-claim by adding a Postgres backend; v2 narrows it again by signing.
+non-claim further; v2 introduces signing for the operator-tampering case.
 
 ---
 
@@ -53,7 +53,7 @@ human." Two forces flow from that:
   nothing is lost from the operator-visible log stream.
 
 The combination of "exact shape, recorded reliably" and "never blocks the
-request" is what RFC 0001 §10 implicitly relied on. RFC 0003 elevates
+request" is what RFC 0001 10 implicitly relied on. RFC 0003 elevates
 that contract to a first-class spec so v1.x and v2 evolutions are
 confined edits rather than rewrites.
 
@@ -83,8 +83,7 @@ confined edits rather than rewrites.
   ship `StdoutSink` JSON to an external SIEM and treat that as the
   system of record.
 - **HA (multi-replica) audit.** SQLite is single-writer. v1.0 deploys
-  Periscope as one replica when audit persistence is on. Postgres
-  (v1.x) lifts this constraint.
+  Periscope as one replica when audit persistence is on.
 - **Free-text or `LIKE` search.** All filters are exact-match or
   time-range on indexed columns; full-text search would degrade past
   the retention cap.
@@ -93,7 +92,7 @@ confined edits rather than rewrites.
 
 - Tracking every read. List/describe/log-view are not audited; only
   privileged or identity-sensitive actions are. (`log_open` is reserved
-  in the taxonomy but not yet wired — see §4.)
+  in the taxonomy but not yet wired — see 4.)
 - Storing apply payloads. Diffs of YAML being applied are not part of
   the audit record. The audit row tells you "alice@corp applied
   Deployment foo at T," not what changed in the manifest.
@@ -170,8 +169,8 @@ serialization differs (slog kv vs SQLite columns vs JSON).
     "email":  "alice@corp.example",                 // optional
     "groups": ["periscope-users", "Sec-Team"]       // optional, IdP claim
   },
-  "verb":        "apply",                           // closed set, see §4
-  "outcome":     "success",                         // closed set, see §5
+  "verb":        "apply",                           // closed set, see 4
+  "outcome":     "success",                         // closed set, see 5
   "cluster":     "prod-eu",                         // registry name, optional for some events
   "resource": {
     "group":     "apps",                            // omitted for core
@@ -181,7 +180,7 @@ serialization differs (slog kv vs SQLite columns vs JSON).
     "name":      "checkout"                         // empty for batch operations
   },
   "reason":      "deployments.apps \"checkout\" already exists", // err.Error() on failure/denied; close-reason on exec_close; empty on plain success
-  "extra": {                                        // verb-specific; see §4
+  "extra": {                                        // verb-specific; see 4
     "dryRun": false,
     "force":  true
   }
@@ -281,7 +280,7 @@ additive fields introduced by the refactor.
 
 ### `SQLiteSink`
 
-Persisted, queryable, retention-bounded. Fully specified in §9–§11.
+Persisted, queryable, retention-bounded. Fully specified in 9–11.
 
 ---
 
@@ -464,7 +463,7 @@ matching the literal value (i.e. zero rows).
 
 ```json
 {
-  "items":  [ /* Row, see §6 */ ],
+  "items":  [ /* Row, see 6 */ ],
   "total":  1247,
   "limit":  50,
   "offset": 0
@@ -542,7 +541,7 @@ and `auditScope`) to hide audit nav when the feature is off.
 ### Adding a verb (minor version)
 
 1. Add the constant in `internal/audit/event.go`.
-2. Update §4 of this RFC with the emission site, outcome classes, and
+2. Update 4 of this RFC with the emission site, outcome classes, and
    `extra` shape.
 3. Wire the emission at the handler. Reuse `actorFromContext` and
    `outcomeFor`.
@@ -552,7 +551,7 @@ and `auditScope`) to hide audit nav when the feature is off.
 
 1. Append a new migration to `migrations` in `sqlite_sink.go`.
 2. Add the column to the Go struct and the `Row` JSON tags.
-3. Update §6 (top-level shape) and §9 (schema) of this RFC.
+3. Update 6 (top-level shape) and 9 (schema) of this RFC.
 4. Old rows return NULL → empty in JSON, which existing clients
    already tolerate for the existing nullable columns.
 
@@ -599,7 +598,7 @@ adding `extra` keys for new verbs review them against this list:
 
 The exec stdin/stdout payload **never** appears in audit fields
 (`bytes_stdin` / `bytes_stdout` are byte counts, not contents). RFC
-0001 §17 acceptance criterion #7 enforces this with a test.
+0001 17 acceptance criterion #7 enforces this with a test.
 
 **RBAC bypass risk.** The `actor` filter override is **server-side**
 in `auditQueryHandler`. There is no client-supplied way to escape it
@@ -636,7 +635,7 @@ The audit pipeline is complete (v1.0) when:
    and ignores any client-supplied `actor=` parameter
    (`audit_handler_test.go` covers both directions).
 9. `limit > 500` is silently clamped to 500.
-10. RFC 0001 §17 #7 (no stdin payloads in any audit field) holds.
+10. RFC 0001 17 #7 (no stdin payloads in any audit field) holds.
 
 All ten are met as of v1.0.0.
 
@@ -644,10 +643,6 @@ All ten are met as of v1.0.0.
 
 ## 15. Future work
 
-- **v1.x — Postgres backend.** Same `Sink` and `Reader` interfaces,
-  same column set, different driver. Lifts the single-replica
-  constraint. The `Reader` interface in
-  `internal/audit/reader.go:10` was carved out for exactly this.
 - **v1.x — `log_open` emission.** Wire the reserved verb behind a
   rate-aware emitter so a tail-follow doesn't flood the table.
 - **v2 — hash-chain signing.** Append a `prev_hash` column and a
@@ -669,5 +664,5 @@ All ten are met as of v1.0.0.
 - [`cmd/periscope/audit_handler.go`](../../cmd/periscope/audit_handler.go) — `/api/audit` HTTP handler
 - [`cmd/periscope/errors.go`](../../cmd/periscope/errors.go) — `outcomeFor`, `actorFromContext`
 - [`docs/setup/audit.md`](../setup/audit.md) — operator-facing guide
-- RFC 0001 §10 — pre-existing exec audit-event shape, preserved by `StdoutSink`
-- RFC 0002 §3 — actor identity sources (OIDC subject, IdP groups)
+- RFC 0001 10 — pre-existing exec audit-event shape, preserved by `StdoutSink`
+- RFC 0002 3 — actor identity sources (OIDC subject, IdP groups)

--- a/docs/rfcs/0003-audit-log.md
+++ b/docs/rfcs/0003-audit-log.md
@@ -1,0 +1,673 @@
+# RFC 0003 — Audit Log: Schema and Retention Semantics
+
+| | |
+|---|---|
+| **Status** | Accepted (shipped in v1.0) |
+| **Owner** | @gnana997 |
+| **Started** | 2026-05-04 |
+| **Targets** | v1.0 (formalize what shipped), v1.x (Postgres backend), v2 (signing / external SIEM contract) |
+| **Related** | RFC 0001 (pod exec — section 10 — audit-event shape), RFC 0002 (auth — actor identity) |
+
+---
+
+## 1. Summary
+
+Periscope writes one structured `audit.Event` for every privileged action a
+human takes through the dashboard: pod exec, secret reveal, resource apply,
+resource delete, cronjob trigger. Events flow through an in-process
+`audit.Emitter` that fans out to one or more `audit.Sink`s. v1.0 ships two
+sinks — `StdoutSink` (always on) and `SQLiteSink` (opt-in, persisted) — and
+one `Reader` (`SQLiteSink` again, behind `GET /api/audit`).
+
+This RFC pins the contract: the closed verb set, the field shape, the
+on-disk schema, the retention semantics, the read-side RBAC, and the
+guarantees the pipeline does and does not make. Operators reading audit
+rows downstream (SIEM ingest, compliance review, forensics) and contributors
+adding new privileged actions should both treat this document as the
+source of truth.
+
+The key claim is **schema stability** (the verb set and field names are
+covered by semver) paired with an **explicit non-claim around tamper
+resistance** (v1.0 is operator-trust, not cryptographic). v1.x narrows the
+non-claim by adding a Postgres backend; v2 narrows it again by signing.
+
+---
+
+## 2. Motivation
+
+Periscope's positioning is "the dashboard whose audit log names a real
+human." Two forces flow from that:
+
+- **Every privileged action must be captured exactly once, with a stable
+  shape.** Pre-refactor the same logical event was emitted as ad-hoc
+  `slog` calls at each handler with three different field shapes and no
+  row at all on the failure path. A SIEM query that worked for
+  `apply` did not work for `delete`. Pinning a single schema in
+  `internal/audit/event.go` and routing every emission through one
+  `Emitter` lets downstream consumers index on stable column names.
+
+- **The audit pipeline cannot become a SPOF for the dashboard.** A stuck
+  PVC, a slow disk, or a transient SQLite error must never block a
+  privileged request. The pipeline is therefore **fail-open**: errors
+  log and the action proceeds, with `StdoutSink` always attached so
+  nothing is lost from the operator-visible log stream.
+
+The combination of "exact shape, recorded reliably" and "never blocks the
+request" is what RFC 0001 §10 implicitly relied on. RFC 0003 elevates
+that contract to a first-class spec so v1.x and v2 evolutions are
+confined edits rather than rewrites.
+
+---
+
+## 3. Goals and non-goals
+
+### Goals (v1.0)
+
+- A closed, semver-covered taxonomy of audit verbs.
+- A wire-stable JSON shape on both stdout and `/api/audit`.
+- A SQLite-backed persistent store with bounded retention and a
+  documented schema-migration story.
+- Read-side RBAC (`X-Audit-Scope`) that lets non-admin users self-audit
+  without exposing colleagues' actions.
+- Fail-open behavior at every step (sink open failure, sink write
+  failure, retention loop failure).
+
+### Non-goals (v1.0)
+
+- **Cryptographic tamper resistance.** Rows are insert-only at the
+  application layer; an operator with disk access can edit `audit.db`.
+  v1.0 trusts the operator. Hash-chain signing is in scope for v2.
+- **Compliance-grade retention (HIPAA, PCI, SOC2 multi-year).** SQLite
+  is a local cache; the `Validate` warning at startup says so out loud
+  for `retentionDays > 365`. Operators with a multi-year requirement
+  ship `StdoutSink` JSON to an external SIEM and treat that as the
+  system of record.
+- **HA (multi-replica) audit.** SQLite is single-writer. v1.0 deploys
+  Periscope as one replica when audit persistence is on. Postgres
+  (v1.x) lifts this constraint.
+- **Free-text or `LIKE` search.** All filters are exact-match or
+  time-range on indexed columns; full-text search would degrade past
+  the retention cap.
+
+### Out of scope forever
+
+- Tracking every read. List/describe/log-view are not audited; only
+  privileged or identity-sensitive actions are. (`log_open` is reserved
+  in the taxonomy but not yet wired — see §4.)
+- Storing apply payloads. Diffs of YAML being applied are not part of
+  the audit record. The audit row tells you "alice@corp applied
+  Deployment foo at T," not what changed in the manifest.
+
+---
+
+## 4. Verb taxonomy
+
+The verb set is **closed**. New verbs land via PR that edits
+`internal/audit/event.go` and (almost always) this RFC. Free-string verbs
+are not allowed — every emission site uses a `audit.Verb*` constant.
+
+| Verb | Emitted by | Outcome classes | `Extra` fields |
+|---|---|---|---|
+| `apply` | `applyResourceHandler` (PUT/POST `/api/clusters/{c}/customresources/.../apply` and the typed apply route) | `success` / `failure` / `denied` | `dryRun: bool`, `force: bool` |
+| `delete` | `deleteResourceHandler` | `success` / `failure` / `denied` | — |
+| `trigger` | `triggerCronJobHandler` | `success` / `failure` / `denied` | on success: `jobName: string` |
+| `secret_reveal` | `secretRevealHandler` | `success` / `failure` / `denied` | `key: string`; on success also `size: int` (bytes of the decoded value) |
+| `exec_open` | `execHandler` immediately after session admit | `success` only | `session_id`, `container`, `tty`, `command`, `k8s_identity`, `started_at` |
+| `exec_close` | `execHandler` once `execsess.Run` returns | `success` / `failure` | all `exec_open` fields plus `transport`, `ended_at`, `duration_ms`, `exit_code`, `bytes_stdin`, `bytes_stdout`, `err`. `Reason` carries the close disposition: `completed` / `idle_timeout` / `abort` / `server_error` |
+| `log_open` | _reserved_ | _reserved_ | _reserved_ |
+
+`apply` is intentionally a single verb covering both create and update.
+Periscope's mutation surface is `PATCH application/apply-patch+yaml`
+(Server-Side Apply); the Kubernetes API does not split the two and we do
+not synthesize the distinction. The forensic question "did this row
+create or modify the resource?" is answerable by joining audit rows: the
+first successful `apply` for a given `(cluster, namespace, group,
+version, resource, name)` tuple is the create; everything after is an
+update.
+
+`log_open` is declared but not yet emitted. Stream opens on
+`/api/clusters/{c}/pods/{ns}/{name}/logs` are out of scope for v1.0
+because the access pattern (long-lived SSE) needs ratelimit-aware
+emission to avoid flooding the audit table. Adding it is a self-contained
+follow-up; the constant exists so the taxonomy is visible.
+
+---
+
+## 5. Outcome taxonomy
+
+`Outcome` is a closed three-value enum:
+
+| Value | When |
+|---|---|
+| `success` | The action completed. For `exec_close`, "completed" means the apiserver stream returned without `runErr`. |
+| `denied` | The action was rejected by Kubernetes RBAC — `k8serrors.IsForbidden` or `k8serrors.IsUnauthorized`. Denials are forensically the most interesting class and get their own outcome so an operator can query "who tried X and got blocked" with one filter. |
+| `failure` | Any other error: validation, conflict, server error, network, dry-run rejection. |
+
+`outcomeFor` in `cmd/periscope/errors.go:48` is the single mapping from
+`error` to `Outcome`. Adding a new error class that should classify as
+`denied` rather than `failure` happens in that one place.
+
+Cancellations propagate as `context.Canceled` and **do not produce an
+audit row** — the action neither completed nor was rejected by policy;
+it was abandoned by the client. Handlers explicitly `return` early in
+that case.
+
+---
+
+## 6. Event schema (wire shape)
+
+The Go struct is `audit.Event` in `internal/audit/event.go`. Both sinks
+and the `/api/audit` reader produce the same field set; only the
+serialization differs (slog kv vs SQLite columns vs JSON).
+
+```jsonc
+{
+  "id":          12345,                             // /api/audit only — DB row id
+  "timestamp":   "2026-05-04T12:34:56.789Z",        // RFC3339Nano UTC; Emitter stamps if zero
+  "requestId":   "abc123",                          // chi request id; ties to access logs
+  "actor": {
+    "sub":    "auth0|123",                          // OIDC subject — required, non-empty
+    "email":  "alice@corp.example",                 // optional
+    "groups": ["periscope-users", "Sec-Team"]       // optional, IdP claim
+  },
+  "verb":        "apply",                           // closed set, see §4
+  "outcome":     "success",                         // closed set, see §5
+  "cluster":     "prod-eu",                         // registry name, optional for some events
+  "resource": {
+    "group":     "apps",                            // omitted for core
+    "version":   "v1",
+    "resource":  "deployments",                     // plural lowercase
+    "namespace": "platform",                        // empty for cluster-scoped
+    "name":      "checkout"                         // empty for batch operations
+  },
+  "reason":      "deployments.apps \"checkout\" already exists", // err.Error() on failure/denied; close-reason on exec_close; empty on plain success
+  "extra": {                                        // verb-specific; see §4
+    "dryRun": false,
+    "force":  true
+  }
+}
+```
+
+**Stability rules:**
+
+- **Verb names** (`apply`, `delete`, …) are part of the public API.
+  Renames are breaking changes and bump the major.
+- **Outcome names** are part of the public API.
+- **Top-level field names** (`actor.sub`, `verb`, `outcome`, `cluster`,
+  `resource.namespace`, …) are part of the public API.
+- **`extra` field names** for already-shipped verbs are part of the
+  public API. Adding new keys to `extra` for an existing verb is
+  additive (minor/patch).
+- The `Route` field exists on the Go struct and `StdoutSink` writes it
+  as `route`; it is **not** persisted to SQLite (no column) and is
+  therefore not returned by `/api/audit`. Treat `route` as a debug aid
+  on the stdout stream, not a queryable dimension.
+
+**Field-absence rules:**
+
+- Empty strings on optional top-level fields (`actor.email`,
+  `cluster`, every `resource.*` field, `reason`) are **omitted** in
+  both stdout slog output and `/api/audit` JSON.
+- In SQLite they are stored as `NULL`, not empty string, so
+  `WHERE namespace IS NULL` queries are honest about cluster-scoped
+  rows.
+
+**Required fields** (every event must have these set or the row is
+malformed):
+
+- `timestamp` (Emitter stamps if caller leaves it zero)
+- `actor.sub` (Emitter falls back to the per-request `RequestContext`
+  Actor planted by `httpx.AuditBegin` + `auth.Middleware`)
+- `verb`
+- `outcome`
+
+---
+
+## 7. Identity propagation
+
+Actor identity flows from one writer:
+
+```
+auth.Middleware  ──►  audit.PatchActor(ctx, Actor{Sub, Email, Groups})
+                              │
+                              ▼
+                  *RequestContext on ctx (planted by httpx.AuditBegin)
+                              │
+                              ▼
+            audit.Emitter.Record reads it when handler leaves Actor zero
+```
+
+The single-writer invariant is documented in
+`internal/audit/context.go:53–65`: `PatchActor` mutates a shared
+`*RequestContext` and **must** be called from the request goroutine,
+never from a handler-spawned goroutine. The race detector catches
+violations on first run with `go test -race`.
+
+Handlers in `cmd/periscope/` populate `Actor` explicitly via
+`actorFromContext(ctx)` (cmd/periscope/errors.go:61) which reads the
+already-resolved `credentials.Session`. The Emitter's
+"fall back to request context" path in
+`internal/audit/emitter.go:56–58` exists for handlers that emit before
+`credentials.Wrap` resolution (none today, but the lane is open).
+
+---
+
+## 8. Sink contract
+
+`Sink.Record(ctx, evt)` is **infallible by signature**. A sink that
+encounters a transient error must log it and return; it must not block
+the calling handler. Rationale: a privileged action that returned 200
+to the user must not be reverted because the audit DB was slow. The
+unconditional `StdoutSink` ensures nothing is lost from the operator's
+log stream even when a buffered sink drops.
+
+Sinks are called **synchronously** from the request goroutine, in the
+order they were attached to the Emitter. Today that means stdout first,
+SQLite second. Re-ordering is a non-breaking change.
+
+**No buffering, no batching, no async** in v1.0. A future
+`KafkaSink` or `OpenTelemetrySink` that needs persistence guarantees
+implements its own buffering — the Emitter is deliberately thin so
+sinks don't share a single failure mode.
+
+### `StdoutSink`
+
+One `slog.InfoContext(ctx, "audit", attrs...)` call per event. Field
+names match the pre-refactor handler conventions
+(`category=audit`, `event=<verb>`, `actor.sub`, `cluster`,
+`session_id`, `bytes_stdin`, …) so existing scrapers and SIEM queries
+keep matching. `outcome`, `request_id`, `route`, `reason` are the
+additive fields introduced by the refactor.
+
+### `SQLiteSink`
+
+Persisted, queryable, retention-bounded. Fully specified in §9–§11.
+
+---
+
+## 9. SQLite schema (v1)
+
+Schema version is tracked in `PRAGMA user_version`. v1.0 is at v1.
+
+```sql
+CREATE TABLE audit_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_unix_nano  INTEGER NOT NULL,
+    request_id    TEXT,
+    route         TEXT,
+    actor_sub     TEXT NOT NULL,
+    actor_email   TEXT,
+    actor_groups  TEXT,    -- JSON array
+    verb          TEXT NOT NULL,
+    outcome       TEXT NOT NULL,
+    cluster       TEXT,
+    res_group     TEXT,
+    res_version   TEXT,
+    res_type      TEXT,
+    res_namespace TEXT,
+    res_name      TEXT,
+    reason        TEXT,
+    extra         TEXT     -- JSON object
+);
+
+CREATE INDEX idx_audit_ts        ON audit_events (ts_unix_nano);
+CREATE INDEX idx_audit_actor_ts  ON audit_events (actor_sub, ts_unix_nano);
+CREATE INDEX idx_audit_verb_ts   ON audit_events (verb, ts_unix_nano);
+CREATE INDEX idx_audit_outcome_ts ON audit_events (outcome, ts_unix_nano);
+CREATE INDEX idx_audit_scope_ts  ON audit_events (cluster, res_namespace, ts_unix_nano);
+```
+
+Indexes match the `/api/audit` filter set: every queryable dimension
+either has its own composite-with-`ts` index or is a leading column of
+one. `ORDER BY ts_unix_nano DESC, id DESC` gives deterministic
+pagination across rows that share a nanosecond timestamp.
+
+PRAGMAs set at open time:
+
+| PRAGMA | Value | Why |
+|---|---|---|
+| `journal_mode` | `WAL` | Reads (the `/api/audit` query) don't block writes. |
+| `busy_timeout` | `5000` (ms) | Burst writes from concurrent handlers wait briefly rather than failing. |
+| `synchronous` | `NORMAL` | Trades a microscopic durability window for throughput; appropriate for an audit cache where stdout is the hard backstop. |
+| `wal_autocheckpoint` | `1000` (pages, ~4 MiB) | Caps WAL growth between explicit checkpoints. |
+
+### Schema evolution
+
+- Migrations are append-only entries in `migrations` in
+  `internal/audit/sqlite_sink.go:194`. **Never edit a shipped
+  migration** — it may have already run on production DBs.
+- Each migration runs in a transaction; failure aborts the transaction
+  but does not corrupt history.
+- A DB at a higher `user_version` than the binary knows is **refused at
+  open time**. This protects an operator from rollback-by-mistake
+  silently corrupting future-schema data.
+- A DB at a lower `user_version` is migrated forward as part of normal
+  startup. Migration takes < 100 ms on a 1 M-row DB; no readiness-probe
+  budget concern.
+
+**Adding a column** (additive): new migration entry that runs
+`ALTER TABLE audit_events ADD COLUMN ...`. SQLite supports this without
+a table rewrite. The Go struct gains the field; readers handle absent
+values for old rows (NULL → empty string, same as the existing
+nullable columns).
+
+**Removing or renaming a column** is a breaking schema change and is
+treated as a major version (would land in v2 with a migration
+strategy).
+
+---
+
+## 10. Retention semantics
+
+Two caps act as belt-and-suspenders:
+
+```yaml
+audit:
+  retentionDays: 30     # delete rows older than this (0 = disabled)
+  maxSizeMB:    1024    # delete oldest until file ≤ this size (0 = disabled)
+  vacuumInterval: 24h   # how often the prune+VACUUM loop runs
+```
+
+Whichever cap binds first wins. **Setting both to 0 is the
+unbounded-growth footgun**; `Validate()` warns at startup but does
+not refuse to boot.
+
+### Prune algorithm (per tick)
+
+1. **Age prune** (if `retentionDays > 0`):
+   `DELETE FROM audit_events WHERE ts_unix_nano < (now − retentionDays × 24h)`.
+   Indexed on `ts_unix_nano`; cost is `O(rows-to-delete)`.
+
+2. **Size prune** (if `maxSizeMB > 0`): single-shot. Compute
+   `excess = (file_size − target) / file_size`, drop the oldest
+   `rowCount × excess × 1.1` rows. The 10% headroom lands the file
+   comfortably under the cap after VACUUM rather than just at it.
+   See `pruneBySize` in `sqlite_sink.go:410` for why it's single-shot
+   rather than a loop (SQLite doesn't shrink the file between
+   DELETEs without an intervening VACUUM, so an in-loop convergence
+   test never converges).
+
+3. **VACUUM** (only if step 1 or 2 deleted anything): reclaims freed
+   pages back to the filesystem. Holds an exclusive write lock for
+   the duration (5–30 s on a 1 GiB DB). Concurrent `Record()` calls
+   block on the busy_timeout (5 s) and may end up logged-and-dropped
+   under sustained pressure — `StdoutSink` continues to capture them.
+
+4. **WAL truncate**: `PRAGMA wal_checkpoint(TRUNCATE)`. Without this,
+   `audit.db-wal` can grow alongside `audit.db` on busy writers and
+   eat into the operator's on-disk budget.
+
+### Initial sweep
+
+`OpenSQLiteSink` runs steps 1–4 **synchronously** before returning,
+with a **30-second deadline**. Handles "pod woke up after a long
+downtime with stale rows" without making the readiness probe wait
+minutes. If 30 s isn't enough the regular loop catches up on its
+24 h cadence; the pod still becomes Ready.
+
+### Volume sizing
+
+In `pvc` mode the operator sets `audit.storage.size` directly. In
+`emptyDir` mode the kubelet `sizeLimit` is **auto-derived** as
+`2 × maxSizeMB`. The 2× factor covers VACUUM's transient
+file-doubling plus WAL growth between checkpoints.
+
+`Validate` warns when `maxSizeMB × 2 > availableDiskMB` at the
+parent directory — i.e. the volume cannot survive a VACUUM cycle. The
+check is best-effort (skipped when the directory doesn't yet exist
+because Validate runs before the volume is mounted in some test
+configurations).
+
+### Failure modes
+
+| What fails | What happens |
+|---|---|
+| `OpenSQLiteSink` (PVC unmountable, schema migration error, disk full) | `slog.Warn`, continue with stdout-only, `/api/audit` returns 404. Pod becomes Ready. |
+| `Record` exec | `slog.Error`, swallow, continue. Stdout sink already wrote the row. |
+| Retention `DELETE` | `slog.Error`, continue. Next tick retries. |
+| `VACUUM` | `slog.Error`, continue. File stays at high-water mark; next prune retries. |
+| WAL checkpoint | `slog.Error`, continue. WAL grows until next successful checkpoint. |
+
+The pipeline never blocks the pod from booting and never blocks a
+privileged request.
+
+---
+
+## 11. Read API: `GET /api/audit`
+
+Registered **only when** the SQLite sink opened successfully. When
+audit persistence is off (or open failed) the route is unregistered
+and returns 404 — the right shape for "feature off."
+
+### Request
+
+```
+GET /api/audit?
+  actor=<sub>
+  &verb=<apply|delete|trigger|secret_reveal|exec_open|exec_close>
+  &outcome=<success|failure|denied>
+  &cluster=<name>
+  &namespace=<ns>
+  &name=<resource-name>
+  &request_id=<id>
+  &from=<RFC3339Nano>     // inclusive
+  &to=<RFC3339Nano>       // exclusive
+  &limit=<1..500>          // default 50
+  &offset=<n>
+```
+
+All filters compose with AND. Empty filters are ignored. Bad time or
+int values return 400; unknown verb/outcome strings return rows
+matching the literal value (i.e. zero rows).
+
+### Response
+
+```json
+{
+  "items":  [ /* Row, see §6 */ ],
+  "total":  1247,
+  "limit":  50,
+  "offset": 0
+}
+```
+
+`total` is the count under the same WHERE clause (cheap on the
+retention-capped DB). `items` is ordered newest-first
+(`ORDER BY ts_unix_nano DESC, id DESC`).
+
+`limit` is **clamped at 500** server-side. A client asking for 1000
+gets 500 back with `limit: 500` in the response — no error, no surprise
+empty page.
+
+### Read-side RBAC: `X-Audit-Scope`
+
+Two scopes, returned as a response header:
+
+- **`X-Audit-Scope: self`** — the server **hard-overrides** the
+  `actor` filter to the caller's own subject regardless of what the
+  client passed. The caller can self-audit but never sees what
+  colleagues did.
+- **`X-Audit-Scope: all`** — the caller can query any actor's rows.
+
+Resolution order (in `auditQueryHandler`, delegating to
+`authz.Resolver.IsAuditAdmin`):
+
+1. **`auth.authorization.auditAdminGroups`** — explicit operator
+   switch. If non-empty, scope is `all` iff any of the user's IdP
+   groups appears in the list. **Wins regardless of authz mode**.
+2. **Mode-specific fallback:**
+
+   | Mode | Default audit-admin |
+   |---|---|
+   | `tier`   | Users whose resolved tier is `admin` |
+   | `shared` | Users in `allowedGroups` (only when that list is non-empty) |
+   | `raw`    | Nobody — must use `auditAdminGroups` explicitly |
+
+3. Otherwise → `self`.
+
+`auditAdminGroups` is matched against the user's **raw IdP groups** (no
+prefix), even in raw mode where K8s impersonation prefixes them. This
+is intentional: audit-admin is decoupled from K8s admin so a security
+team can read history without needing cluster-mutation power.
+
+The SPA reads `X-Audit-Scope` to render a banner explaining the scope
+to the user, and consults `/api/whoami` (which returns `auditEnabled`
+and `auditScope`) to hide audit nav when the feature is off.
+
+---
+
+## 12. Compatibility and forward evolution
+
+### What is covered by semver
+
+- **Verb names and outcome names** (the closed enums).
+- **Top-level event field names** in JSON (`actor.sub`, `verb`,
+  `outcome`, `cluster`, `resource.{group,version,resource,namespace,name}`,
+  `reason`, `extra`).
+- **`extra` field names** for already-shipped verbs.
+- **`/api/audit` query param names** and response field names.
+- **Sink interface** (`Record(ctx, evt)`).
+- **Reader interface** (`Query(ctx, args) → result, error`).
+
+### What is NOT covered by semver
+
+- Stdout slog field ordering (slog does not guarantee key order
+  anyway).
+- Internal SQL queries, index names, PRAGMA values.
+- The `route` field (debug aid, not persisted).
+- Prune algorithm details (single-shot vs loop, headroom factor).
+- Specific error wording in `reason` — that's `err.Error()` from
+  client-go, which is upstream-defined and itself not semver-stable.
+
+### Adding a verb (minor version)
+
+1. Add the constant in `internal/audit/event.go`.
+2. Update §4 of this RFC with the emission site, outcome classes, and
+   `extra` shape.
+3. Wire the emission at the handler. Reuse `actorFromContext` and
+   `outcomeFor`.
+4. No schema migration needed — verb is a TEXT column.
+
+### Adding a column (minor version)
+
+1. Append a new migration to `migrations` in `sqlite_sink.go`.
+2. Add the column to the Go struct and the `Row` JSON tags.
+3. Update §6 (top-level shape) and §9 (schema) of this RFC.
+4. Old rows return NULL → empty in JSON, which existing clients
+   already tolerate for the existing nullable columns.
+
+### Renaming or removing a verb / column / field (major version)
+
+Lands in v2 with a documented migration. The schema version refusal
+in `runMigrations` (a binary at v1 refuses to open a DB at v2) means
+operators must roll forward, but not cliff-edge: the v2 binary reads
+v1 DBs.
+
+---
+
+## 13. Security considerations
+
+**Tamper resistance.** v1.0 trusts the operator with disk access. An
+admin who can `kubectl exec` into the pod can edit `audit.db` directly.
+The mitigations in v1.0 are:
+- Stdout shipping to an external SIEM (operator's responsibility) gives
+  an out-of-band copy that the in-pod admin cannot retroactively edit.
+- Read-only root filesystem and dropped capabilities limit casual
+  tampering from inside the container — but the audit volume is
+  necessarily writable to the periscope process.
+
+v2 adds hash-chain signing: each row carries a hash of the previous
+row, signed by a per-pod key. An operator can detect retroactive edits
+(any break in the chain) without preventing them. The ledger is
+verified on read.
+
+**Sensitive data in `reason`.** `reason` is `err.Error()` from
+client-go on failure paths. Kubernetes error strings can contain
+resource names, namespaces, even snippets of the rejected payload.
+Treat `reason` as roughly the same sensitivity as an apiserver audit
+log line: visible to anyone with audit-read access. The `secret_reveal`
+verb itself only records the secret **key name** and the **size** of
+the decoded value, never the value.
+
+**Sensitive data in `extra`.** Schema-level discipline: contributors
+adding `extra` keys for new verbs review them against this list:
+
+- ✅ identifiers, sizes, durations, exit codes, transport names,
+  session IDs, command vectors (the user *typed* them, audit shows them)
+- ❌ stdin payloads, secret values, kubeconfig contents, AWS
+  credentials, OIDC access tokens, raw response bodies, manifest YAML
+
+The exec stdin/stdout payload **never** appears in audit fields
+(`bytes_stdin` / `bytes_stdout` are byte counts, not contents). RFC
+0001 §17 acceptance criterion #7 enforces this with a test.
+
+**RBAC bypass risk.** The `actor` filter override is **server-side**
+in `auditQueryHandler`. There is no client-supplied way to escape it
+when the resolver returns `self` scope — the server overwrites the
+field unconditionally, ignoring whatever the client sent. The
+`X-Audit-Scope` header lets the SPA render the right banner; it is
+not load-bearing for security.
+
+---
+
+## 14. Acceptance criteria
+
+The audit pipeline is complete (v1.0) when:
+
+1. Every privileged handler in `cmd/periscope/` (apply, delete,
+   trigger, secret_reveal, exec_open, exec_close) emits exactly one
+   `audit.Event` per request lifecycle, with `Outcome` set on every
+   non-canceled path.
+2. The `Verb` and `Outcome` constants are the only string sources
+   for those fields — no free-string literals at emission sites
+   (`grep -rn 'audit.Event{' cmd/ internal/` shows only constant
+   verbs).
+3. `OpenSQLiteSink` failures (mkdir, open, ping, migrate, prepare)
+   leave the pod Ready with stdout-only audit and `/api/audit`
+   unregistered.
+4. `Record` errors during normal operation log at `slog.Error` and
+   never propagate to the calling handler (verified by
+   `sqlite_sink_test.go`).
+5. The retention loop honors both caps independently and the
+   "both zero" combo is rejected at startup with a `slog.Warn`.
+6. A binary at schema v1 refuses to open a DB at schema v2.
+7. `GET /api/audit` returns `404` when SQLite is off.
+8. `GET /api/audit` with no admin grant returns `X-Audit-Scope: self`
+   and ignores any client-supplied `actor=` parameter
+   (`audit_handler_test.go` covers both directions).
+9. `limit > 500` is silently clamped to 500.
+10. RFC 0001 §17 #7 (no stdin payloads in any audit field) holds.
+
+All ten are met as of v1.0.0.
+
+---
+
+## 15. Future work
+
+- **v1.x — Postgres backend.** Same `Sink` and `Reader` interfaces,
+  same column set, different driver. Lifts the single-replica
+  constraint. The `Reader` interface in
+  `internal/audit/reader.go:10` was carved out for exactly this.
+- **v1.x — `log_open` emission.** Wire the reserved verb behind a
+  rate-aware emitter so a tail-follow doesn't flood the table.
+- **v2 — hash-chain signing.** Append a `prev_hash` column and a
+  per-pod signing key. Verify on read.
+- **v2 — external SIEM contract.** Document a stable JSON schema
+  version (`schema_version` field) so downstream parsers don't need
+  to track Periscope versions.
+
+---
+
+## 16. Appendix — references
+
+- [`internal/audit/event.go`](../../internal/audit/event.go) — `Event`, `Verb`, `Outcome`, `Actor`, `ResourceRef`
+- [`internal/audit/emitter.go`](../../internal/audit/emitter.go) — fanout
+- [`internal/audit/sink.go`](../../internal/audit/sink.go) — `Sink` interface, `StdoutSink`
+- [`internal/audit/sqlite_sink.go`](../../internal/audit/sqlite_sink.go) — schema, retention, query
+- [`internal/audit/reader.go`](../../internal/audit/reader.go) — `Reader` interface, `QueryArgs`, `Row`
+- [`internal/audit/context.go`](../../internal/audit/context.go) — `RequestContext`, `PatchActor`
+- [`cmd/periscope/audit_handler.go`](../../cmd/periscope/audit_handler.go) — `/api/audit` HTTP handler
+- [`cmd/periscope/errors.go`](../../cmd/periscope/errors.go) — `outcomeFor`, `actorFromContext`
+- [`docs/setup/audit.md`](../setup/audit.md) — operator-facing guide
+- RFC 0001 §10 — pre-existing exec audit-event shape, preserved by `StdoutSink`
+- RFC 0002 §3 — actor identity sources (OIDC subject, IdP groups)

--- a/docs/setup/audit.md
+++ b/docs/setup/audit.md
@@ -51,7 +51,9 @@ The default is `false` — opt-in. When off:
 ### Helm values ↔ env var mapping
 
 The chart templates each `audit.*` value to a `PERISCOPE_AUDIT_*`
-env var on the pod. Useful when debugging what's actually applied:
+env var on the pod. Useful when debugging what's actually applied;
+the central reference for every Periscope env var (with semver
+coverage) is [`environment-variables.md`](environment-variables.md).
 
 | Helm value | Env var | Required when `audit.enabled=true` |
 |---|---|---|

--- a/docs/setup/audit.md
+++ b/docs/setup/audit.md
@@ -12,6 +12,11 @@ This page covers both halves of the feature:
 - **RBAC** — who can read the persisted history via `GET /api/audit`,
   and how to grant that access in each authz mode.
 
+For the formal contract — the closed verb taxonomy, the wire-stable
+event schema, the SQLite schema, retention semantics, semver coverage,
+and the security model around tamper resistance — see
+[RFC 0003](../rfcs/0003-audit-log.md).
+
 ## Quick decision tree
 
 ```

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -30,7 +30,7 @@ shape itself), see [`docs/setup/deploy.md`](deploy.md).
 | `PERISCOPE_WATCH_STREAMS` | `all` | Which kinds get an SSE watch route | `watchStreams.kinds` |
 | `PERISCOPE_WATCH_PER_USER_LIMIT` | `60` | Concurrent watch streams per user | `watchStreams.perUserLimit` |
 | `PERISCOPE_PROBE_CLUSTERS_ON_BOOT` | _(unset)_ | `1` to seed exec circuit breakers at boot | `exec.probeClustersOnBoot` |
-| `PERISCOPE_DEV_ALLOW_ORIGINS` | _(unset)_ | Extra WebSocket origins (dev only) | _(no Helm value — see §6)_ |
+| `PERISCOPE_DEV_ALLOW_ORIGINS` | _(unset)_ | Extra WebSocket origins (dev only) | _(no Helm value — see 6)_ |
 
 Empty / unset values fall back to the documented default. Negative or
 non-numeric values where a positive integer is expected fall back to
@@ -143,7 +143,7 @@ How often the prune+VACUUM loop runs. Go duration syntax (`24h`,
 hammering disk.
 
 The retention and prune algorithms are specified in
-[RFC 0003 §10](../rfcs/0003-audit-log.md).
+[RFC 0003 10](../rfcs/0003-audit-log.md).
 
 ---
 
@@ -285,7 +285,7 @@ oidc:
   # or:
   clientSecret: file:///run/secrets/oidc  # file read
   # or:
-  clientSecret: aws-secrets-manager://...  # AWS Secrets Manager
+  clientSecret: aws-secretsmanager://...  # AWS Secrets Manager
   clientSecret: aws-ssm://...              # AWS SSM Parameter Store
 ```
 
@@ -323,7 +323,7 @@ exceptions worth knowing:
 
 ## 10. Compatibility and forward evolution
 
-Env var names that appear in §1–§6 are **part of the v1.0 public
+Env var names that appear in 1–6 are **part of the v1.0 public
 configuration surface**. They are covered by the same semver
 promise as the HTTP API:
 
@@ -337,7 +337,7 @@ promise as the HTTP API:
 - Tightening parsing (rejecting a previously-tolerated value) is
   breaking.
 
-Variables in §7 are explicitly **not covered** — they're for
+Variables in 7 are explicitly **not covered** — they're for
 development workflows and may change shape between releases.
 
 ---
@@ -346,9 +346,6 @@ development workflows and may change shape between releases.
 
 Likely additions in v1.x:
 
-- `PERISCOPE_AUDIT_BACKEND=postgres` plus `PERISCOPE_AUDIT_DSN=...`
-  when the Postgres audit backend lands (RFC 0003 §15). The
-  `_DB_PATH` knob will continue to exist for SQLite.
 - `PERISCOPE_SESSION_STORE=redis` plus `PERISCOPE_SESSION_DSN=...`
   when the multi-replica session store lands.
 - `PERISCOPE_LOG_LEVEL` for runtime log-level tuning. Today the

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -1,0 +1,359 @@
+# Environment variables
+
+Centralized reference for every environment variable the Periscope
+binary reads. The Helm chart renders most of these from
+`values.yaml`; this page is the source of truth when something
+doesn't match what you expect.
+
+For Helm-side configuration that **doesn't** map to an env var
+(volumes, RBAC, ingress, image pull policy, the cluster registry
+shape itself), see [`docs/setup/deploy.md`](deploy.md).
+
+## At a glance
+
+| Variable | Default | Purpose | Helm value |
+|---|---|---|---|
+| `PORT` | `8080` | HTTP listen port | `service.port` |
+| `PERISCOPE_AUTH_MODE` | _(inferred from file)_ | `oidc` or `dev` | _(none — set via auth file)_ |
+| `PERISCOPE_AUTH_FILE` | _(unset = dev mode)_ | Path to auth config YAML | _(fixed: `/etc/periscope/auth.yaml`)_ |
+| `PERISCOPE_CLUSTERS_FILE` | _(unset = empty registry)_ | Path to cluster registry YAML | _(fixed: `/etc/periscope/clusters.yaml`)_ |
+| `PERISCOPE_AUDIT_ENABLED` | `false` | Open the SQLite audit sink at startup | `audit.enabled` |
+| `PERISCOPE_AUDIT_DB_PATH` | `/var/lib/periscope/audit/audit.db` | SQLite file path | _(fixed by chart)_ |
+| `PERISCOPE_AUDIT_RETENTION_DAYS` | `30` | Age cap (`0` disables) | `audit.retentionDays` |
+| `PERISCOPE_AUDIT_MAX_SIZE_MB` | `1024` | Size cap (`0` disables) | `audit.maxSizeMB` |
+| `PERISCOPE_AUDIT_VACUUM_INTERVAL` | `24h` | Prune+VACUUM loop period | `audit.vacuumInterval` |
+| `PERISCOPE_EXEC_IDLE_SECONDS` | `600` | Server-side exec idle timeout | `exec.serverIdleSeconds` |
+| `PERISCOPE_EXEC_IDLE_WARN_SECONDS` | `30` | Warn-before-tear-down lead | `exec.idleWarnSeconds` |
+| `PERISCOPE_EXEC_HEARTBEAT_SECONDS` | `20` | Exec WebSocket ping period | `exec.heartbeatSeconds` |
+| `PERISCOPE_EXEC_MAX_SESSIONS_PER_USER` | `5` | Concurrent exec sessions per user | `exec.maxSessionsPerUser` |
+| `PERISCOPE_EXEC_MAX_SESSIONS_TOTAL` | `50` | Concurrent exec sessions across all users | `exec.maxSessionsTotal` |
+| `PERISCOPE_WATCH_STREAMS` | `all` | Which kinds get an SSE watch route | `watchStreams.kinds` |
+| `PERISCOPE_WATCH_PER_USER_LIMIT` | `60` | Concurrent watch streams per user | `watchStreams.perUserLimit` |
+| `PERISCOPE_PROBE_CLUSTERS_ON_BOOT` | _(unset)_ | `1` to seed exec circuit breakers at boot | `exec.probeClustersOnBoot` |
+| `PERISCOPE_DEV_ALLOW_ORIGINS` | _(unset)_ | Extra WebSocket origins (dev only) | _(no Helm value — see §6)_ |
+
+Empty / unset values fall back to the documented default. Negative or
+non-numeric values where a positive integer is expected fall back to
+the default and emit a `slog.Warn` line at startup.
+
+---
+
+## 1. Server / runtime
+
+### `PORT`
+
+The HTTP listening port. Default `8080`. Set by the Helm chart from
+`service.port` so the container port and the K8s `Service` stay in
+sync.
+
+This is the only non-`PERISCOPE_*` env var the binary reads; the
+`PORT` name is conventional for Twelve-Factor / containerized apps.
+
+---
+
+## 2. Authentication
+
+See [`docs/setup/auth0.md`](auth0.md) / [`docs/setup/okta.md`](okta.md)
+for the IdP wiring; [RFC 0002](../rfcs/0002-auth.md) for the design
+contract.
+
+### `PERISCOPE_AUTH_FILE`
+
+Path to the auth YAML file. The Helm chart always renders the file
+at `/etc/periscope/auth.yaml` and sets this env var to that path —
+operators don't normally touch it. Only override when running
+locally with a hand-rolled file:
+
+```sh
+PERISCOPE_AUTH_FILE=$(pwd)/examples/config/auth.yaml.okta make backend
+```
+
+When unset and `PERISCOPE_AUTH_MODE` is empty / `dev`, the binary
+runs in dev mode with the built-in `dev@local` actor — useful for
+SPA development and tests, **never for production**.
+
+### `PERISCOPE_AUTH_MODE`
+
+Optional. Forces the auth mode regardless of what the auth file
+implies. Two values:
+
+- `dev` — runs every request as the `Default()` dev actor
+  (`subject: dev@local`, `groups: [dev]`). The login screen is
+  skipped.
+- `oidc` — requires `PERISCOPE_AUTH_FILE` to point at a valid file
+  with a populated `oidc:` block; otherwise the binary fails to
+  start with a clear error.
+
+Resolution when both are unset: if the file has an `oidc.issuer`,
+the mode is `oidc`; otherwise `dev`.
+
+---
+
+## 3. Cluster registry
+
+### `PERISCOPE_CLUSTERS_FILE`
+
+Path to the cluster registry YAML. The Helm chart always renders
+the file at `/etc/periscope/clusters.yaml` and sets this env var to
+that path. When unset, the binary boots with an empty registry and
+logs a warning — the SPA renders the empty-state fleet view.
+
+The file shape is documented in
+[`examples/config/clusters.yaml`](../../examples/config/clusters.yaml)
+and [`docs/setup/deploy.md`](deploy.md).
+
+---
+
+## 4. Audit log
+
+Full operator guide: [`docs/setup/audit.md`](audit.md). Formal
+contract: [RFC 0003](../rfcs/0003-audit-log.md).
+
+### `PERISCOPE_AUDIT_ENABLED`
+
+`true` opens the SQLite audit sink at startup. Anything else
+(empty, `false`, `1`, `yes`) leaves audit at stdout-only. The
+exact-string match is intentional: a malformed value defaults to
+off rather than silently enabling persistence.
+
+### `PERISCOPE_AUDIT_DB_PATH`
+
+Path to the SQLite DB file. Default
+`/var/lib/periscope/audit/audit.db`. The directory is created at
+startup if missing. The Helm chart pins this path and mounts the
+PVC (or `emptyDir`) at the parent directory.
+
+### `PERISCOPE_AUDIT_RETENTION_DAYS`
+
+Age-based prune cap. Default `30`. Set to `0` to disable
+time-based pruning (the size cap still applies). Setting **both**
+`RETENTION_DAYS` and `MAX_SIZE_MB` to `0` is the unbounded-growth
+footgun; the startup validator emits a `slog.Warn` line.
+
+### `PERISCOPE_AUDIT_MAX_SIZE_MB`
+
+Size-based prune cap. Default `1024`. Set to `0` to disable. The
+prune loop estimates `(size − target) / size × rowCount × 1.1` rows
+to drop, removes them in one DELETE, then VACUUMs.
+
+### `PERISCOPE_AUDIT_VACUUM_INTERVAL`
+
+How often the prune+VACUUM loop runs. Go duration syntax (`24h`,
+`6h`, `30m`). Default `24h`. Below `1m` the validator warns about
+hammering disk.
+
+The retention and prune algorithms are specified in
+[RFC 0003 §10](../rfcs/0003-audit-log.md).
+
+---
+
+## 5. Pod exec
+
+Full operator guide: [`docs/setup/pod-exec.md`](pod-exec.md). Design:
+[RFC 0001](../rfcs/0001-pod-exec.md).
+
+These five variables set the **global defaults** applied to every
+cluster's sessions. Per-cluster overrides live in
+`clusters[i].exec.*` (see `examples/config/clusters.yaml`) and
+merge on top of these globals — the cluster value wins when set
+to a positive number.
+
+### `PERISCOPE_EXEC_IDLE_SECONDS`
+
+Server-side idle timeout. Default `600` (10 minutes). After this
+many seconds with no I/O, the server tears the session down. The
+SPA shows a warning `IDLE_WARN_SECONDS` before the tear-down so
+the user can keep typing to reset the timer.
+
+### `PERISCOPE_EXEC_IDLE_WARN_SECONDS`
+
+Lead time for the idle warning banner. Default `30`. Must be
+smaller than `IDLE_SECONDS` to do anything useful.
+
+### `PERISCOPE_EXEC_HEARTBEAT_SECONDS`
+
+WebSocket ping period. Default `20`. Lets the server detect
+half-open connections and keeps intermediaries (proxies, load
+balancers) from tearing the connection down for inactivity.
+
+### `PERISCOPE_EXEC_MAX_SESSIONS_PER_USER`
+
+Per-user concurrent exec session cap. Default `5`. The 6th open
+attempt returns `HTTP 429 E_CAP_USER` with a JSON body listing the
+user's active sessions for the SPA to surface as "you have 5
+shells open; close one before opening another."
+
+### `PERISCOPE_EXEC_MAX_SESSIONS_TOTAL`
+
+Process-wide concurrent exec session cap. Default `50`.
+Cluster-aware (see RFC 0001 PR4 — the per-cluster split is
+`E_CAP_CLUSTER`).
+
+---
+
+## 6. Watch streams (SSE)
+
+Full operator guide: [`docs/setup/watch-streams.md`](watch-streams.md).
+Design: [`docs/architecture/watch-streams.md`](../architecture/watch-streams.md).
+
+### `PERISCOPE_WATCH_STREAMS`
+
+Selects which resource kinds get an SSE watch route registered.
+Grammar:
+
+```
+""           # unset = "all"
+"all"        # every registered kind (~22)
+"off"        # no SSE; SPA falls back to polling everywhere
+"none"       # synonym for "off"
+"pods"       # one kind
+"workloads"  # group alias (deployments, statefulsets, daemonsets, replicasets, jobs, cronjobs, hpas, pdbs)
+"core,workloads,networking"   # multiple groups
+"pods,workloads"              # mixed kinds and groups
+```
+
+Group aliases: `core`, `workloads`, `networking`, `storage`,
+`cluster`. The kind ↔ group mapping is the `watchKinds` registry
+in `cmd/periscope/main.go`. Unknown tokens are silently dropped;
+operators see a startup `slog` line summarizing what's enabled, so
+typos surface immediately.
+
+Default is "all on" because the SSE plumbing has a per-user stream
+cap and a tested polling-fallback path — restrictive proxies that
+mishandle long-lived connections degrade gracefully, but if you
+know yours doesn't, set `off` to skip the upgrade dance.
+
+### `PERISCOPE_WATCH_PER_USER_LIMIT`
+
+Caps concurrent watch streams per OIDC subject across all clusters
+and kinds. Default `60` (≈ 10 tabs × 6 list views). Exceeding the
+cap returns `HTTP 429`; the SPA falls back to polling for that
+view.
+
+The cap protects the apiserver's watch quota from a runaway
+client. As more kinds gain SSE streams, this grows linearly with
+realistic usage; bump if `/debug/streams` shows users hitting the
+ceiling.
+
+---
+
+## 7. Development and debug
+
+These exist for development convenience and are **not** part of the
+v1.0 public configuration surface — treat them as breakable.
+
+### `PERISCOPE_PROBE_CLUSTERS_ON_BOOT`
+
+Set to `1` to fire a one-shot `/bin/true` exec against every
+registered cluster at boot, seeding the per-cluster transport
+circuit breaker before the first user click. Useful in environments
+where the EKS apiserver's WebSocket-vs-SPDY behavior is known
+ahead of time. Off by default; the breaker self-recovers from a
+cold start within the first user session anyway.
+
+Helm rendering: `exec.probeClustersOnBoot: true` emits the env var
+with value `"1"`.
+
+### `PERISCOPE_DEV_ALLOW_ORIGINS`
+
+Comma-separated list of WebSocket Origin headers to allow on the
+exec endpoint, beyond the same-origin default. Used for local
+dev (Vite proxy on `:5173` → backend on `:8088`) and embedded
+scenarios. v1.0 default is **same-origin only**; set this only
+when the backend's bind origin and the SPA's serve origin
+genuinely differ and you accept the implications.
+
+```sh
+PERISCOPE_DEV_ALLOW_ORIGINS=localhost:5173,127.0.0.1:5173 make backend
+```
+
+There is **no Helm value** for this — production ingress should
+serve the SPA and the backend from the same origin, making the
+allowlist unnecessary.
+
+---
+
+## 8. Secret references inside config files
+
+The auth YAML and clusters YAML support env-var interpolation for
+sensitive fields (OIDC client secret, optionally a kubeconfig
+path). Syntax:
+
+```yaml
+oidc:
+  clientSecret: ${OIDC_CLIENT_SECRET}     # env-var lookup
+  # or:
+  clientSecret: file:///run/secrets/oidc  # file read
+  # or:
+  clientSecret: aws-secrets-manager://...  # AWS Secrets Manager
+  clientSecret: aws-ssm://...              # AWS SSM Parameter Store
+```
+
+For `${VAR}` references, the resolver calls `os.LookupEnv(VAR)` at
+startup. The most common name is `OIDC_CLIENT_SECRET`, which the
+Helm chart wires up automatically when `secrets.mode != native` —
+the chart mounts a K8s Secret as that env var so the auth YAML's
+`${OIDC_CLIENT_SECRET}` resolves cleanly.
+
+Secret-resolver implementation:
+[`internal/secrets/resolver.go`](../../internal/secrets/resolver.go).
+
+---
+
+## 9. Helm chart vs raw env vars
+
+The Helm chart renders most env vars from `values.yaml`. Two
+exceptions worth knowing:
+
+- **Always-set, fixed**: `PERISCOPE_AUTH_FILE`, `PERISCOPE_CLUSTERS_FILE`,
+  and `PERISCOPE_AUDIT_DB_PATH` are pinned to specific paths the
+  chart mounts files at. Don't try to override these from
+  `values.yaml.env`; the chart's own env list wins.
+- **Conditionally rendered**: `PERISCOPE_WATCH_STREAMS` and
+  `PERISCOPE_WATCH_PER_USER_LIMIT` are only emitted when their
+  values.yaml fields are non-empty / non-zero. The server defaults
+  to "all on" / `60` when unset, so leaving them out of `values.yaml`
+  is the right choice for most deployments.
+- **Escape hatch**: `values.yaml.env` is appended after the
+  rendered env list, so an operator can add an arbitrary
+  `name: value` pair (e.g. for a future `PERISCOPE_*` var that
+  doesn't have a values.yaml field yet) without forking the chart.
+
+---
+
+## 10. Compatibility and forward evolution
+
+Env var names that appear in §1–§6 are **part of the v1.0 public
+configuration surface**. They are covered by the same semver
+promise as the HTTP API:
+
+- Renaming a variable is a breaking change → next major.
+- Removing a variable is a breaking change → next major.
+- Changing the default value of a variable is **not** a breaking
+  change provided the new default is "more conservative" (smaller
+  cap, shorter retention, etc.) and is documented in the
+  `CHANGELOG.md` under the corresponding release.
+- Adding a new variable is additive (minor / patch).
+- Tightening parsing (rejecting a previously-tolerated value) is
+  breaking.
+
+Variables in §7 are explicitly **not covered** — they're for
+development workflows and may change shape between releases.
+
+---
+
+## 11. Forward roadmap
+
+Likely additions in v1.x:
+
+- `PERISCOPE_AUDIT_BACKEND=postgres` plus `PERISCOPE_AUDIT_DSN=...`
+  when the Postgres audit backend lands (RFC 0003 §15). The
+  `_DB_PATH` knob will continue to exist for SQLite.
+- `PERISCOPE_SESSION_STORE=redis` plus `PERISCOPE_SESSION_DSN=...`
+  when the multi-replica session store lands.
+- `PERISCOPE_LOG_LEVEL` for runtime log-level tuning. Today the
+  binary uses `slog.Default()` at info; level overrides require a
+  rebuild.
+
+These will be additive — operators who don't set them get the
+SQLite / in-memory / info-level defaults that v1.0 ships with.

--- a/docs/setup/pod-exec.md
+++ b/docs/setup/pod-exec.md
@@ -70,7 +70,9 @@ exec:
 
 Each value renders to a `PERISCOPE_EXEC_*` environment variable on the
 Periscope pod (or `PERISCOPE_PROBE_CLUSTERS_ON_BOOT=1` for the boot
-probe). The mapping:
+probe). The mapping below covers exec specifically; the cross-cutting
+reference for every env var the binary reads is
+[`environment-variables.md`](environment-variables.md).
 
 | Helm value | Env var | Code default |
 |---|---|---|

--- a/docs/setup/watch-streams.md
+++ b/docs/setup/watch-streams.md
@@ -82,7 +82,10 @@ the pod. Useful when debugging what's actually applied:
 | Helm value | Env var | Notes |
 |---|---|---|
 | `watchStreams.kinds` | `PERISCOPE_WATCH_STREAMS` | Only rendered when non-empty (server default is "all on" when env is unset) |
-| `watchStreams.perUserLimit` | `PERISCOPE_WATCH_PER_USER_LIMIT` | Only rendered when non-zero |
+| `watchStreams.perUserLimit` | `PERISCOPE_WATCH_PER_USER_LIMIT` | Only rendered when non-zero (server default `60`) |
+
+The central reference for every Periscope env var is
+[`environment-variables.md`](environment-variables.md).
 
 ---
 

--- a/examples/config/auth.yaml.auth0
+++ b/examples/config/auth.yaml.auth0
@@ -46,7 +46,7 @@ session:
 authorization:
   # K8s authorization mode: shared (default) | tier | raw.
   # See docs/setup/cluster-rbac.md.
-  moe: shared
+  mode: shared
 
   # tier-mode only — map your existing Auth0 groups to one of
   # read / triage / write / maintain / admin. Leave empty in

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -196,8 +196,11 @@ func LoggedOutHandler() http.HandlerFunc {
 	}
 }
 
-// WhoamiHandler returns {subject, email, groups, mode, expiresAt} for
-// the current session. Used by the SPA's <AuthProvider> on first load.
+// WhoamiHandler returns the full session introspection payload for the
+// current session: subject, email, groups, mode, authzMode, tier (when
+// the resolver is in tier mode), auditEnabled, auditScope (when audit
+// is on), and expiresAt. Used by the SPA's <AuthProvider> on first
+// load, by the user menu, and by audit-nav gating.
 func WhoamiHandler(store SessionStore, cfg Config, resolver *authz.Resolver, auditEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		s, ok := SessionFromContext(r.Context())


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for Periscope v1.0's public API contract, audit log specification, and configuration surface. Three new reference documents formalize the stability guarantees and operational requirements for the stable release.

## Key changes

- **`docs/api.md`** — HTTP API reference documenting:
  - Three stability tiers (Tier 1: stable paths/methods/fields; Tier 2: SPA-coupled with additive field evolution; Tier 3: live channels)
  - Authentication modes (OIDC + PKCE, dev mode) and session/cookie contract
  - Tier 1 stable endpoints (`/healthz`, `/api/auth/*`, `/api/whoami`, `/api/features`, `/api/clusters`, `/api/fleet`, `/api/audit`, `/api/clusters/{c}/can-i`)
  - Eight Tier 2 patterns (list, detail, yaml, events, logs, apply, delete, meta) covering ~130 resource endpoints
  - Error code enum and versioning policy (no `/v1/` prefix in v1.0; `/api/v2/...` for future breaking changes)

- **`docs/rfcs/0003-audit-log.md`** — Formal audit log specification covering:
  - Closed verb taxonomy (`apply`, `delete`, `trigger`, `secret_reveal`, `exec_open`, `exec_close`)
  - Outcome classification (`success`, `denied`, `failure`)
  - Wire-stable JSON event schema with semver-covered field names
  - SQLite schema (v1) with indexes, PRAGMAs, and migration strategy
  - Retention semantics (age + size caps, prune algorithm, VACUUM)
  - Read-side RBAC (`X-Audit-Scope: self|all`)
  - Security model: operator-trust in v1.0; hash-chain signing deferred to v2

- **`docs/setup/environment-variables.md`** — Centralized reference for all `PERISCOPE_*` env vars:
  - Server/runtime (`PORT`)
  - Authentication (`PERISCOPE_AUTH_FILE`, `PERISCOPE_AUTH_MODE`)
  - Cluster registry (`PERISCOPE_CLUSTERS_FILE`)
  - Audit log (`PERISCOPE_AUDIT_*` family)
  - Pod exec (`PERISCOPE_EXEC_*` family)
  - Watch streams (`PERISCOPE_WATCH_*` family)
  - Helm value mappings and semver coverage rules

- **`CHANGELOG.md`** — Initial changelog documenting v1.0.0 release with feature summary and v1.x roadmap

- **Version bumps** — Helm chart version updated to 1.0.0 in `Chart.yaml`

- **Documentation fixes**:
  - Fixed typo in `examples/config/auth.yaml.auth0` (`moe` → `mode`)
  - Corrected stale default in `docs/architecture/watch-streams.md` (per-user limit: 30 → 60)
  - Added cross-references in `docs/setup/audit.md` and `docs/setup/pod-exec.md` to new environment variables doc

## Notable implementation details

- The API reference explicitly documents what is **not** covered by semver: slog field ordering, internal cache TTLs, `/debug/*` paths, error message prose (only error classification is stable), and anything outside `/api/*` or `/healthz`
- Audit schema is append-only; migrations never edit shipped entries to protect production DBs
- Session state is in-memory only in v1.0 (single-replica deployment when audit is enabled); Redis/Postgres backend deferred to v1.x
- Bearer tokens / API keys not supported in v1.0; service account lane deferred post-v1
- The three authorization modes (`shared`, `tier`, `raw`) are documented as configuration options with RBAC implications

https://claude.ai/code/session_01C9MsonTLY9DPKLCfs5r5hB