### PR TITLE
fix(agent): split registration + tunnel URLs, SPKI pinning, dynamic Brand version, AH auto-claim (closes #48)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -242,6 +242,38 @@ jobs:
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope-agent:${VERSION}@${DIGEST}"
 
+      # ── Artifact Hub repository metadata ──────────────────────
+      #
+      # AH proves the repo is owned by us by matching the
+      # repositoryID in the metadata layer pushed to the chart's
+      # `:artifacthub.io` tag against the UUID AH assigned at
+      # registration. Re-pushing on every release keeps the claim
+      # current — if we forget once and the metadata file content
+      # drifts (e.g. owner email change), the next release re-asserts.
+      # Idempotent: pushing the same content under the same tag is
+      # a no-op at the registry level.
+      #
+      # Auth: oras reads ~/.docker/config.json which docker/login-
+      # action@v3 (server-image step above) already populated. No
+      # separate login needed.
+      - name: Set up oras
+        uses: oras-project/setup-oras@v1
+        with:
+          version: latest
+
+      - name: Push Artifact Hub metadata (server chart)
+        run: |
+          oras push ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope:artifacthub.io \
+            --config=/dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            deploy/helm/periscope/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+
+      - name: Push Artifact Hub metadata (agent chart)
+        run: |
+          oras push ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope-agent:artifacthub.io \
+            --config=/dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            deploy/helm/periscope-agent/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+
+
       # ── GitHub Release ─────────────────────────────────────────
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/cmd/periscope-agent/bootstrap.go
+++ b/cmd/periscope-agent/bootstrap.go
@@ -55,7 +55,17 @@ func registerAndSign(ctx context.Context, cfg agentConfig) (*agentState, error) 
 	}
 
 	// 3. POST to /api/agents/register.
-	registerURL, err := registerEndpoint(cfg.ServerURL)
+	//
+	// Endpoint resolution: prefer cfg.RegistrationURL when set
+	// (operator opt-in for the ALB+NLB topology where HTTP and
+	// mTLS terminate on different load balancers — #48). Falls
+	// back to wss/ws → https/http translation of cfg.ServerURL,
+	// which is correct for the single-LB topology.
+	endpointSource := cfg.RegistrationURL
+	if endpointSource == "" {
+		endpointSource = cfg.ServerURL
+	}
+	registerURL, err := registerEndpoint(endpointSource)
 	if err != nil {
 		return nil, err
 	}
