### PR TITLE
fix(auth): add /api/agents/register to public allowlist (#48)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -46,6 +46,15 @@ func isPublic(path string) bool {
 		"/api/auth/login",
 		"/api/auth/callback",
 		"/api/auth/loggedout",
+		// Agent registration: the bootstrap token IS the auth.
+		// Validated inside tunnel.RegisterHandler atomically with CSR
+		// signing — adding this to the public allowlist moves the auth
+		// gate from "session cookie" to "bootstrap token in body,"
+		// not removing it. /api/agents/tokens is NOT public (admin-only,
+		// session-gated by adminOnlyMiddleware in cmd/periscope), and
+		// /api/agents/connect runs on the separate tunnel TLS listener
+		// (mTLS-gated) so never hits this middleware. See #48.
+		"/api/agents/register",
 		"/api/auth/logout",
 		"/api/auth/logout/everywhere":
 		return true

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -193,3 +193,59 @@ func TestAcceptsHTML(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPublic_AgentRegister(t *testing.T) {
+	// /api/agents/register is unauth-by-design (the bootstrap token in
+	// the request body IS the auth). If this regresses, agents fail
+	// first-boot registration with 401 from the auth middleware long
+	// before tunnel.RegisterHandler ever sees the request — see #48.
+	if !isPublic("/api/agents/register") {
+		t.Fatal("/api/agents/register should be in the isPublic allowlist")
+	}
+}
+
+func TestIsPublic_AgentTokensRequiresAuth(t *testing.T) {
+	// /api/agents/tokens is admin-tier-only — must NOT be in the
+	// isPublic allowlist. The session-cookie check runs first; the
+	// adminOnlyMiddleware in cmd/periscope enforces tier on top.
+	if isPublic("/api/agents/tokens") {
+		t.Fatal("/api/agents/tokens must NOT be public — it's admin-tier-only")
+	}
+}
+
+func TestIsPublic_KnownPathsCovered(t *testing.T) {
+	// Lock the full set so future additions to isPublic show up as a
+	// test diff, prompting a security review of the new entry.
+	wantPublic := []string{
+		"/healthz",
+		"/api/auth/config",
+		"/api/auth/login",
+		"/api/auth/callback",
+		"/api/auth/loggedout",
+		"/api/auth/logout",
+		"/api/auth/logout/everywhere",
+		"/api/agents/register",
+	}
+	for _, p := range wantPublic {
+		if !isPublic(p) {
+			t.Errorf("isPublic(%q) = false, want true", p)
+		}
+	}
+
+	// Negative: a sample of paths that MUST require auth.
+	wantPrivate := []string{
+		"/api/whoami",
+		"/api/clusters",
+		"/api/fleet",
+		"/api/audit",
+		"/api/agents/tokens",                 // admin-tier-only
+		"/api/clusters/prod-eu/pods",         // per-cluster handler
+		"/",                                  // SPA root — auth-gated for HTML
+		"/some/random/path",                  // unknown path — fail closed
+	}
+	for _, p := range wantPrivate {
+		if isPublic(p) {
+			t.Errorf("isPublic(%q) = true, want false (would bypass auth)", p)
+		}
+	}
+}


### PR DESCRIPTION
The agent's first-boot registration POST was being rejected with `401` by the auth middleware before `tunnel.RegisterHandler` ever ran. The handler does its own bootstrap-token validation atomically with CSR signing, so the endpoint is unauth-by-design — but `isPublic()` in `internal/auth/middleware.go` had not been updated to match when the registration handler shipped in #50.

## What changed

Add `/api/agents/register` to `isPublic`. The auth gate moves from "session cookie" to "bootstrap token in body," not removed:

- `/api/agents/tokens` (admin-only mint) is **NOT** in the allowlist — session-gated by `adminOnlyMiddleware` in `cmd/periscope`
- `/api/agents/connect` runs on the separate tunnel TLS listener (mTLS-gated), never hits this middleware

Three tests added:

- `TestIsPublic_AgentRegister` — locks the new entry
- `TestIsPublic_AgentTokensRequiresAuth` — locks that `/tokens` stays gated
- `TestIsPublic_KnownPathsCovered` — locks the full allowlist + a negative-set sample (e.g. `/api/clusters/prod-eu/pods`, `/api/agents/tokens`) so future additions to `isPublic` surface as a test diff, prompting security review

## Smoke test (post-merge, post-tag)

```sh
# tag v1.0.0-rc8, helm upgrade, verify agent reaches register without 401
TOKEN=$(curl -sX POST https://periscope.example.com/api/agents/tokens \
  -H "Cookie: periscope_session=..." \
  -d '{"cluster":"prod-eu"}' | jq -r .token)

helm upgrade --install periscope-agent oci://ghcr.io/gnana997/charts/periscope-agent \
  --version 1.0.0-rc8 \
  --set agent.serverURL=wss://agents.example.com:8443 \
  --set agent.registrationURL=https://periscope.example.com \
  --set agent.clusterName=prod-eu \
  --set agent.registrationToken=$TOKEN

# expect: agent log "tunnel.client_connected" within ~10s, no 401 in server log
```

Refs #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)