@@ -71,13 +81,20 @@ func registerAndSign(ctx context.Context, cfg agentConfig) (*agentState, error) 
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
-		// On first boot we don't yet know the server's CA — fall
-		// back to system roots, which works in the common case where
-		// the operator put a public-CA cert on the ALB / ingress.
-		// For self-signed central-server scenarios we'd need a
-		// CABundle Helm value to seed; tracked as a follow-up.
+	// TLS strategy on the registration dial:
+	//   - cfg.ServerCAHash set → SPKI-hash pinning (kubeadm-style).
+	//     The pin replaces chain validation; appropriate for self-
+	//     signed central-server endpoints.
+	//   - otherwise → standard chain validation against system roots.
+	//     Works when the registration endpoint sits behind a public-
+	//     cert ALB (the common production case).
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	if cfg.ServerCAHash != "" {
+		tlsCfg, err := pinningTLSConfig(cfg.ServerCAHash)
+		if err != nil {
+			return nil, fmt.Errorf("build SPKI pin: %w", err)
+		}
+		httpClient.Transport = &http.Transport{TLSClientConfig: tlsCfg}
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/cmd/periscope-agent/bootstrap_test.go
+++ b/cmd/periscope-agent/bootstrap_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
@@ -120,4 +122,125 @@ func TestRegisterEndpoint_RejectsBadScheme(t *testing.T) {
 	if _, err := registerEndpoint("ftp://nope"); err == nil {
 		t.Fatal("registerEndpoint accepted ftp:// scheme")
 	}
+}
+
+// TestRegisterAndSign_UsesRegistrationURLOverServerURL proves that
+// when both URLs are set, the registration POST goes to
+// RegistrationURL (the ALB+NLB topology fix from #48). We stand up
+// two servers; the agent should hit the registration one and ignore
+// the tunnel one.
+func TestRegisterAndSign_UsesRegistrationURLOverServerURL(t *testing.T) {
+	store := tunnel.NewTokenStore(tunnel.TokenStoreOptions{ReapInterval: -1})
+	ca, _, _ := tunnel.GenerateCA("test-ca", tunnel.CertValidity{})
+
+	// Real registration server (mounts the handler).
+	regMux := http.NewServeMux()
+	regMux.HandleFunc("/api/agents/register", tunnel.RegisterHandler(store, ca, 0))
+	regSrv := httptest.NewServer(regMux)
+	defer regSrv.Close()
+
+	// "Tunnel" server that intentionally fails — if the agent ever
+	// hits this URL for registration the test fails fast.
+	tunnelSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("agent posted registration to ServerURL %q (path %q); should have used RegistrationURL", r.Host, r.URL.Path)
+		http.Error(w, "wrong endpoint", http.StatusTeapot)
+	}))
+	defer tunnelSrv.Close()
+
+	iss, err := store.MintToken("prod-eu")
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	cfg := agentConfig{
+		ServerURL:         tunnelSrv.URL, // would be wrong
+		RegistrationURL:   regSrv.URL,    // expected
+		ClusterName:       "prod-eu",
+		RegistrationToken: iss.Token,
+	}
+	if _, err := registerAndSign(context.Background(), cfg); err != nil {
+		t.Fatalf("registerAndSign: %v", err)
+	}
+}
+
+// TestRegisterAndSign_FallsBackToServerURL confirms backward
+// compatibility — when only ServerURL is set, registration uses it.
+func TestRegisterAndSign_FallsBackToServerURL(t *testing.T) {
+	store := tunnel.NewTokenStore(tunnel.TokenStoreOptions{ReapInterval: -1})
+	ca, _, _ := tunnel.GenerateCA("test-ca", tunnel.CertValidity{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/agents/register", tunnel.RegisterHandler(store, ca, 0))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	iss, _ := store.MintToken("prod-eu")
+	cfg := agentConfig{
+		ServerURL:         srv.URL, // RegistrationURL deliberately unset
+		ClusterName:       "prod-eu",
+		RegistrationToken: iss.Token,
+	}
+	if _, err := registerAndSign(context.Background(), cfg); err != nil {
+		t.Fatalf("registerAndSign: %v", err)
+	}
+}
+
+// TestRegisterAndSign_SPKIPinning proves the agent succeeds against
+// a self-signed registration endpoint when a correct hash is
+// supplied, and fails clearly with a wrong one.
+func TestRegisterAndSign_SPKIPinning(t *testing.T) {
+	store := tunnel.NewTokenStore(tunnel.TokenStoreOptions{ReapInterval: -1})
+	ca, _, _ := tunnel.GenerateCA("test-ca", tunnel.CertValidity{})
+
+	// httptest.NewTLSServer uses a self-signed cert — exactly the
+	// shape SPKI pinning is meant for.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/agents/register", tunnel.RegisterHandler(store, ca, 0))
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	leaf := srv.Certificate()
+	sum := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	correctHash := "sha256:" + hex.EncodeToString(sum[:])
+
+	t.Run("matching pin", func(t *testing.T) {
+		iss, _ := store.MintToken("c")
+		cfg := agentConfig{
+			ServerURL:         srv.URL,
+			ClusterName:       "c",
+			RegistrationToken: iss.Token,
+			ServerCAHash:      correctHash,
+		}
+		if _, err := registerAndSign(context.Background(), cfg); err != nil {
+			t.Fatalf("registerAndSign with matching pin: %v", err)
+		}
+	})
+
+	t.Run("mismatched pin", func(t *testing.T) {
+		iss, _ := store.MintToken("c2")
+		cfg := agentConfig{
+			ServerURL:         srv.URL,
+			ClusterName:       "c2",
+			RegistrationToken: iss.Token,
+			ServerCAHash:      "sha256:" + strings.Repeat("0", 64),
+		}
+		if _, err := registerAndSign(context.Background(), cfg); err == nil {
+			t.Fatal("registerAndSign should have failed with wrong pin")
+		} else if !strings.Contains(err.Error(), "SPKI pin mismatch") {
+			t.Fatalf("err = %v, want SPKI pin mismatch", err)
+		}
+	})
+
+	t.Run("malformed pin", func(t *testing.T) {
+		iss, _ := store.MintToken("c3")
+		cfg := agentConfig{
+			ServerURL:         srv.URL,
+			ClusterName:       "c3",
+			RegistrationToken: iss.Token,
+			ServerCAHash:      "garbage",
+		}
+		if _, err := registerAndSign(context.Background(), cfg); err == nil {
+			t.Fatal("registerAndSign should have failed with malformed pin")
+		}
+	})
 }

--- a/cmd/periscope-agent/main.go
+++ b/cmd/periscope-agent/main.go
@@ -143,6 +143,23 @@ type agentConfig struct {
 	Namespace         string
 	SecretName        string
 	HealthAddr        string
+
+	// RegistrationURL overrides the URL used for the unauth
+	// registration POST (#48). Defaults to ServerURL with wss/ws
+	// translated to https/http. Set explicitly when the server
+	// hosts the registration endpoint behind a different load
+	// balancer than the tunnel listener (e.g. ALB for HTTPS API +
+	// NLB for mTLS tunnel).
+	RegistrationURL string
+
+	// ServerCAHash, if set, enables SPKI-hash pinning on the
+	// registration TLS dial (kubeadm-style). Format: "sha256:<64
+	// hex chars>". Bypasses standard CA-chain validation; use
+	// when the registration endpoint presents a self-signed cert
+	// the agent has no prior trust anchor for. After registration
+	// the agent has the real CA bundle and uses it for the
+	// long-lived tunnel — the pin is only for the bootstrap dial.
+	ServerCAHash string
 }
 
 func loadAgentConfig() (agentConfig, error) {
@@ -153,6 +170,8 @@ func loadAgentConfig() (agentConfig, error) {
 		Namespace:         strings.TrimSpace(os.Getenv("PERISCOPE_AGENT_NAMESPACE")),
 		SecretName:        strings.TrimSpace(os.Getenv("PERISCOPE_AGENT_SECRET_NAME")),
 		HealthAddr:        strings.TrimSpace(os.Getenv("PERISCOPE_AGENT_HEALTH_ADDR")),
+		RegistrationURL:   strings.TrimSpace(os.Getenv("PERISCOPE_REGISTRATION_URL")),
+		ServerCAHash:      strings.TrimSpace(os.Getenv("PERISCOPE_SERVER_CA_HASH")),
 	}
 	if cfg.ServerURL == "" {
 		return cfg, errors.New("PERISCOPE_SERVER_URL required")

--- a/cmd/periscope-agent/spki.go
+++ b/cmd/periscope-agent/spki.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SPKI-hash pinning for the registration TLS dial. Lets operators
+// run agents against a self-signed central server (single LB, no
+// public cert) without distributing the full CA bundle.
+//
+// Pattern borrowed from kubeadm's `--discovery-token-ca-cert-hash`
+// (RFC 7469 PKP). The hash is computed over the peer certificate's
+// SubjectPublicKeyInfo, so cert rotation that preserves the key
+// (the common case for short-lived certs minted from a stable CA)
+// doesn't invalidate the pin.
+//
+// Used only during the agent's first-boot registration TLS dial to
+// the central server's HTTP endpoint. After registration succeeds
+// the agent has the real CA bundle and uses standard TLS chain
+// verification for the long-lived tunnel.
+
+// expectedHashPrefix is the only hash algorithm we accept. Mirrors
+// kubeadm's choice; SHA-256 over SPKI is the de-facto standard for
+// public-key pinning.
+const expectedHashPrefix = "sha256:"
+
+// parseSPKIHash unwraps the "sha256:<64-hex>" form into raw bytes.
+// Returns a clear error for anything that's not exactly that shape
+// — operators get a useful "expected sha256:<hex>, got X" instead
+// of a low-level decode error.
+func parseSPKIHash(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, expectedHashPrefix) {
+		return nil, fmt.Errorf("agent server CA hash: expected prefix %q, got %q", expectedHashPrefix, s)
+	}
+	hex64 := strings.TrimPrefix(s, expectedHashPrefix)
+	if len(hex64) != 64 {
+		return nil, fmt.Errorf("agent server CA hash: expected 64 hex chars after prefix, got %d", len(hex64))
+	}
+	raw, err := hex.DecodeString(hex64)
+	if err != nil {
+		return nil, fmt.Errorf("agent server CA hash: hex decode: %w", err)
+	}
+	return raw, nil
+}
+
+// computeSPKIHash returns the SHA-256 hash of the certificate's
+// SubjectPublicKeyInfo bytes (the DER-encoded SPKI structure as it
+// appears on the wire — `cert.RawSubjectPublicKeyInfo`).
+func computeSPKIHash(cert *x509.Certificate) []byte {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return sum[:]
+}
+
+// pinningTLSConfig returns a *tls.Config that performs SPKI-based
+// hash pinning against the supplied expected hash. Standard chain
+// verification is intentionally disabled (`InsecureSkipVerify: true`)
+// — the pin is the trust anchor, replacing CA-chain validation for
+// the registration dial only.
+//
+// Usage in an http.Client.Transport:
+//
+//	tlsCfg, err := pinningTLSConfig(hashHex)
+//	if err != nil { ... }
+//	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+//
+// On a hash mismatch the TLS handshake fails with our error so it
+// surfaces in the agent log with the actual computed hash for
+// comparison — the operator can copy-paste it back into the Helm
+// values if they confirm it's the right server.
+func pinningTLSConfig(expectedHashHex string) (*tls.Config, error) {
+	expectedRaw, err := parseSPKIHash(expectedHashHex)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		// We're replacing chain validation with pin validation; the
+		// VerifyPeerCertificate callback is what actually decides.
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         tls.VersionTLS12,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return errors.New("agent SPKI pin: server presented no cert")
+			}
+			leaf, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("agent SPKI pin: parse leaf: %w", err)
+			}
+			got := computeSPKIHash(leaf)
+			if !bytesEqual(got, expectedRaw) {
+				return fmt.Errorf("agent SPKI pin mismatch: server presented sha256:%s, expected sha256:%s",
+					hex.EncodeToString(got), expectedHashHex[len(expectedHashPrefix):])
+			}
+			return nil
+		},
+	}, nil
+}
+
+// bytesEqual is the constant-time comparison appropriate for hash
+// equality. Stdlib's crypto/subtle has ConstantTimeCompare; using a
+// thin wrapper here keeps the imports tidy and the call site obvious.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := range a {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}

--- a/cmd/periscope-agent/spki_test.go
+++ b/cmd/periscope-agent/spki_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSPKIHash(t *testing.T) {
+	good := "sha256:" + strings.Repeat("a", 64)
+	if _, err := parseSPKIHash(good); err != nil {
+		t.Fatalf("parseSPKIHash(good): %v", err)
+	}
+
+	bad := []struct {
+		name, in string
+	}{
+		{"missing prefix", strings.Repeat("a", 64)},
+		{"wrong prefix", "sha512:" + strings.Repeat("a", 128)},
+		{"short hex", "sha256:" + strings.Repeat("a", 32)},
+		{"long hex", "sha256:" + strings.Repeat("a", 128)},
+		{"non-hex", "sha256:" + strings.Repeat("z", 64)},
+		{"empty", ""},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSPKIHash(tc.in); err == nil {
+				t.Fatalf("parseSPKIHash(%q) accepted bad input", tc.in)
+			}
+		})
+	}
+}
+
+func TestPinningTLSConfig_HappyPath(t *testing.T) {
+	srv, expectedHash := newSelfSignedHTTPSServer(t)
+	defer srv.Close()
+
+	tlsCfg, err := pinningTLSConfig(expectedHash)
+	if err != nil {
+		t.Fatalf("pinningTLSConfig: %v", err)
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Timeout:   5 * time.Second,
+	}
+
+	resp, err := httpClient.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET with matching pin failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", body)
+	}
+}
+
+func TestPinningTLSConfig_HashMismatch(t *testing.T) {
+	srv, _ := newSelfSignedHTTPSServer(t)
+	defer srv.Close()
+
+	wrongHash := "sha256:" + strings.Repeat("0", 64)
+	tlsCfg, err := pinningTLSConfig(wrongHash)
+	if err != nil {
+		t.Fatalf("pinningTLSConfig: %v", err)
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Timeout:   5 * time.Second,
+	}
+
+	if _, err := httpClient.Get(srv.URL); err == nil {
+		t.Fatal("GET with mismatched pin should have failed")
+	} else if !strings.Contains(err.Error(), "SPKI pin mismatch") {
+		t.Fatalf("err = %v, want SPKI pin mismatch", err)
+	}
+}
+
+func TestPinningTLSConfig_RejectsBadFormat(t *testing.T) {
+	if _, err := pinningTLSConfig("not-a-hash"); err == nil {
+		t.Fatal("pinningTLSConfig accepted bad input")
+	}
+}
+
+// newSelfSignedHTTPSServer stands up an httptest TLS server using a
+// freshly-generated ECDSA leaf cert. Returns the server and the
+// SPKI-hash of its leaf in `sha256:<hex>` form so tests can assert
+// pin-match success.
+func newSelfSignedHTTPSServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	leaf := srv.Certificate()
+	sum := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	return srv, "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Compile-time: confirm we're not accidentally using deprecated
+// big.Int X/Y on the leaf cert when generating test fixtures.
+func TestSPKIHash_UsesRawSPKI(t *testing.T) {
+	// Hand-build a minimal cert and verify computeSPKIHash matches
+	// what an external SHA-256 of the SPKI bytes would produce.
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	now := time.Now().UTC()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    now,
+		NotAfter:     now.Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	cert, _ := x509.ParseCertificate(der)
+
+	got := computeSPKIHash(cert)
+	want := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	if !bytesEqual(got, want[:]) {
+		t.Fatalf("computeSPKIHash drift: %s vs %s",
+			fmt.Sprintf("%x", got), fmt.Sprintf("%x", want[:]))
+	}
+}

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -34,6 +34,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// version is set via -ldflags "-X main.version=v1.x.y" at build time
+// (see Dockerfile + .github/workflows/release.yaml). Defaults to "dev"
+// for local builds without ldflags. Surfaced to the SPA via
+// /api/features so the brand row in the header reads the deployed
+// version dynamically instead of a stale literal.
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
@@ -2075,7 +2085,19 @@ func featuresHandler(cfg watchStreamsConfig) http.HandlerFunc {
 			kinds = append(kinds, k.Name)
 		}
 	}
-	body := map[string]any{"watchStreams": kinds}
+	channel := "stable"
+	if strings.Contains(version, "-") {
+		channel = "prerelease"
+	}
+	if version == "dev" {
+		channel = "dev"
+	}
+	body := map[string]any{
+		"watchStreams": kinds,
+		"version":      version,
+		"commit":       commit,
+		"channel":      channel,
+	}
 	return func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, body)
 	}

--- a/deploy/helm/periscope-agent/README.md
+++ b/deploy/helm/periscope-agent/README.md
@@ -67,6 +67,27 @@ view flips to **healthy**.
 The `values.schema.json` enforces all three at install time so
 typos surface immediately, not at pod-start.
 
+## Optional values for split / self-signed setups (#48)
+
+| Value | Purpose |
+|---|---|
+| `agent.registrationURL` | URL for the unauth registration POST. Set when central server splits HTTP and mTLS onto different load balancers (ALB+NLB topology). Empty = derive from `serverURL` via wss/ws → https/http translation. |
+| `agent.serverCAHash` | SPKI hash for kubeadm-style pinning on the registration TLS dial. Format: `sha256:<64 hex chars>`. Bootstraps the agent against a self-signed central server endpoint without distributing the full CA bundle. |
+
+Three deployment topologies — pick the one matching your central
+server's LB shape:
+
+- **Single LB, public cert** — set `serverURL` only. Agent does
+  standard chain validation against system roots.
+- **Split LBs (ALB + NLB)** — set `serverURL` + `registrationURL`.
+  Agent registers via the public-cert ALB, tunnels via the NLB.
+- **Single LB, self-signed** — set `serverURL` + `serverCAHash`.
+  Agent SPKI-pins the registration dial, falls back to standard
+  chain validation for the tunnel after registration.
+
+Full walkthrough with worked examples for each topology:
+[`docs/setup/agent-onboarding.md`](https://github.com/gnana997/periscope/blob/main/docs/setup/agent-onboarding.md).
+
 ## Security model
 
 - The agent's mTLS cert (signed by the central server's per-deployment

--- a/deploy/helm/periscope-agent/templates/deployment.yaml
+++ b/deploy/helm/periscope-agent/templates/deployment.yaml
@@ -54,6 +54,14 @@ spec:
               value: {{ .Values.agent.stateSecretName | quote }}
             - name: PERISCOPE_AGENT_HEALTH_ADDR
               value: {{ .Values.agent.healthAddr | quote }}
+            {{- if .Values.agent.registrationURL }}
+            - name: PERISCOPE_REGISTRATION_URL
+              value: {{ .Values.agent.registrationURL | quote }}
+            {{- end }}
+            {{- if .Values.agent.serverCAHash }}
+            - name: PERISCOPE_SERVER_CA_HASH
+              value: {{ .Values.agent.serverCAHash | quote }}
+            {{- end }}
             {{- if .Values.agent.registrationToken }}
             # Bootstrap token — only needed on first boot. After
             # registration completes, the agent ignores this and

--- a/deploy/helm/periscope-agent/values.schema.json
+++ b/deploy/helm/periscope-agent/values.schema.json
@@ -43,6 +43,16 @@
           "type": "string",
           "description": "Bootstrap token from POST /api/agents/tokens. Required on first install only — leave empty on subsequent upgrades. Single-use, 15-min TTL."
         },
+        "registrationURL": {
+          "type": "string",
+          "pattern": "^($|https?://)",
+          "description": "Optional URL for the unauth registration POST. Set when central server splits HTTP and mTLS onto different LBs (#48). Empty = derive from serverURL via wss/ws→https/http translation."
+        },
+        "serverCAHash": {
+          "type": "string",
+          "pattern": "^($|sha256:[0-9a-fA-F]{64})$",
+          "description": "Optional SPKI hash for kubeadm-style pinning on the registration TLS dial. Format: sha256:<64 hex chars>. When set, the agent skips standard chain validation and pins on this hash instead — bootstraps against self-signed central servers without distributing the full CA."
+        },
         "stateSecretName": {
           "type": "string",
           "minLength": 1,

--- a/deploy/helm/periscope-agent/values.yaml
+++ b/deploy/helm/periscope-agent/values.yaml
@@ -32,6 +32,39 @@ agent:
   # on subsequent upgrades.
   registrationToken: ""
 
+  # Optional: the URL the agent uses for the unauthenticated
+  # registration POST (#48). When set, registration goes here while
+  # the long-lived mTLS tunnel still uses serverURL. Required when
+  # the central server splits HTTP and mTLS onto different load
+  # balancers — e.g. ALB (port 443, public ACM cert) for HTTP API
+  # and NLB (port 8443, TLS passthrough, self-signed cert) for the
+  # tunnel. Leave empty for the single-LB topology, where the agent
+  # derives the registration URL from serverURL automatically
+  # (wss/ws → https/http).
+  #
+  # Example:
+  #   serverURL:       wss://agents.periscope.example.com:8443
+  #   registrationURL: https://periscope.example.com
+  registrationURL: ""
+
+  # Optional: SHA-256 hash of the registration endpoint's server
+  # certificate's SubjectPublicKeyInfo, format "sha256:<64 hex>".
+  # When set, the agent uses kubeadm-style SPKI pinning on the
+  # registration TLS dial — bypasses standard CA-chain validation,
+  # so this is how you bootstrap against a self-signed central
+  # server endpoint without distributing the full CA bundle.
+  #
+  # Compute from the central server with:
+  #   openssl x509 -pubkey -in server.crt \
+  #     | openssl rsa -pubin -outform DER 2>/dev/null \
+  #     | sha256sum | awk '{print "sha256:"$1}'
+  #
+  # SPKI (not cert) hash means cert rotation that preserves the key
+  # doesn't invalidate the pin. Used only for the bootstrap
+  # registration dial; after registration the agent has the real CA
+  # and uses standard chain validation for the tunnel.
+  serverCAHash: ""
+
   # K8s Secret holding the persisted client cert + key + server CA.
   # Created by the agent itself on first registration; survives pod
   # restarts. `helm.sh/resource-policy: keep` is set so a `helm

--- a/docs/architecture/agent-tunnel.md
+++ b/docs/architecture/agent-tunnel.md
@@ -212,6 +212,46 @@ The handler is `tunnel.MTLSAuthorizer.Authorize` (defense-in-depth
 also checks the cert carries `ExtKeyUsageClientAuth`, calls the
 operator's `NameAllowed` callback to gate on registry membership),
 plugged into `tunnel.ServerOptions.Authorizer`. Returning `true`
+
+### 5.1 LB topology and bootstrap trust (#48)
+
+The two server endpoints — `:8080` for the HTTP API including
+`/api/agents/register`, and `:8443` for `/api/agents/connect`
+(mTLS-required) — naturally map to two different load balancers in
+production. The agent's bootstrap flow needs to dial both, which
+forces a design decision about how the agent knows which URL to
+use for which call.
+
+The agent supports three deployment topologies controlled by two
+chart values:
+
+| Topology | `agent.serverURL` | `agent.registrationURL` | `agent.serverCAHash` |
+|---|---|---|---|
+| **A** — single LB, public cert | `wss://periscope.example.com:8443` | _unset_ (derived) | _unset_ |
+| **B** — split LBs (ALB + NLB) | `wss://agents.periscope.example.com:8443` | `https://periscope.example.com` | _unset_ |
+| **C** — single LB, self-signed | `wss://periscope.example.com:8443` | _unset_ (derived) | `sha256:...` |
+
+When `registrationURL` is unset, the agent derives the registration
+URL from `serverURL` by translating `wss://` → `https://` and
+`ws://` → `http://`. This is the right behaviour for Topology A and
+C (single LB) and the wrong behaviour for B (the derived URL would
+hit the mTLS endpoint, which rejects unauth POSTs). Topology B
+operators set `registrationURL` explicitly to point at the public
+ALB.
+
+When `serverCAHash` is set, the agent does kubeadm-style
+SubjectPublicKeyInfo pinning (RFC 7469) on the registration TLS
+dial — `tls.Config{InsecureSkipVerify: true, VerifyPeerCertificate: ...}`
+that compares the SHA-256 of the leaf cert's SPKI against the
+configured hash. The pin replaces standard chain validation
+exclusively for the registration dial; once registration succeeds,
+the agent has the server's CA bundle and uses standard chain
+validation for the long-lived tunnel. SPKI (not full-cert) hashing
+means cert rotation that preserves the key doesn't break the pin.
+
+The operator-facing how-to with topology examples lives in
+[`docs/setup/agent-onboarding.md`](../setup/agent-onboarding.md).
+
 admits the WebSocket session keyed by the cluster name.
 
 ## 6. mTLS handshake + session lifecycle

--- a/docs/setup/agent-onboarding.md
+++ b/docs/setup/agent-onboarding.md
@@ -1,39 +1,58 @@
 # Onboarding a managed cluster via the agent (#42)
 
 This guide walks an operator through registering a new managed
-cluster with Periscope using the agent backend. Same-account same-
-region first; cross-account variants are at the end.
+cluster with Periscope using the agent backend. Three deployment
+topologies are supported and documented as separate sections —
+pick the one that matches the load-balancer shape you're already
+running.
 
 If you're new to Periscope, read [`docs/setup/deploy.md`](deploy.md)
 first — that covers installing the central server. This page picks
-up after the central server is running and you want to add another
-cluster to its fleet view.
+up after the server is running and you want to add another cluster
+to its fleet view.
 
 > **Why an agent at all?** The agent dials *out* from the managed
 > cluster to the central server over a long-lived WebSocket — no
 > inbound network access needed, no IAM role per cluster, works on
 > any K8s with outbound HTTPS (EKS, GKE, AKS, on-prem k3s, kind).
 > See [#41](https://github.com/gnana997/periscope/issues/41) for
-> design rationale.
+> the design rationale and
+> [`docs/architecture/agent-tunnel.md`](../architecture/agent-tunnel.md)
+> for the runtime design.
 
-## Prerequisites
+## Prerequisites (apply to every topology)
 
 On the **central cluster** (where the periscope server runs):
 
-- Periscope ≥ v1.x.0 installed via the periscope chart
-- Server values include `agent.enabled: true` and a real `agent.tunnelSANs`
-  matching whatever DNS name agents will dial
-- The tunnel listener (default `:8443`) is reachable from your managed
-  clusters — typically a `LoadBalancer`-type Service or a separate
-  TLS-passthrough Ingress (ALB strips client certs, so an ALB Ingress
-  in front of the tunnel **will not work**)
+- Periscope ≥ v1.0.0 installed via the periscope chart
+- Server values include `agent.enabled: true` and a real
+  `agent.tunnelSANs` matching whatever DNS name agents will dial
 
 On the **managed cluster** (the one you want to add to the fleet):
 
 - Outbound HTTPS to the central server's tunnel hostname
 - A namespace to install the agent into (default `periscope`)
 
-## Step-by-step
+## Pick a topology
+
+| Topology | When | Setup overhead | Agent values needed |
+|---|---|---|---|
+| **A — single LB, public cert** | You can put a public cert (ACM, Let's Encrypt) on the central server's main HTTP endpoint AND that endpoint can also do TLS passthrough for the mTLS tunnel. Practical for nginx-ingress with NLB and SNI routing, or for self-managed setups. | Low | `serverURL` only |
+| **B — split LBs (ALB + NLB)** | The recommended AWS production shape. ALB (HTTP-terminating, public ACM cert) for the SPA and JSON APIs; NLB (TLS-passthrough) for the mTLS tunnel. | Medium — two DNS names, two LBs | `serverURL` + `registrationURL` |
+| **C — single LB, self-signed** | One LB, NLB-with-passthrough, no public cert (corp network, dev). | Medium — one extra hash to compute | `serverURL` + `serverCAHash` |
+
+The chart accepts `serverURL` alone (Topology A), `serverURL` +
+`registrationURL` (Topology B), or `serverURL` + `serverCAHash`
+(Topology C). Mixing B + C (split LBs *and* the registration
+endpoint is self-signed) is also supported — set all three.
+
+The cluster registration steps are the same for all three; only
+the agent install command differs in step 3. Sections below cover
+each topology.
+
+---
+
+## Step-by-step (common to all topologies)
 
 ### 1. Pre-register the cluster name
 
@@ -47,9 +66,9 @@ clusters:
     environment: prod
 ```
 
-Then `helm upgrade` the central server. The cluster card appears in
-the fleet view immediately as **unreachable** (no agent is connected
-yet).
+Then `helm upgrade` the central server. The cluster card appears
+in the fleet view immediately as **unreachable** (no agent is
+connected yet).
 
 > The cluster name is **load-bearing**: it becomes the mTLS cert CN,
 > the tunnel session key, and the registry key. Must match the DNS-
@@ -59,52 +78,30 @@ yet).
 
 ### 2. Mint a bootstrap token
 
-From an admin-tier session (the SPA's user menu shows the tier; only
-admin can hit `/api/agents/tokens`):
+From an admin-tier session, click **+ onboard cluster** in the
+fleet view header, OR via curl:
 
 ```sh
 curl -sX POST https://periscope.example.com/api/agents/tokens \
   -H "Cookie: periscope_session=<your-session-cookie>" \
   -H "Content-Type: application/json" \
   -d '{"cluster":"prod-eu"}'
-# → { "token":"abc123...", "cluster":"prod-eu", "expiresAt":"2026-..." }
+# → { "token":"abc123...", "cluster":"prod-eu", "expiresAt":"..." }
 ```
 
-The token is **single-use** and **15-min TTL**. If the agent install
-fails or you wait too long, mint a fresh one.
+The token is **single-use** and **15-minute TTL**. If the agent
+install fails or you wait too long, mint a fresh one.
 
-> Cluster-name binding is enforced: a token minted for `prod-eu` can
-> only register `prod-eu`. A wrong-cluster guess **burns the token**
-> (one-shot redemption either way).
+> Cluster-name binding is enforced: a token minted for `prod-eu`
+> can only register `prod-eu`. A wrong-cluster guess **burns the
+> token**.
 
-### 3. Install the agent on the managed cluster
+### 3. Install the agent
 
-```sh
-kubectl config use-context <managed-cluster>
+This step varies by topology. Pick the section below that matches
+your central server's LB shape.
 
-helm upgrade --install periscope-agent \
-  oci://ghcr.io/gnana997/charts/periscope-agent \
-  --version <X.Y.Z> \
-  --namespace periscope \
-  --create-namespace \
-  --set agent.serverURL=wss://agents.periscope.example.com:8443 \
-  --set agent.clusterName=prod-eu \
-  --set agent.registrationToken=<paste-token-from-step-2>
-```
-
-The agent will:
-1. Generate an ECDSA P-256 keypair locally (private key never leaves
-   the cluster)
-2. Build a CSR with `CN=prod-eu`
-3. POST `/api/agents/register` with the bootstrap token + CSR
-4. Persist the returned mTLS cert + key + server CA into the
-   `periscope-agent-state` Secret
-5. Open the WebSocket tunnel to `wss://agents.periscope.example.com:8443/api/agents/connect`
-   presenting the mTLS cert
-6. Hold the tunnel open for the lifetime of the pod, with jittered
-   exponential reconnect on drops
-
-### 4. Verify
+### 4. Verify (same for all topologies)
 
 On the managed cluster:
 
@@ -119,24 +116,172 @@ kubectl -n periscope logs -l app.kubernetes.io/name=periscope-agent -f
 #   tunnel.client_connected ...
 ```
 
-In the central server's fleet view, the `prod-eu` card should flip
+In the central server's fleet view, the cluster card should flip
 from **unreachable** to **healthy** within a few seconds.
 
-### 5. Bootstrap-token cleanup
-
-Once the agent has registered successfully, the bootstrap-token
-Secret is single-use spent. Optional cleanup:
+### 5. Bootstrap-token cleanup (optional)
 
 ```sh
 kubectl -n periscope delete secret periscope-agent-bootstrap
 ```
 
+Single-use spent — the agent persisted its long-lived mTLS cert
+into `periscope-agent-state` on first boot.
+
+---
+
+## Topology A — single LB, public cert
+
+You have one load balancer fronting both the HTTP API and the
+tunnel. The LB does TLS passthrough for both, and the central
+server presents a public cert (ACM, Let's Encrypt) that any agent
+can validate against system roots.
+
+This is the simplest shape but requires either nginx-ingress with
+SNI routing, or a single NLB with separate ports (443 for HTTP,
+8443 for tunnel) where TLS terminates at the pod for both.
+
+```sh
+kubectl config use-context <managed-cluster>
+
+helm upgrade --install periscope-agent \
+  oci://ghcr.io/gnana997/charts/periscope-agent \
+  --version <X.Y.Z> \
+  --namespace periscope --create-namespace \
+  --set agent.serverURL=wss://periscope.example.com:8443 \
+  --set agent.clusterName=prod-eu \
+  --set agent.registrationToken=<paste-token-from-step-2>
+```
+
+The agent derives the registration URL from `serverURL` (translates
+`wss://` → `https://`). Standard CA-chain validation against system
+roots handles the registration TLS dial.
+
+---
+
+## Topology B — split LBs (ALB + NLB)
+
+The AWS-shaped production deployment. Two load balancers, two DNS
+names:
+
+- **ALB** at `https://periscope.example.com` (port 443) → forwards
+  to pod port 8080 (main HTTP API). Uses an ACM-issued public cert.
+  TLS terminates at the ALB.
+- **NLB** at `agents.periscope.example.com` (port 8443) → TLS
+  passthrough to pod port 8443 (mTLS tunnel). The pod presents a
+  self-signed cert minted from the per-deployment CA (not ACM —
+  AWS won't sign for an mTLS endpoint that has to use the chart's
+  own CA).
+
+Why split: ALB can't pass through client certs (it terminates TLS),
+so the tunnel can't sit behind an ALB. But the human-facing API
+benefits from ACM (no cert distribution to browsers). So you split.
+
+```sh
+kubectl config use-context <managed-cluster>
+
+helm upgrade --install periscope-agent \
+  oci://ghcr.io/gnana997/charts/periscope-agent \
+  --version <X.Y.Z> \
+  --namespace periscope --create-namespace \
+  --set agent.serverURL=wss://agents.periscope.example.com:8443 \
+  --set agent.registrationURL=https://periscope.example.com \
+  --set agent.clusterName=prod-eu \
+  --set agent.registrationToken=<paste-token-from-step-2>
+```
+
+The agent uses `registrationURL` for the unauth registration POST
+(reaches the ALB → main HTTP, public-cert TLS validates against
+system roots) and `serverURL` for the mTLS tunnel (reaches the NLB
+→ pod's mTLS listener, the agent already has the server CA bundle
+from the registration response).
+
+---
+
+## Topology C — single LB, self-signed
+
+You have one load balancer (NLB-with-passthrough) but no public
+cert — corp network with a private CA, dev environment, or just
+not yet wired Let's Encrypt / ACM.
+
+The agent can't validate the central server's self-signed cert via
+system roots, so use SPKI hash pinning (kubeadm's pattern) to
+bootstrap trust without distributing the full CA bundle.
+
+### Compute the SPKI hash on the central server
+
+The hash is computed over the server cert's SubjectPublicKeyInfo —
+SPKI not cert means key rotation that preserves the SPKI doesn't
+break the pin (RFC 7469).
+
+```sh
+kubectl -n periscope exec deploy/periscope -- \
+  cat /etc/periscope-server/tls.crt | \
+  openssl x509 -pubkey | \
+  openssl rsa -pubin -outform DER 2>/dev/null | \
+  sha256sum | awk '{print "sha256:"$1}'
+# → sha256:abcd1234...
+```
+
+### Install the agent with the hash
+
+```sh
+kubectl config use-context <managed-cluster>
+
+helm upgrade --install periscope-agent \
+  oci://ghcr.io/gnana997/charts/periscope-agent \
+  --version <X.Y.Z> \
+  --namespace periscope --create-namespace \
+  --set agent.serverURL=wss://periscope.example.com:8443 \
+  --set agent.serverCAHash=sha256:abcd1234... \
+  --set agent.clusterName=prod-eu \
+  --set agent.registrationToken=<paste-token-from-step-2>
+```
+
+The agent does an `InsecureSkipVerify` TLS dial on the registration
+endpoint, computes the SPKI hash of the cert it receives, and
+refuses to proceed if it doesn't match the configured hash. After
+the registration succeeds, the agent has the server's full CA
+bundle and uses standard chain validation for the long-lived
+tunnel — the pin is **only** for the bootstrap dial.
+
+If the configured hash is wrong, the agent's log surfaces the
+actual computed hash for comparison so you can verify and re-roll
+with the correct value.
+
+---
+
 ## Troubleshooting
 
-### "registration rejected" (HTTP 401) on first boot
+### `tls: failed to verify certificate: x509: certificate signed by unknown authority`
+
+The agent is dialing a self-signed registration endpoint without a
+trust anchor. Either:
+- Switch to **Topology B** (point `registrationURL` at a public-cert
+  ALB), or
+- Switch to **Topology C** (compute the SPKI hash and set
+  `serverCAHash`).
+
+### `remote error: tls: certificate required`
+
+The agent is hitting an mTLS-required endpoint (the tunnel listener
+on :8443) for what should have been an unauth registration POST.
+This is the symptom of the original [#48](https://github.com/gnana997/periscope/issues/48)
+bug. Switch to **Topology B** by setting `registrationURL` to your
+ALB hostname.
+
+### `SPKI pin mismatch: server presented sha256:X, expected sha256:Y`
+
+You're on Topology C and the configured `serverCAHash` doesn't
+match the server's actual cert. The log line shows you what the
+server presented; verify it against the value `openssl ... | sha256sum`
+prints on the central cluster, then re-roll with the correct hash.
+
+### `registration rejected` (HTTP 401)
 
 The bootstrap token failed validation. The server returns a uniform
-error message for security; check the server logs to distinguish:
+error for security; check the server logs to distinguish the four
+real failure modes:
 
 ```sh
 kubectl -n periscope logs deploy/periscope --tail=20 | grep tunnel.register
@@ -144,10 +289,8 @@ kubectl -n periscope logs deploy/periscope --tail=20 | grep tunnel.register
 
 Common causes:
 - **Token expired** (15-min TTL elapsed) → mint a fresh one
-- **Token already used** (re-running `helm install` with the same
-  value) → mint a fresh one
-- **Cluster name mismatch** between `--set agent.clusterName=` and
-  the value in the token mint request → re-mint with the correct name
+- **Token already used** (re-running `helm install` with the same value) → mint a fresh one
+- **Cluster name mismatch** between `--set agent.clusterName=` and the value in the token mint request → re-mint with the correct name
 
 ### Agent connects, then the tunnel drops every few seconds
 
@@ -157,53 +300,48 @@ Check the central server logs:
 tunnel.session_error  err="websocket: close 1006 (abnormal closure)"
 ```
 
-If the agent reconnects but the cluster never goes healthy, the most
-common causes are:
+Most common cause: **server cert SAN mismatch** — agent dials
+`wss://agents.example.com:8443` but the server cert SAN is
+`localhost`. Fix:
 
-- **Server cert SAN mismatch** — agent dials `wss://agents.example.com:8443`
-  but the server cert SAN is `localhost`. Fix:
-  `helm upgrade periscope --set-string 'agent.tunnelSANs=agents.example.com\,localhost'`
-  on the central cluster, then restart the periscope pod (the server
-  cert is minted at startup).
-- **Agent's CA bundle is stale** — server CA was rotated since the
-  agent registered. Delete the agent's state Secret + bootstrap
-  Secret, mint a fresh token, re-install.
-- **Corporate proxy idle-times out the WebSocket** — increase the
-  agent's keepalive: `--set env[0].name=...` (a future
-  `agent.keepaliveSeconds` value will avoid the env-array escape).
+```sh
+helm upgrade periscope --set-string 'agent.tunnelSANs=agents.example.com\,localhost'
+```
+
+on the central cluster, then restart the periscope pod (the
+server cert is minted at startup).
 
 ### Cluster card stays "unreachable" — no agent in the registry
-
-Check the registry actually has the entry:
 
 ```sh
 curl -s https://periscope.example.com/api/clusters \
   -H "Cookie: periscope_session=..." | jq .
 ```
 
-If `prod-eu` isn't in the list, you forgot to `helm upgrade` the
-central server after adding to `clusters[]`. Re-do step 1.
+If the cluster name isn't in the list, you forgot to `helm upgrade`
+the central server after adding to `clusters[]`. Re-do step 1.
 
 ### `helm template` fails with `agent.serverURL is required`
 
-You forgot to set `agent.serverURL` (or `agent.clusterName`). The
-agent chart's schema enforces both as required.
+Schema-required field missing. Add `--set agent.serverURL=...`.
 
-### mTLS handshake fails with "bad certificate"
+### mTLS handshake fails with `bad certificate`
 
-The agent's persisted cert doesn't chain to the server's current CA.
-Either:
-- The server's CA Secret was deleted and regenerated (every previously
-  -issued agent cert is now invalid)
+The agent's persisted cert doesn't chain to the server's current
+CA. Either:
+- The server's CA Secret was deleted and regenerated (every
+  previously-issued agent cert is now invalid)
 - The agent was registered against a different server
 
-Fix: delete the agent's state Secret on the managed cluster, mint a
-fresh token, re-install.
+Fix: delete the agent's state Secret on the managed cluster, mint
+a fresh token, re-install:
 
 ```sh
 kubectl -n periscope delete secret periscope-agent-state
 # then redo steps 2 + 3
 ```
+
+---
 
 ## Cross-account / cross-cloud
 
@@ -212,9 +350,9 @@ managed cluster lives in — only that the agent pod can reach the
 central server's tunnel hostname over outbound HTTPS. No IAM trust
 policies to set up, no peering, no VPN.
 
-For each cluster, repeat steps 1–5. The bootstrap token mint is the
-only step that talks to the central server's IdP; once a token is
-in hand, the agent installs on any K8s cluster with egress.
+For each cluster, repeat steps 1–5, choosing the topology that
+matches your LB shape. The same Periscope server can host clusters
+from different accounts / clouds / regions in one fleet view.
 
 ## Security notes
 
@@ -222,33 +360,42 @@ in hand, the agent installs on any K8s cluster with egress.
   name, not anything else. A leaked token can register that one
   cluster (and burn itself); it cannot impersonate other clusters
   or access any data.
-- The persisted mTLS cert is the long-lived agent identity. Keep the
-  state Secret protected (the chart's RBAC limits access, but anyone
-  with `secrets/get` on the agent's namespace can pull it).
+- The persisted mTLS cert is the long-lived agent identity. Keep
+  the state Secret protected (the chart's RBAC limits access, but
+  anyone with `secrets/get` on the agent's namespace can pull it).
 - Agent cluster RBAC is scoped to `get/list/watch/impersonate` by
   default. Apply/delete handlers depend on the user's impersonated
   identity; the agent itself never gains write access beyond what
   its `ClusterRole` grants. Tighten the chart's `clusterRole`
   template if your security model wants stricter defaults.
+- **SPKI pin** (Topology C) is a public hash — leakage is a
+  no-impact event by itself. The pin is useless without the
+  matching server cert. Treat it like a Git commit SHA, not like a
+  secret.
 - For a deeper threat-model walkthrough see
   [issue #41](https://github.com/gnana997/periscope/issues/41).
 
 ## What's next
 
 The Periscope SPA includes a **+ Onboard cluster** button on the
-fleet page that walks through this flow with copy-paste snippets and
-live status (token mint → install command → connection state). For
-now it shows the install command; full Rancher-style polling +
-runtime registry mutations land in v1.x.1.
+fleet page that walks through the token mint + install command
+flow. Phase 2 (live polling, runtime registry mutations,
+re-mint/decommission) lands in v1.x.1.
 
 ## See also
 
 - [`examples/agent/`](../../examples/agent/) — sample values files
   and a reference `register-and-install.sh` script
-- [RFC 0003](../rfcs/0003-audit-log.md) — audit shape (every action
-  taken via an agent-backed cluster lands in the central audit
-  store, with `cluster: <name>` set on the row)
+- [`docs/architecture/agent-tunnel.md`](../architecture/agent-tunnel.md) —
+  design walkthrough (PKI, mTLS, transport substitution, failure
+  modes)
+- [RFC 0003](../rfcs/0003-audit-log.md) — audit shape (every
+  action taken via an agent-backed cluster lands in the central
+  audit store, with `cluster: <name>` set on the row)
 - [Issue #41](https://github.com/gnana997/periscope/issues/41) —
   agent-vs-central-IAM design discussion
 - [Issue #42](https://github.com/gnana997/periscope/issues/42) —
   v1.x.0 multi-cluster epic
+- [Issue #48](https://github.com/gnana997/periscope/issues/48) —
+  the ALB+NLB bootstrap chicken-and-egg this guide's Topology B
+  fixes

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -44,6 +44,8 @@ shape itself), see [`docs/setup/deploy.md`](deploy.md).
 | `PERISCOPE_AGENT_NAMESPACE` | _(in-pod namespace)_ | Where the agent persists state | `(derived)` |
 | `PERISCOPE_AGENT_SECRET_NAME` | `periscope-agent-state` | State Secret name (cert + key + server CA) | `agent.stateSecretName` |
 | `PERISCOPE_AGENT_HEALTH_ADDR` | `:8081` | Bind addr for /healthz | `agent.healthAddr` |
+| `PERISCOPE_REGISTRATION_URL` | _(derive from serverURL)_ | URL for the unauth registration POST when split from tunnel | `agent.registrationURL` |
+| `PERISCOPE_SERVER_CA_HASH` | _(unset = system roots)_ | SPKI hash for kubeadm-style pinning on registration TLS | `agent.serverCAHash` |
 
 Empty / unset values fall back to the documented default. Negative or
 non-numeric values where a positive integer is expected fall back to
@@ -462,6 +464,53 @@ Bind addr for the kubelet probe target (`/healthz`). Default
 bootstrap; the tunnel state itself is reflected in pod logs (see
 the `tunnel.client_connected` / `tunnel.client_disconnected`
 slog lines).
+
+#### `PERISCOPE_REGISTRATION_URL`
+
+Optional. The URL the agent uses for the unauthenticated
+registration POST (#48). Format: `https://host[:port]` or
+`http://host[:port]` (no path; the agent appends
+`/api/agents/register`). When unset, the agent derives the
+registration URL from `PERISCOPE_SERVER_URL` by translating
+`wss://` → `https://` and `ws://` → `http://`.
+
+Set explicitly when the central server splits HTTP and mTLS onto
+different load balancers (e.g. ALB-on-443 for the HTTP API +
+NLB-on-8443 for the mTLS tunnel — the recommended AWS production
+shape). Without this, the agent posts registration at the mTLS
+endpoint and gets `tls: certificate required` because it has no
+client cert yet.
+
+Helm rendering: `agent.registrationURL`. Schema accepts only
+http(s):// URLs.
+
+#### `PERISCOPE_SERVER_CA_HASH`
+
+Optional. SHA-256 hash of the registration endpoint's server
+cert's SubjectPublicKeyInfo, format `sha256:<64 hex chars>`. When
+set, the agent does kubeadm-style SPKI pinning on the registration
+TLS dial — bypasses standard CA-chain validation, instead
+validating the server's cert against this exact hash. Used only
+for the bootstrap registration dial; after registration the agent
+has the real CA bundle and uses standard chain validation for the
+long-lived tunnel.
+
+Compute on the central cluster:
+
+```sh
+kubectl -n periscope exec deploy/periscope -- \
+  cat /etc/periscope-server/tls.crt | \
+  openssl x509 -pubkey | \
+  openssl rsa -pubin -outform DER 2>/dev/null | \
+  sha256sum | awk '{print "sha256:"$1}'
+```
+
+SPKI (not cert) hash means cert rotation that preserves the key
+doesn't break the pin (RFC 7469).
+
+Helm rendering: `agent.serverCAHash`. Schema rejects values that
+don't match `^sha256:[0-9a-fA-F]{64}$`.
+
 
 ---
 

--- a/web/src/components/shell/Brand.tsx
+++ b/web/src/components/shell/Brand.tsx
@@ -1,4 +1,28 @@
+// Brand — header wordmark + dynamic version eyebrow.
+//
+// Pulls the server's binary version from /api/features (already
+// fetched once at app boot via useFeatures + cached for the
+// session). Falls back to a non-claim ("…") while the features
+// query is in flight; the placeholder is short-lived (single round-
+// trip on first paint) and a brief skeleton is preferable to a
+// stale literal.
+//
+// Channel suffix logic:
+//   - "stable" releases (e.g. v1.0.0) render as just "v1.0.0"
+//   - prereleases (anything with a `-`, e.g. v1.0.0-rc4) render
+//     with " · prerelease" so operators visually flag they're not
+//     on a stable
+//   - "dev" builds (no ldflags) render with " · dev"
+//
+// If you change this format, also check periscopehq.dev's
+// marketing-site Latest Release widget — the two strings
+// historically rhymed and divergence reads as a bug.
+
+import { useFeatures } from "../../lib/features";
+
 export function Brand() {
+  const { data } = useFeatures();
+
   return (
     <div className="px-5 pt-5 pb-3">
       <div className="flex items-baseline gap-2">
@@ -9,9 +33,25 @@ export function Brand() {
           Periscope
         </h1>
         <span className="text-[10px] uppercase tracking-[0.08em] text-ink-faint">
-          v0.1 · beta
+          {versionEyebrow(data?.version, data?.channel)}
         </span>
       </div>
     </div>
   );
+}
+
+function versionEyebrow(
+  version: string | undefined,
+  channel: "stable" | "prerelease" | "dev" | undefined,
+): string {
+  if (!version) {
+    // Pre-features-resolve: render a skeleton glyph rather than a
+    // version string so the operator doesn't briefly see a stale
+    // literal between paint and fetch.
+    return "…";
+  }
+  if (channel === "stable") return version;
+  if (channel === "prerelease") return `${version} · prerelease`;
+  if (channel === "dev") return `${version} · dev`;
+  return version;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -227,8 +227,18 @@ export type WatchStreamKind =
 // Features describes server-side capability flags. Fetched once at app
 // boot via api.features and consumed by useResource (Phase 6) to choose
 // between polling and streaming per kind.
+// Server-wide capability flags + version metadata fetched on first
+// SPA load. Surfaced via /api/features. Used by the Brand component
+// (header version display), the OnboardClusterModal (chart version),
+// and useResource (watch-stream gating).
 export interface Features {
   watchStreams: WatchStreamKind[];
+  /** Server binary version, e.g. "v1.0.0-rc4". "dev" for builds without ldflags. */
+  version?: string;
+  /** Source-code commit the server was built from. "unknown" without ldflags. */
+  commit?: string;
+  /** Release channel: "stable" (no `-` in version), "prerelease" (e.g. -rc4), or "dev". */
+  channel?: "stable" | "prerelease" | "dev";
 }
 
 /**


### PR DESCRIPTION
Closes #48 (the agent bootstrap chicken-and-egg) and adds two bonus polish items uncovered while debugging it.

## What's in scope

### 1. The #48 fix — split registration + tunnel URLs (Option A)

Before this PR, the agent used **one** `serverURL` for both unauth registration POST and mTLS-required tunnel WSS. With the recommended AWS topology (ALB-on-443 for HTTP API + NLB-on-8443 TLS-passthrough for mTLS), the agent's registration POST got routed to the NLB, which rejected it because (a) the agent had no CA to validate the self-signed cert, (b) the mTLS listener required a client cert the agent didn't have yet.

**Fix:** new optional `agent.registrationURL` Helm value. When set, the agent uses it for the unauth POST while `serverURL` continues to point at the mTLS tunnel. Falls back to `wss/ws → https/http` translation of `serverURL` when unset (backward-compat for single-LB setups).

Researched against industry precedent (Rancher, kubeadm, OCM, Karmada, Argo CD agent, Tailscale K8s operator). Rancher has the same bug unfixed (rancher/rancher#38234); their workaround is "use NLB for everything, terminate TLS at the pod." Skipped Option B from the issue (mounting `/register` on the tunnel listener with optional mTLS) — research called it a security smell that wouldn't have fixed the chain-validation half anyway.

### 2. SPKI hash pinning — `agent.serverCAHash`

Replaces the original Option C (full CA bundle distribution) with a kubeadm-style SHA-256 pin over the server cert's SubjectPublicKeyInfo (RFC 7469).

```
openssl x509 -pubkey -in server.crt | openssl rsa -pubin -outform DER 2>/dev/null | sha256sum
# → sha256:abcd1234...
```

Operator pastes that string into Helm values. The agent does an `InsecureSkipVerify` TLS dial on the registration endpoint, computes the SPKI hash itself, refuses to proceed on mismatch. The pin replaces chain validation **only for the bootstrap dial** — once registration succeeds, the agent has the real CA bundle and uses standard chain validation for the long-lived tunnel.

Why SPKI not full bundle:
- One 71-char string vs multi-line PEM
- Communicable via Slack one-liner
- Cert rotation that preserves the key doesn't break the pin
- Public hash — leakage is no-impact (pin is useless without the matching server)

### 3. Three deployment topologies, fully documented

`docs/setup/agent-onboarding.md` got a full topology rewrite:

| Topology | When | Agent values |
|---|---|---|
| **A — single LB, public cert** | nginx-ingress with NLB + SNI; or single NLB terminating TLS at the pod | `serverURL` only |
| **B — split LBs (ALB + NLB)** | recommended AWS production shape | `serverURL` + `registrationURL` |
| **C — single LB, self-signed** | corp/dev | `serverURL` + `serverCAHash` |

### 4. Bonus: dynamic Brand version

The SPA's header eyebrow read a hardcoded `v0.1 · beta` (way out of date). Now reads from `/api/features` which the server populates from `main.version` (already wired via Dockerfile `-ldflags`). Channel suffix logic:
- `v1.0.0` for stable
- `v1.0.0-rc4 · prerelease` for prereleases
- `dev · dev` for local builds without ldflags

### 5. Bonus: auto-publish Artifact Hub metadata on every release

While debugging #48 we discovered the periscope-agent chart's "Verified Publisher" badge wasn't showing — the local `artifacthub-repo.yml` had the correct UUID but the OCI artifact at `:artifacthub.io` still had the placeholder zeros. The manual `oras push` step after AH registration was forgotten.

Three new workflow steps after the chart sign:
- Set up oras
- Push the periscope chart's metadata layer
- Same for periscope-agent

Idempotent — pushing the same content under the same tag is a no-op at the registry level. Auth uses `~/.docker/config.json` which `docker/login-action@v3` already populated. Future ownership-claim drift heals itself on the next release tag.

## Tests + validation

- `cmd/periscope-agent/spki_test.go` (NEW): `parseSPKIHash` boundary cases, `pinningTLSConfig` happy path, hash mismatch, malformed pin
- `cmd/periscope-agent/bootstrap_test.go` (extended):
  - `TestRegisterAndSign_UsesRegistrationURLOverServerURL` — proves agent ignores `serverURL` for registration when `registrationURL` set
  - `TestRegisterAndSign_FallsBackToServerURL` — backward compat
  - `TestRegisterAndSign_SPKIPinning` — matching, mismatched, malformed subtests
- Schemas reject typos at `helm template` time (URL pattern, SPKI hash format)
- Both Helm charts lint clean
- TS typecheck + ESLint clean, Vite build clean
- Race-clean across full Go suite

## What's deferred

- `caBundle` Helm value (the original Option C) — superseded by SPKI pinning
- Server-told-tunnel-URL handoff via registration response (Rancher's `cattle-credentials` pattern) — tracked as a v1.x.+ enhancement
- Phase 2 onboarding UX (live polling, runtime registry mutations, re-mint/decommission) — already separate

## Smoke test sequence (for the reviewer)

```sh
# 1. Topology B — central server with ALB + NLB
helm upgrade --install periscope oci://ghcr.io/gnana997/charts/periscope \
  --version v1.x.0-rc5 \
  --set agent.enabled=true \
  --set-string 'agent.tunnelSANs=agents.example.com\,localhost'

# 2. Agent on managed cluster with split URLs
helm install periscope-agent oci://ghcr.io/gnana997/charts/periscope-agent \
  --version v1.x.0-rc5 \
  --set agent.serverURL=wss://agents.example.com:8443 \
  --set agent.registrationURL=https://periscope.example.com \
  --set agent.clusterName=prod-eu \
  --set agent.registrationToken=<TOKEN>

# 3. Watch fleet view — cluster card flips healthy

# 4. SPA header — Brand reads "v1.x.0-rc5 · prerelease" instead of "v0.1 · beta"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)