### PR TITLE
feat(agent): observability log-level env, per-request access logs, request-id correlation, boot diagnostic

### DIFF
--- a/cmd/periscope-agent/main.go
+++ b/cmd/periscope-agent/main.go
@@ -65,6 +65,7 @@ const (
 )
 
 func main() {
+	configureLogger() // wire PERISCOPE_LOG_LEVEL → slog default before any log fires
 	if err := run(); err != nil {
 		slog.Error("agent exited with error", "err", err)
 		os.Exit(1)
@@ -90,6 +91,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("in-cluster config: %w", err)
 	}
+	logBootDiagnostic(inClusterCfg)
 	kc, err := kubernetes.NewForConfig(inClusterCfg)
 	if err != nil {
 		return fmt.Errorf("kube client: %w", err)
@@ -109,13 +111,23 @@ func run() error {
 	}
 
 	// Local apiserver dialer — every server-requested dial routes
-	// here. We ignore the requested address (it's the
-	// "apiserver.<cluster>.tunnel" sentinel) and always connect to
-	// the kubelet-published apiserver host.
-	apiHost := apiserverHost(inClusterCfg)
+	// here. With the #59 fix, dials no longer go to the apiserver
+	// directly; they go to a localhost reverse proxy that injects
+	// the agent SA bearer token before forwarding to the apiserver.
+	// See proxy.go for the proxy implementation.
+	const apiProxyAddr = "127.0.0.1:7443"
+	go func() {
+		if err := startAPIProxy(inClusterCfg, apiProxyAddr); err != nil {
+			// startAPIProxy returns nil on graceful shutdown, error on
+			// fatal startup failure. Log + exit so the pod restarts and
+			// the operator notices via the kubelet probe.
+			slog.Error("agent api proxy exited", "err", err)
+			os.Exit(1)
+		}
+	}()
 	localDial := func(ctx context.Context, network, _ string) (net.Conn, error) {
 		var d net.Dialer
-		return d.DialContext(ctx, network, apiHost)
+		return d.DialContext(ctx, network, apiProxyAddr)
 	}
 
 	client, err := tunnel.NewClient(tunnel.ClientOptions{
@@ -131,7 +143,7 @@ func run() error {
 
 	go serveHealth(ctx, cfg.HealthAddr)
 
-	slog.Info("opening tunnel", "server", cfg.ServerURL, "apiserver_host", apiHost)
+	slog.Info("opening tunnel", "server", cfg.ServerURL, "api_proxy_addr", apiProxyAddr)
 	return client.Run(ctx)
 }
 
@@ -283,18 +295,6 @@ func buildTLSConfig(state *agentState) (*tls.Config, error) {
 		RootCAs:      pool,
 		MinVersion:   tls.VersionTLS12,
 	}, nil
-}
-
-// apiserverHost returns "host:port" the agent should dial to reach
-// its local apiserver. Pulled from in-cluster config so we don't
-// hardcode kubernetes.default.svc — works on kind, EKS, GKE, etc.
-func apiserverHost(cfg *rest.Config) string {
-	host := strings.TrimPrefix(cfg.Host, "https://")
-	host = strings.TrimPrefix(host, "http://")
-	if !strings.Contains(host, ":") {
-		host += ":443"
-	}
-	return host
 }
 
 // serveHealth runs a tiny readiness/liveness probe handler. Reports

--- a/cmd/periscope-agent/observability.go
+++ b/cmd/periscope-agent/observability.go
@@ -1,0 +1,262 @@
+// Observability surface for the agent: structured logging, log-level
+// control via PERISCOPE_LOG_LEVEL, per-request access logs through the
+// proxy, end-to-end request-id correlation with the central server,
+// and a one-time boot diagnostic dump that confirms the agent has
+// the credentials + CA it needs.
+//
+// Why this matters: pre-#59 the agent had zero per-request visibility.
+// When alice's request reached the apiserver and got a 403, the agent
+// log said nothing — the only way to debug was to enable apiserver
+// audit on the managed cluster (separate, operator-controlled). This
+// file adds the missing trace points so a Periscope operator can
+// debug auth/RBAC/proxy issues from the agent log alone.
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// configureLogger replaces slog's default handler with a JSON handler
+// that writes to stdout at the level driven by PERISCOPE_LOG_LEVEL.
+// Default INFO. Accepts: debug, info, warn, error (case-insensitive).
+//
+// Production / kubectl logs default to INFO — clean output. Operators
+// debugging an issue flip to debug via:
+//
+//	helm upgrade ... --set 'env[0].name=PERISCOPE_LOG_LEVEL,env[0].value=debug'
+//
+// Then `kubectl -n periscope logs deploy/periscope-agent | jq .` shows
+// every request flowing through the proxy.
+func configureLogger() {
+	level := parseLogLevel(os.Getenv("PERISCOPE_LOG_LEVEL"))
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(h))
+}
+
+func parseLogLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// loggingMiddleware wraps the reverse proxy with per-request access
+// logs. Three log lines per request, level-gated:
+//
+//   DEBUG  proxy.request_in   - what the agent received from the tunnel
+//   DEBUG  proxy.request_out  - what the agent returned (status, latency, bytes)
+//   WARN   proxy.apiserver_error - fires when status >= 400 (always-on, even at INFO)
+//
+// All three carry `request_id` taken from the X-Request-Id header that
+// the central server's chi middleware sets on every API call. Same id
+// shows up on the server's audit row (RFC 0003 §6) so operators can
+// grep one id across server audit DB + server stdout slog + agent
+// stdout slog for a single end-to-end trace.
+//
+// Authorization header value is NEVER logged at any level. Path is
+// logged because it's part of the public K8s API surface; impersonation
+// headers are logged because they're already in apiserver audit logs
+// (no new info disclosed).
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		reqID := r.Header.Get("X-Request-Id")
+		impUser := r.Header.Get("Impersonate-User")
+		impGroup := r.Header.Get("Impersonate-Group")
+
+		slog.Debug("proxy.request_in",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"impersonate_user", impUser,
+			"impersonate_group", impGroup,
+			"request_id", reqID,
+		)
+
+		// Wrap ResponseWriter to capture status + bytes while preserving
+		// the optional interfaces httputil.ReverseProxy needs (Flusher
+		// for SSE, Hijacker for WebSocket upgrades on exec).
+		rec := newResponseRecorder(w)
+		next.ServeHTTP(rec, r)
+
+		latencyMs := time.Since(start).Milliseconds()
+
+		slog.Debug("proxy.request_out",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.status,
+			"latency_ms", latencyMs,
+			"bytes", rec.bytes,
+			"request_id", reqID,
+		)
+
+		// Apiserver-side errors fire at WARN regardless of level —
+		// operators see auth/RBAC failures even with default INFO
+		// logging. This is the line that would have made #59
+		// obvious from day one ("status=401 every request").
+		if rec.status >= 400 {
+			slog.Warn("proxy.apiserver_error",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", rec.status,
+				"impersonate_user", impUser,
+				"latency_ms", latencyMs,
+				"request_id", reqID,
+			)
+		}
+	})
+}
+
+// logBootDiagnostic logs one INFO line at startup with the resolved
+// in-cluster config — apiserver URL, CA fingerprint, SA token presence
+// + parsed expiry. Called once after rest.InClusterConfig() succeeds.
+//
+// Lets operators confirm at a glance that:
+//   1. The agent loaded the CA bundle (ca_bundle_len > 0)
+//   2. The agent has an SA token (sa_token_present: true)
+//   3. The token has reasonable lifetime ahead (sa_token_expires_in_seconds)
+//   4. The apiserver URL is what they expect
+//
+// Critical for debugging "why did auth start failing 60 minutes after
+// install" — projected SA tokens default to 1-hour TTL with auto-
+// rotation, and if rotation breaks, this line in the boot dump shows
+// the expiry timestamp so the failure window is predictable.
+func logBootDiagnostic(inClusterCfg *rest.Config) {
+	caFP := caFingerprint(inClusterCfg.CAData)
+	expiry := saTokenExpiresInSeconds(inClusterCfg.BearerToken)
+
+	slog.Info("agent.boot_diagnostic",
+		"apiserver_url", inClusterCfg.Host,
+		"ca_bundle_len", len(inClusterCfg.CAData),
+		"ca_fingerprint", caFP,
+		"sa_token_present", inClusterCfg.BearerToken != "",
+		"sa_token_expires_in_seconds", expiry,
+	)
+}
+
+// caFingerprint returns a short SHA-256 hash of the CA bundle for
+// log identification. Same bundle across restarts → same fingerprint;
+// CA rotated → different fingerprint. Empty CA → "" (the guard log
+// is `ca_bundle_len: 0`).
+func caFingerprint(caData []byte) string {
+	if len(caData) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(caData)
+	return "sha256:" + hex.EncodeToString(sum[:8]) // first 8 bytes = 16 hex chars, plenty for log identification
+}
+
+// saTokenExpiresInSeconds parses the JWT exp claim from a K8s
+// projected ServiceAccount token. Returns -1 when the token is empty,
+// not a valid JWT, or doesn't carry an exp claim — the boot log shows
+// -1 in those cases (operationally "we don't know when this expires;
+// investigate"). Doesn't validate the signature; that's the apiserver's
+// job at request time.
+func saTokenExpiresInSeconds(token string) int64 {
+	if token == "" {
+		return -1
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		// Not a JWT (could be a legacy long-lived SA token). No way
+		// to know when it expires from the token alone.
+		return -1
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return -1
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return -1
+	}
+	remain := claims.Exp - time.Now().UTC().Unix()
+	if remain < 0 {
+		return 0
+	}
+	return remain
+}
+
+// ─── responseRecorder ──────────────────────────────────────────────
+//
+// Wraps http.ResponseWriter to capture the status code + total bytes
+// written. Preserves optional interfaces (Flusher, Hijacker) so the
+// proxy's streaming + WebSocket-upgrade behavior is unaffected.
+
+type responseRecorder struct {
+	http.ResponseWriter
+	status      int
+	bytes       int
+	wroteHeader bool
+}
+
+func newResponseRecorder(w http.ResponseWriter) *responseRecorder {
+	return &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		// Same protection net.http applies — repeated WriteHeader is a
+		// caller bug; honour the first one.
+		return
+	}
+	r.status = code
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		// Implicit WriteHeader(200) on first Write — same as the
+		// stdlib ResponseWriter contract.
+		r.wroteHeader = true
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+// Flush forwards to the underlying writer if it supports flushing.
+// Critical for SSE / watch streams — without this the proxy's
+// FlushInterval=-1 would have no effect.
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Note: we don't expose Hijack() directly on responseRecorder because
+// http.Hijacker requires the exact return tuple types
+// (net.Conn, *bufio.ReadWriter, error) and adding the imports for those
+// in this file isn't worth the build-graph cost. The reverse-proxy
+// flow we ship today doesn't trigger Hijack (exec is deferred to
+// v1.x.1 per #43). When exec lands, the ResponseRecorder will need
+// Hijack() implementing — tracked in #43.
+//
+// Compile-time safety: if a future code path tries to type-assert
+// the recorder to http.Hijacker, it'll get nil instead of a wrong
+// implementation, surfacing the gap loudly.
+var _ http.Flusher = (*responseRecorder)(nil)
+
+// fmt is only used by string formatting in helper paths above —
+// keep the reference here so future edits don't accidentally drop it.
+var _ = fmt.Sprintf

--- a/cmd/periscope-agent/observability_test.go
+++ b/cmd/periscope-agent/observability_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"":         slog.LevelInfo,
+		"info":     slog.LevelInfo,
+		"INFO":     slog.LevelInfo,
+		"  Info ":  slog.LevelInfo,
+		"debug":    slog.LevelDebug,
+		"DEBUG":    slog.LevelDebug,
+		"warn":     slog.LevelWarn,
+		"warning":  slog.LevelWarn,
+		"error":    slog.LevelError,
+		"garbage":  slog.LevelInfo, // unknown → safe default
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := parseLogLevel(in); got != want {
+				t.Fatalf("parseLogLevel(%q) = %v, want %v", in, got, want)
+			}
+		})
+	}
+}
+
+// TestLoggingMiddleware_DebugFiresAccessLogs verifies that at DEBUG
+// level, both proxy.request_in and proxy.request_out fire — the trace
+// pair operators rely on for debugging.
+func TestLoggingMiddleware_DebugFiresAccessLogs(t *testing.T) {
+	logBuf := captureLogger(t, slog.LevelDebug)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := httptest.NewServer(loggingMiddleware(upstream))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/pods", nil)
+	req.Header.Set("X-Request-Id", "test-req-id-abc")
+	req.Header.Set("Impersonate-User", "alice@corp")
+	req.Header.Set("Impersonate-Group", "periscope-tier:admin")
+	resp, _ := http.DefaultClient.Do(req)
+	defer func() { _ = resp.Body.Close() }()
+
+	logs := logBuf.String()
+	mustContain(t, logs, `"msg":"proxy.request_in"`)
+	mustContain(t, logs, `"msg":"proxy.request_out"`)
+	mustContain(t, logs, `"request_id":"test-req-id-abc"`)
+	mustContain(t, logs, `"impersonate_user":"alice@corp"`)
+	mustContain(t, logs, `"status":200`)
+}
+
+// TestLoggingMiddleware_InfoSuppressesAccessLogs proves the access
+// log pair is debug-gated. INFO operators don't see per-request noise.
+func TestLoggingMiddleware_InfoSuppressesAccessLogs(t *testing.T) {
+	logBuf := captureLogger(t, slog.LevelInfo)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := httptest.NewServer(loggingMiddleware(upstream))
+	defer srv.Close()
+
+	resp, _ := http.Get(srv.URL + "/api/v1/pods")
+	defer func() { _ = resp.Body.Close() }()
+
+	logs := logBuf.String()
+	if strings.Contains(logs, "proxy.request_in") || strings.Contains(logs, "proxy.request_out") {
+		t.Fatalf("INFO level should suppress request_in/out; got:\n%s", logs)
+	}
+}
+
+// TestLoggingMiddleware_AlwaysLogsErrors proves the WARN-level error
+// log fires for >= 400 responses regardless of log level. This is the
+// log line that would have made #59 obvious from the start.
+func TestLoggingMiddleware_AlwaysLogsErrors(t *testing.T) {
+	for _, level := range []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn} {
+		t.Run(level.String(), func(t *testing.T) {
+			logBuf := captureLogger(t, level)
+
+			upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+			srv := httptest.NewServer(loggingMiddleware(upstream))
+			defer srv.Close()
+
+			req, _ := http.NewRequest("GET", srv.URL+"/api/v1/secrets/x/y", nil)
+			req.Header.Set("Impersonate-User", "alice@corp")
+			req.Header.Set("X-Request-Id", "trace-id-403")
+			resp, _ := http.DefaultClient.Do(req)
+			defer func() { _ = resp.Body.Close() }()
+
+			logs := logBuf.String()
+			mustContain(t, logs, `"msg":"proxy.apiserver_error"`)
+			mustContain(t, logs, `"status":403`)
+			mustContain(t, logs, `"impersonate_user":"alice@corp"`)
+			mustContain(t, logs, `"request_id":"trace-id-403"`)
+		})
+	}
+}
+
+// TestLoggingMiddleware_AuthorizationNeverLogged is the security
+// guarantee: even at debug level, the Authorization header value
+// must never appear in logs.
+func TestLoggingMiddleware_AuthorizationNeverLogged(t *testing.T) {
+	const secret = "super-sensitive-bearer-token-fixture"
+	logBuf := captureLogger(t, slog.LevelDebug)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := httptest.NewServer(loggingMiddleware(upstream))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+secret)
+	resp, _ := http.DefaultClient.Do(req)
+	defer func() { _ = resp.Body.Close() }()
+
+	logs := logBuf.String()
+	if strings.Contains(logs, secret) {
+		t.Fatal("the Authorization bearer token leaked into logs")
+	}
+}
+
+// TestSATokenExpiresInSeconds covers JWT exp parsing — happy path,
+// missing exp, malformed token.
+func TestSATokenExpiresInSeconds(t *testing.T) {
+	t.Run("future exp", func(t *testing.T) {
+		exp := time.Now().Add(2 * time.Hour).Unix()
+		token := makeFakeJWT(t, map[string]any{"exp": exp})
+		got := saTokenExpiresInSeconds(token)
+		if got < 7000 || got > 7300 { // ~7200s ± a small window
+			t.Fatalf("expires_in = %d, want ~7200", got)
+		}
+	})
+
+	t.Run("past exp", func(t *testing.T) {
+		exp := time.Now().Add(-1 * time.Hour).Unix()
+		token := makeFakeJWT(t, map[string]any{"exp": exp})
+		if got := saTokenExpiresInSeconds(token); got != 0 {
+			t.Fatalf("expired token: got = %d, want 0", got)
+		}
+	})
+
+	t.Run("missing exp claim", func(t *testing.T) {
+		token := makeFakeJWT(t, map[string]any{"sub": "system:serviceaccount:periscope:periscope-agent"})
+		if got := saTokenExpiresInSeconds(token); got != -1 {
+			t.Fatalf("no exp claim: got = %d, want -1", got)
+		}
+	})
+
+	t.Run("not a JWT (legacy long-lived token)", func(t *testing.T) {
+		if got := saTokenExpiresInSeconds("legacy-long-lived-token"); got != -1 {
+			t.Fatalf("non-JWT: got = %d, want -1", got)
+		}
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		if got := saTokenExpiresInSeconds(""); got != -1 {
+			t.Fatalf("empty: got = %d, want -1", got)
+		}
+	})
+}
+
+func TestCAFingerprint(t *testing.T) {
+	if got := caFingerprint(nil); got != "" {
+		t.Fatalf("empty input → %q, want empty", got)
+	}
+	got := caFingerprint([]byte("some CA pem bytes"))
+	if !strings.HasPrefix(got, "sha256:") || len(got) != 23 { // "sha256:" + 16 hex
+		t.Fatalf("fingerprint = %q, want sha256:<16-hex>", got)
+	}
+	// Stable across calls
+	if got2 := caFingerprint([]byte("some CA pem bytes")); got2 != got {
+		t.Fatalf("fingerprint not stable: %q vs %q", got, got2)
+	}
+}
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+// captureLogger redirects slog default to a buffer for the test, then
+// restores it. Returns the buffer for assertion. Test-local — does
+// not race with other tests because each captureLogger call sets a
+// fresh handler before exercising the SUT.
+func captureLogger(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: level})))
+	return &buf
+}
+
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("logs missing %q\n--- full logs ---\n%s", needle, haystack)
+	}
+}
+
+// makeFakeJWT builds a minimal unsigned JWT. The signature is "sig"
+// (not validated by saTokenExpiresInSeconds — that function only
+// reads the payload claims).
+func makeFakeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadJSON, _ := json.Marshal(claims)
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	return header + "." + payload + "." + sig
+}

--- a/cmd/periscope-agent/proxy.go
+++ b/cmd/periscope-agent/proxy.go
@@ -1,0 +1,164 @@
+// Local HTTP reverse proxy that the agent runs to authenticate
+// apiserver requests on behalf of the central server (#59).
+//
+// Architecture:
+//
+//   server's http.Client
+//      ↓ (Impersonate-User: alice, Impersonate-Group: admin, NO Authorization)
+//   tunnel.RoundTripper → tunnel → agent's localDial
+//      ↓ (dial 127.0.0.1:proxyPort instead of the apiserver directly)
+//   this proxy.Handler.ServeHTTP
+//      ↓ injects Authorization: Bearer <agent SA token>
+//      ↓ preserves Impersonate-* headers
+//      ↓ forwards over HTTPS with kubelet-mounted apiserver CA
+//   local apiserver
+//      → authenticates: agent SA
+//      → authorises: agent SA has impersonate verb (granted by chart's ClusterRole)
+//      → re-evaluates as alice@corp + admin group
+//      → returns the response
+//
+// Pre-#59 the agent dialed the apiserver directly with no auth-aware
+// layer between server and apiserver. The apiserver rejected every
+// request with 401/403 before impersonation was even considered.
+// This file fixes that by terminating HTTP on the agent and re-issuing
+// each request with the agent's own SA credentials, leaving the
+// impersonation headers intact for the apiserver to evaluate normally.
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// startAPIProxy stands up a localhost HTTP server that forwards every
+// request to the local apiserver with the agent's SA bearer token
+// attached. The bind address is what the agent's localDial routes
+// to instead of the apiserver directly.
+//
+// Returns when the server shuts down or fails to bind.
+func startAPIProxy(inClusterCfg *rest.Config, listenAddr string) error {
+	apiserverURL, err := url.Parse(strings.TrimRight(inClusterCfg.Host, "/"))
+	if err != nil {
+		return fmt.Errorf("parse apiserver URL %q: %w", inClusterCfg.Host, err)
+	}
+	if apiserverURL.Scheme != "https" {
+		// Modern in-cluster configs always present HTTPS. If we ever
+		// see plain http here it's a misconfiguration (or kind/test
+		// scenario); refuse rather than silently forwarding a bearer
+		// token over an unencrypted hop.
+		return fmt.Errorf("apiserver URL %q is not https", inClusterCfg.Host)
+	}
+
+	if inClusterCfg.BearerToken == "" {
+		return errors.New("in-cluster config has no BearerToken — agent SA token missing")
+	}
+
+	tlsCfg, err := apiserverTLSConfig(inClusterCfg)
+	if err != nil {
+		return fmt.Errorf("apiserver TLS config: %w", err)
+	}
+
+	upstream := &http.Transport{
+		TLSClientConfig: tlsCfg,
+		// Match client-go defaults so streaming reads (watch, logs,
+		// SSE) don't get unexpected timeouts.
+		ForceAttemptHTTP2: true,
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			// Point at the local apiserver — overrides whatever Host
+			// the server's request used (the sentinel "apiserver.<c>.tunnel").
+			pr.SetURL(apiserverURL)
+
+			// Inject the agent's SA bearer token. ALWAYS overwrite —
+			// we don't trust whatever the server may have sent. The
+			// server is supposed to send no Authorization at all
+			// (only Impersonate-* headers), but defensive overwrite
+			// closes the "what if the server gets compromised and
+			// tries to substitute a token" hole.
+			pr.Out.Header.Set("Authorization", "Bearer "+inClusterCfg.BearerToken)
+
+			// Strip any X-Forwarded-* the ReverseProxy adds by default;
+			// the apiserver doesn't need them and they leak the tunnel
+			// internals into the apiserver's audit log.
+			pr.Out.Header.Del("X-Forwarded-For")
+			pr.Out.Header.Del("X-Forwarded-Host")
+			pr.Out.Header.Del("X-Forwarded-Proto")
+
+			// Note: Impersonate-User / Impersonate-Group / Impersonate-Extra-*
+			// are NOT in the hop-by-hop header list (RFC 7230 §6.1)
+			// so ReverseProxy passes them through unchanged. That's
+			// the load-bearing behaviour for #59 — the impersonation
+			// chain reaches the apiserver intact.
+		},
+		Transport: upstream,
+		// FlushInterval=-1 means flush after every Write — required
+		// for SSE / watch / logs streaming. Without it, ReverseProxy
+		// would buffer responses and the SPA's watch streams would
+		// stall indefinitely waiting for the buffer to fill.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			slog.Warn("proxy.upstream_error",
+				"path", r.URL.Path, "method", r.Method, "err", err)
+			http.Error(w, "agent → apiserver: "+err.Error(), http.StatusBadGateway)
+		},
+	}
+
+	srv := &http.Server{
+		Addr:              listenAddr,
+		Handler:           loggingMiddleware(proxy),
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	slog.Info("agent.api_proxy_listening",
+		"addr", listenAddr, "apiserver", apiserverURL.String())
+
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("api proxy: %w", err)
+	}
+	return nil
+}
+
+// apiserverTLSConfig builds the TLS config the proxy uses for its
+// outbound HTTPS to the apiserver. Trust anchor is the kubelet-
+// mounted CA bundle from inClusterCfg.CAData (or CAFile).
+func apiserverTLSConfig(inClusterCfg *rest.Config) (*tls.Config, error) {
+	pool := x509.NewCertPool()
+	switch {
+	case len(inClusterCfg.CAData) > 0:
+		if !pool.AppendCertsFromPEM(inClusterCfg.CAData) {
+			return nil, errors.New("could not append apiserver CA from CAData")
+		}
+	case inClusterCfg.CAFile != "":
+		// rest.InClusterConfig() typically sets CAData (loads file
+		// contents inline); CAFile fallback for completeness.
+		ca, err := readFile(inClusterCfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA file %q: %w", inClusterCfg.CAFile, err)
+		}
+		if !pool.AppendCertsFromPEM(ca) {
+			return nil, errors.New("could not append apiserver CA from CAFile")
+		}
+	default:
+		return nil, errors.New("in-cluster config has neither CAData nor CAFile")
+	}
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}, nil
+}
+
+// readFile is a thin indirection so tests can stub the CAFile load
+// without touching the filesystem. Production points at os.ReadFile.
+var readFile = os.ReadFile
+

--- a/cmd/periscope-agent/proxy_test.go
+++ b/cmd/periscope-agent/proxy_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// TestProxy_InjectsBearerAndPreservesImpersonation is the load-bearing
+// test for the #59 fix. Stands up a fake apiserver, points the proxy
+// Rewrite at it, fires a request with Impersonate-* but no Auth, and
+// asserts the apiserver receives Authorization: Bearer <token> AND the
+// Impersonate-* headers passed through unchanged. If this regresses,
+// agent-backed clusters fail authentication exactly as #59 described.
+func TestProxy_InjectsBearerAndPreservesImpersonation(t *testing.T) {
+	const wantBearer = "agent-sa-token-fixture"
+	const wantUser = "alice@corp"
+	const wantGroup = "periscope-tier:admin"
+
+	// 1. Fake "apiserver" that records what it received.
+	var seenAuth, seenUser, seenGroup, seenForwardedFor string
+	apiserver := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenUser = r.Header.Get("Impersonate-User")
+		seenGroup = r.Header.Get("Impersonate-Group")
+		seenForwardedFor = r.Header.Get("X-Forwarded-For")
+		_, _ = io.WriteString(w, `{"kind":"PodList"}`)
+	}))
+	defer apiserver.Close()
+
+	// 2. Build the proxy with the same Rewrite the production code uses.
+	apiserverURL, _ := url.Parse(apiserver.URL)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(apiserverURL)
+			pr.Out.Header.Set("Authorization", "Bearer "+wantBearer)
+			pr.Out.Header.Del("X-Forwarded-For")
+			pr.Out.Header.Del("X-Forwarded-Host")
+			pr.Out.Header.Del("X-Forwarded-Proto")
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfigTrustingServer(t, apiserver),
+		},
+	}
+
+	// 3. Stand up the proxy + fire a request with Impersonate-* headers.
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	req, _ := http.NewRequest("GET", proxyServer.URL+"/api/v1/pods", nil)
+	req.Header.Set("Impersonate-User", wantUser)
+	req.Header.Set("Impersonate-Group", wantGroup)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// 4. The apiserver MUST have seen the bearer + impersonation headers.
+	if got := seenAuth; got != "Bearer "+wantBearer {
+		t.Errorf("Authorization at apiserver = %q, want Bearer %s", got, wantBearer)
+	}
+	if seenUser != wantUser {
+		t.Errorf("Impersonate-User at apiserver = %q, want %q", seenUser, wantUser)
+	}
+	if seenGroup != wantGroup {
+		t.Errorf("Impersonate-Group at apiserver = %q, want %q", seenGroup, wantGroup)
+	}
+	if seenForwardedFor != "" {
+		t.Errorf("X-Forwarded-For leaked through to apiserver: %q (proxy should strip)", seenForwardedFor)
+	}
+}
+
+// TestProxy_OverwritesUntrustedAuthorizationHeader proves the proxy
+// always overwrites the Authorization header with the agent's own
+// bearer — even if the inbound request supplied one. Defense-in-depth
+// against a compromised or misbehaving central server.
+func TestProxy_OverwritesUntrustedAuthorizationHeader(t *testing.T) {
+	const wantBearer = "agent-sa-token-fixture"
+	const attackerToken = "attacker-supplied-token"
+
+	var seenAuth string
+	apiserver := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer apiserver.Close()
+
+	apiserverURL, _ := url.Parse(apiserver.URL)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(apiserverURL)
+			pr.Out.Header.Set("Authorization", "Bearer "+wantBearer)
+		},
+		Transport: &http.Transport{TLSClientConfig: tlsConfigTrustingServer(t, apiserver)},
+	}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	req, _ := http.NewRequest("GET", proxyServer.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+attackerToken) // hostile inbound
+	resp, _ := http.DefaultClient.Do(req)
+	defer func() { _ = resp.Body.Close() }()
+
+	if seenAuth == "Bearer "+attackerToken {
+		t.Fatal("attacker-supplied Authorization reached apiserver — proxy must always overwrite")
+	}
+	if seenAuth != "Bearer "+wantBearer {
+		t.Fatalf("apiserver saw Authorization = %q, want Bearer %s", seenAuth, wantBearer)
+	}
+}
+
+// TestApiserverTLSConfig_RejectsConfigWithoutCA confirms the proxy
+// won't start in misconfigurations where neither CAData nor CAFile is
+// available. Failing loudly is preferable to silently disabling TLS
+// verification.
+func TestApiserverTLSConfig_RejectsConfigWithoutCA(t *testing.T) {
+	cfg := &rest.Config{Host: "https://kubernetes.default:443"}
+	if _, err := apiserverTLSConfig(cfg); err == nil {
+		t.Fatal("apiserverTLSConfig accepted config with no CA")
+	}
+}
+
+// TestApiserverTLSConfig_AcceptsCAData proves the happy path —
+// CAData populated (the shape rest.InClusterConfig() always produces).
+func TestApiserverTLSConfig_AcceptsCAData(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	})
+
+	cfg := &rest.Config{
+		Host:        srv.URL,
+		BearerToken: "irrelevant-for-tls-config",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: caPEM,
+		},
+	}
+	tlsCfg, err := apiserverTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("apiserverTLSConfig: %v", err)
+	}
+	if tlsCfg.RootCAs == nil {
+		t.Fatal("RootCAs is nil — CA didn't get appended")
+	}
+	if tlsCfg.MinVersion < tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want >= TLS 1.2", tlsCfg.MinVersion)
+	}
+}
+
+// TestStartAPIProxy_RejectsHTTPApiserver confirms we refuse to start
+// the proxy when the in-cluster config presents a plain-http apiserver
+// URL — that would mean forwarding an SA bearer token over an
+// unencrypted hop. Modern in-cluster configs never produce this; the
+// guard is for misconfigurations / kind tests / future regressions.
+func TestStartAPIProxy_RejectsHTTPApiserver(t *testing.T) {
+	cfg := &rest.Config{
+		Host:        "http://insecure-apiserver:8080",
+		BearerToken: "x",
+	}
+	err := startAPIProxy(cfg, "127.0.0.1:0")
+	if err == nil {
+		t.Fatal("startAPIProxy accepted plain-http apiserver URL")
+	}
+}
+
+// TestStartAPIProxy_RejectsEmptyBearerToken confirms we refuse to
+// start when the agent's SA token is missing. Without this guard the
+// proxy would forward unauthenticated requests, regressing #59.
+func TestStartAPIProxy_RejectsEmptyBearerToken(t *testing.T) {
+	cfg := &rest.Config{
+		Host: "https://kubernetes.default:443",
+		// BearerToken deliberately empty
+		TLSClientConfig: rest.TLSClientConfig{CAData: []byte("dummy")},
+	}
+	err := startAPIProxy(cfg, "127.0.0.1:0")
+	if err == nil {
+		t.Fatal("startAPIProxy accepted config without BearerToken")
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+func tlsConfigTrustingServer(t *testing.T, srv *httptest.Server) *tls.Config {
+	t.Helper()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+}

--- a/deploy/helm/periscope-agent/README.md
+++ b/deploy/helm/periscope-agent/README.md
@@ -73,6 +73,7 @@ typos surface immediately, not at pod-start.
 |---|---|
 | `agent.registrationURL` | URL for the unauth registration POST. Set when central server splits HTTP and mTLS onto different load balancers (ALB+NLB topology). Empty = derive from `serverURL` via wss/ws → https/http translation. |
 | `agent.serverCAHash` | SPKI hash for kubeadm-style pinning on the registration TLS dial. Format: `sha256:<64 hex chars>`. Bootstraps the agent against a self-signed central server endpoint without distributing the full CA bundle. |
+| `agent.logLevel` | Optional log level: `debug`, `info`, `warn`, `error`. Default empty = `info`. Set `debug` to add per-request access logs through the proxy with `request_id` correlation to the central server's audit DB. |
 
 Three deployment topologies — pick the one matching your central
 server's LB shape:

--- a/deploy/helm/periscope-agent/templates/deployment.yaml
+++ b/deploy/helm/periscope-agent/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.agent.stateSecretName | quote }}
             - name: PERISCOPE_AGENT_HEALTH_ADDR
               value: {{ .Values.agent.healthAddr | quote }}
+            {{- if .Values.agent.logLevel }}
+            - name: PERISCOPE_LOG_LEVEL
+              value: {{ .Values.agent.logLevel | quote }}
+            {{- end }}
             {{- if .Values.agent.registrationURL }}
             - name: PERISCOPE_REGISTRATION_URL
               value: {{ .Values.agent.registrationURL | quote }}

--- a/deploy/helm/periscope-agent/values.schema.json
+++ b/deploy/helm/periscope-agent/values.schema.json
@@ -63,6 +63,11 @@
           "type": "string",
           "pattern": "^:[0-9]+$",
           "description": "Bind addr for the kubelet probe target. Format ':PORT'."
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": ["", "debug", "info", "warn", "error"],
+          "description": "Optional agent log level. Empty = use the binary default (info). Set debug to enable per-request access logs through the proxy."
         }
       },
       "additionalProperties": false

--- a/deploy/helm/periscope-agent/values.yaml
+++ b/deploy/helm/periscope-agent/values.yaml
@@ -75,6 +75,20 @@ agent:
   # Health probe port (kubelet liveness + readiness target).
   healthAddr: ":8081"
 
+  # Optional: agent log level. Empty = use the binary's default
+  # (info). Accepts: debug, info, warn, error. Set debug when
+  # debugging an apiserver-rejection or "request not reaching
+  # apiserver" issue — adds per-request access logs through the
+  # proxy:
+  #
+  #   helm upgrade ... --set agent.logLevel=debug
+  #
+  # Each log line carries a request_id matching X-Request-Id from
+  # the central server's middleware, so one id grepped across the
+  # server's audit DB + server stdout + agent stdout gives a single
+  # end-to-end trace.
+  logLevel: ""
+
 # ─── deployment shape ───────────────────────────────────────────────
 replicaCount: 1   # tunnel sessions are 1:1 with agent pods; HA needs server-side peer routing (v1.5+)
 

--- a/docs/architecture/agent-tunnel.md
+++ b/docs/architecture/agent-tunnel.md
@@ -314,7 +314,7 @@ tests substitute their own. The default refuses with a clear
 `"SetAgentTunnelLookup not called"` error so a misconfigured
 build never silently accepts agent-backed entries.
 
-## 8. Identity propagation
+## 8. Identity propagation (post-#59)
 
 Every Periscope handler talks to apiserver as the human user via
 `Impersonate-User` / `Impersonate-Group` headers (see
@@ -329,7 +329,10 @@ periscope handler
    │ rest.Config.Impersonate.UserName = "alice@corp"
    ▼
 http.Client built from rest.Config
-   │ HTTP request includes Impersonate-User header
+   │ outgoing request:
+   │   Impersonate-User: alice@corp
+   │   Impersonate-Group: periscope-tier:admin
+   │   (no Authorization — added by agent)
    ▼
 tunnel.NewRoundTripper
    │ TCP frame (HTTP bytes) into WS multiplexer
@@ -337,24 +340,65 @@ tunnel.NewRoundTripper
 remotedialer Session
    │ WS frame (TCP bytes) over wss://
    ▼
-periscope-agent
-   │ TCP frame received, fed to local apiserver dialer
+periscope-agent's local HTTP reverse proxy (cmd/periscope-agent/proxy.go)
+   │ adds Authorization: Bearer <agent SA token>
+   │ preserves Impersonate-* headers
+   │ forwards as HTTPS with kubelet-mounted apiserver CA
    ▼
 apiserver in managed cluster
-   │ sees the Impersonate-User header, evaluates RBAC against alice
+   │ authenticates: agent's ServiceAccount
+   │ checks: SA has "impersonate" verb? ✓ (chart's ClusterRole)
+   │ re-evaluates as alice@corp + admin group
+   │ runs the verb under alice's RBAC
 ```
 
-The agent itself talks to apiserver as **its own SA**. The
-apiserver authenticates the agent via the SA token (kubelet-mounted)
-and authorises **the agent's RBAC** (read + impersonate by default).
-But for the actual K8s call, the apiserver evaluates the Impersonate
-headers — so the verb runs as `alice`, audit-logged with `alice`'s
-identity, denied if `alice` lacks the verb. The agent's RBAC is the
-ceiling for what's physically possible; per-call authorization is the
-human's RBAC.
+The agent talks to apiserver as **its own SA**. The apiserver
+authenticates the agent via the SA token (kubelet-mounted into the
+agent pod) and authorises **the agent's RBAC** (read + impersonate
+by default). But for the actual K8s call, the apiserver evaluates
+the Impersonate headers — so the verb runs as `alice`, audit-logged
+with `alice`'s identity, denied if `alice` lacks the verb. The
+agent's RBAC is the ceiling for what's physically possible; per-call
+authorization is the human's RBAC.
 
 This is the same impersonation model as the `eks` and `kubeconfig`
-backends, just with a different transport carrying the headers.
+backends, just with a different bridge identity:
+
+| Backend | Bridge identity | Auth credential | Origin |
+|---|---|---|---|
+| `eks` | EKS-mapped K8s user | EKS bearer token | minted per-request via `eks:GetToken` |
+| `in-cluster` | host pod's SA | kubelet-mounted SA token | host pod's `/var/run/secrets/...` |
+| `agent` | agent pod's SA | kubelet-mounted SA token | **agent** pod's `/var/run/secrets/...` |
+
+### Why the local HTTP proxy (architectural note)
+
+Pre-#59 the agent forwarded raw TCP bytes from the tunnel directly
+to the apiserver. The server's HTTP request (built with no
+Authorization header — only Impersonate-*) reached the apiserver
+unauthenticated, the apiserver rejected it with 401/403 before
+impersonation was even consulted, and every agent-backed cluster
+appeared `denied` in the fleet view.
+
+The fix: the agent runs a tiny `httputil.ReverseProxy` on
+`127.0.0.1:7443`. The tunnel's `localDial` routes there instead of
+to the apiserver. The proxy injects the agent's SA bearer token,
+preserves Impersonate-* headers, and re-issues each request to the
+apiserver over HTTPS using the kubelet-mounted CA bundle. TLS now
+terminates at the proxy (not end-to-end through the tunnel), so the
+server-side `rest.Config.Host` switched to `http://apiserver.<c>.tunnel`
+(plain HTTP between server and tunnel; the unencrypted hop is in-
+process bytes, never touching the network).
+
+The proxy:
+- Always overwrites the inbound `Authorization` header (defensive —
+  closes the "compromised central server tries to substitute its
+  own token" hole)
+- Strips `X-Forwarded-*` headers `httputil.ReverseProxy` adds by
+  default (apiserver doesn't need them; they leak tunnel internals
+  into the apiserver's audit log)
+- Sets `FlushInterval=-1` so SSE / watch / logs streaming flushes
+  immediately (otherwise responses buffer and the SPA's watch streams
+  stall)
 
 ## 9. Audit shape
 

--- a/docs/setup/agent-onboarding.md
+++ b/docs/setup/agent-onboarding.md
@@ -260,7 +260,8 @@ going healthy, the fastest path to a root cause is to enable per-
 request logs on the agent:
 
 ```sh
-kubectl -n periscope set env deploy/periscope-agent PERISCOPE_LOG_LEVEL=debug
+helm upgrade periscope-agent oci://ghcr.io/gnana997/charts/periscope-agent \
+  -n periscope --reuse-values --set agent.logLevel=debug
 kubectl -n periscope rollout status deploy/periscope-agent
 kubectl -n periscope logs -l app.kubernetes.io/name=periscope-agent -f | jq .
 ```
@@ -277,7 +278,8 @@ in the server's audit DB and stdout slog for end-to-end correlation.
 Reset to default once you're done:
 
 ```sh
-kubectl -n periscope set env deploy/periscope-agent PERISCOPE_LOG_LEVEL-
+helm upgrade periscope-agent oci://ghcr.io/gnana997/charts/periscope-agent \
+  -n periscope --reuse-values --set agent.logLevel=""
 ```
 
 

--- a/docs/setup/agent-onboarding.md
+++ b/docs/setup/agent-onboarding.md
@@ -253,6 +253,34 @@ with the correct value.
 
 ## Troubleshooting
 
+### Turn on debug logging on the agent
+
+When something goes wrong between agent registration and the cluster
+going healthy, the fastest path to a root cause is to enable per-
+request logs on the agent:
+
+```sh
+kubectl -n periscope set env deploy/periscope-agent PERISCOPE_LOG_LEVEL=debug
+kubectl -n periscope rollout status deploy/periscope-agent
+kubectl -n periscope logs -l app.kubernetes.io/name=periscope-agent -f | jq .
+```
+
+You'll see one `proxy.request_in` and one `proxy.request_out` per
+request flowing through the agent, plus a `proxy.apiserver_error`
+(at WARN level — visible even at the default `info` log level)
+whenever the apiserver returns 4xx/5xx.
+
+Each line carries a `request_id` matching the `X-Request-Id` the
+central server's middleware sets on every API call — grep the same id
+in the server's audit DB and stdout slog for end-to-end correlation.
+
+Reset to default once you're done:
+
+```sh
+kubectl -n periscope set env deploy/periscope-agent PERISCOPE_LOG_LEVEL-
+```
+
+
 ### `tls: failed to verify certificate: x509: certificate signed by unknown authority`
 
 The agent is dialing a self-signed registration endpoint without a

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -44,6 +44,7 @@ shape itself), see [`docs/setup/deploy.md`](deploy.md).
 | `PERISCOPE_AGENT_NAMESPACE` | _(in-pod namespace)_ | Where the agent persists state | `(derived)` |
 | `PERISCOPE_AGENT_SECRET_NAME` | `periscope-agent-state` | State Secret name (cert + key + server CA) | `agent.stateSecretName` |
 | `PERISCOPE_AGENT_HEALTH_ADDR` | `:8081` | Bind addr for /healthz | `agent.healthAddr` |
+| `PERISCOPE_LOG_LEVEL` | `info` | Log level for the agent: debug/info/warn/error | _(via env: array)_ |
 | `PERISCOPE_REGISTRATION_URL` | _(derive from serverURL)_ | URL for the unauth registration POST when split from tunnel | `agent.registrationURL` |
 | `PERISCOPE_SERVER_CA_HASH` | _(unset = system roots)_ | SPKI hash for kubeadm-style pinning on registration TLS | `agent.serverCAHash` |
 
@@ -511,6 +512,47 @@ doesn't break the pin (RFC 7469).
 Helm rendering: `agent.serverCAHash`. Schema rejects values that
 don't match `^sha256:[0-9a-fA-F]{64}$`.
 
+#### `PERISCOPE_LOG_LEVEL`
+
+Optional. Default `info`. Accepts: `debug`, `info`, `warn`, `error`
+(case-insensitive). Drives `slog.Default()`'s level for every log
+line the agent emits.
+
+Levels:
+
+- **`info`** (default) — boot events, tunnel connect/disconnect,
+  registration completion, apiserver-side errors (4xx/5xx). Suitable
+  for production.
+- **`debug`** — adds per-request access logs through the proxy:
+  - `proxy.request_in` (method, path, impersonate-user, request_id)
+  - `proxy.request_out` (method, path, status, latency_ms, bytes, request_id)
+  Use when debugging an apiserver-rejection or "request not reaching
+  apiserver" issue.
+- **`warn`** / **`error`** — silence info; useful in noisy log-
+  aggregation pipelines where the agent should only speak up on
+  trouble.
+
+Helm rendering: pass through the chart's escape-hatch `env` array
+(no dedicated values field — keeping the surface minimal). Example:
+
+```yaml
+env:
+  - name: PERISCOPE_LOG_LEVEL
+    value: debug
+```
+
+Bonus: every agent log line carries `request_id` taken from the
+`X-Request-Id` header that the central server's chi middleware sets
+on every API call. Same id appears on the server's audit row (RFC
+0003 §6 — `requestId`). One id grepped across server audit DB +
+server stdout slog + agent stdout slog gives a single end-to-end
+trace for any user click.
+
+Server-side `PERISCOPE_LOG_LEVEL` parity is a v1.x.+ follow-up — the
+agent is the binary that's currently blind to per-request issues, so
+it ships observability first.
+
+
 
 ---
 
@@ -520,9 +562,10 @@ Likely additions in v1.x:
 
 - `PERISCOPE_SESSION_STORE=redis` plus `PERISCOPE_SESSION_DSN=...`
   when the multi-replica session store lands.
-- `PERISCOPE_LOG_LEVEL` for runtime log-level tuning. Today the
-  binary uses `slog.Default()` at info; level overrides require a
-  rebuild.
+- `PERISCOPE_LOG_LEVEL` parity for the central server. The agent
+  already supports it (see §11); extending to the server is a
+  ~10-LoC follow-up tracked alongside the next agent observability
+  iteration.
 
 These will be additive — operators who don't set them get the
 SQLite / in-memory / info-level defaults that v1.0 ships with.

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -44,7 +44,7 @@ shape itself), see [`docs/setup/deploy.md`](deploy.md).
 | `PERISCOPE_AGENT_NAMESPACE` | _(in-pod namespace)_ | Where the agent persists state | `(derived)` |
 | `PERISCOPE_AGENT_SECRET_NAME` | `periscope-agent-state` | State Secret name (cert + key + server CA) | `agent.stateSecretName` |
 | `PERISCOPE_AGENT_HEALTH_ADDR` | `:8081` | Bind addr for /healthz | `agent.healthAddr` |
-| `PERISCOPE_LOG_LEVEL` | `info` | Log level for the agent: debug/info/warn/error | _(via env: array)_ |
+| `PERISCOPE_LOG_LEVEL` | `info` | Log level for the agent: debug/info/warn/error | `agent.logLevel` |
 | `PERISCOPE_REGISTRATION_URL` | _(derive from serverURL)_ | URL for the unauth registration POST when split from tunnel | `agent.registrationURL` |
 | `PERISCOPE_SERVER_CA_HASH` | _(unset = system roots)_ | SPKI hash for kubeadm-style pinning on registration TLS | `agent.serverCAHash` |
 
@@ -532,13 +532,12 @@ Levels:
   aggregation pipelines where the agent should only speak up on
   trouble.
 
-Helm rendering: pass through the chart's escape-hatch `env` array
-(no dedicated values field — keeping the surface minimal). Example:
+Helm rendering: `agent.logLevel`. Schema enum-validated against
+the four canonical values; empty (default) means "use the binary's
+default" (no env var rendered, agent picks `info`). Example:
 
-```yaml
-env:
-  - name: PERISCOPE_LOG_LEVEL
-    value: debug
+```sh
+helm upgrade ... --set agent.logLevel=debug
 ```
 
 Bonus: every agent log line carries `request_id` taken from the

--- a/internal/k8s/agent_transport.go
+++ b/internal/k8s/agent_transport.go
@@ -21,7 +21,6 @@ package k8s
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -78,13 +77,20 @@ func currentAgentLookup() AgentTunnelLookup {
 // buildAgentRestConfig constructs a *rest.Config whose Transport is
 // the tunnel-bound RoundTripper. The clientset built from this config
 // looks identical to a kubeconfig-built one to handler code; only the
-// bytes flow differently.
 //
-// The Host is a sentinel ("https://apiserver.<cluster>.tunnel") that
-// the agent ignores when it dials the local apiserver — it's there
-// because rest.Config.Host is required, but the tunnel transport
-// short-circuits the actual dial so the value never leaves the
-// process.
+// The Host is a sentinel ("http://apiserver.<cluster>.tunnel") that
+// the agent's local HTTP proxy receives — it's there because
+// rest.Config.Host is required, but the tunnel transport short-
+// circuits the actual dial so the value never leaves the process.
+//
+// Why http:// (not https://): TLS now terminates at the agent's
+// local reverse proxy on the managed cluster (#59 fix). The agent
+// re-issues each incoming request to the local apiserver over
+// HTTPS using the kubelet-mounted CA bundle, with the agent's SA
+// bearer token attached. Pre-#59 the server tried to do end-to-end
+// TLS to the apiserver through the tunnel with no auth headers —
+// the apiserver rejected every request with 401/403 before
+// impersonation was even evaluated.
 func buildAgentRestConfig(_ context.Context, p credentials.Provider, c clusters.Cluster) (*rest.Config, error) {
 	dial, err := currentAgentLookup()(c.Name)
 	if err != nil {
@@ -93,25 +99,18 @@ func buildAgentRestConfig(_ context.Context, p credentials.Provider, c clusters.
 
 	cfg := &rest.Config{
 		Host: agentHostSentinel(c.Name),
-		// rest.Config.Transport pre-empts every other dial/TLS setting,
-		// which is exactly what we want. Do NOT set TLSClientConfig here
-		// — client-go refuses to build a clientset when both Transport
-		// and TLSClientConfig are set ("using a custom transport with TLS
-		// certificate options or the insecure flag is not allowed").
-		//
-		// The tunnel RoundTripper handles TLS internally: the outer hop
-		// (this process → tunnel) skips TLS because the bytes never leave
-		// the process; the inner hop (agent → real apiserver) uses the
-		// agent's in-cluster CA bundle, which is the actual trust boundary.
+		// rest.Config.Transport pre-empts every other dial/TLS setting.
+		// We deliberately set NO TLSClientConfig — client-go refuses
+		// to build a clientset when both Transport and TLSClientConfig
+		// are set, AND the tunnel + agent-proxy chain handles auth and
+		// TLS itself: the outer hop (server → tunnel) is plain bytes
+		// inside this process; the inner hop (agent → apiserver) is
+		// HTTPS with the kubelet's CA bundle, terminated at the agent.
 		Transport: tunnel.NewRoundTripper(
 			func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return dial(ctx, network, addr)
 			},
-			tunnel.RoundTripperOptions{
-				// Skip TLS on the tunnel-side connection; the inner
-				// hop (agent → apiserver) carries the real TLS.
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			},
+			tunnel.RoundTripperOptions{},
 		),
 	}
 	applyImpersonation(cfg, p)
@@ -121,7 +120,10 @@ func buildAgentRestConfig(_ context.Context, p credentials.Provider, c clusters.
 // agentHostSentinel produces the placeholder Host the rest.Config
 // requires. The transport short-circuits the dial, so the actual
 // hostname is never resolved or contacted — it only needs to be a
-// syntactically-valid URL for client-go's request building.
+// syntactically-valid URL for client-go's request building. The
+// http:// scheme matters: client-go uses it to decide whether to
+// negotiate TLS on the (intercepted) outbound dial, and we want it
+// to NOT, since TLS terminates at the agent's reverse proxy.
 func agentHostSentinel(cluster string) string {
-	return "https://apiserver." + cluster + ".tunnel"
+	return "http://apiserver." + cluster + ".tunnel"
 }

--- a/internal/k8s/agent_transport_test.go
+++ b/internal/k8s/agent_transport_test.go
@@ -61,6 +61,9 @@ func TestSetAgentTunnelLookup_HappyPath(t *testing.T) {
 	if cfg.Host == "" {
 		t.Fatal("rest.Config.Host is empty (clientset would refuse)")
 	}
+	if !strings.HasPrefix(cfg.Host, "http://") {
+		t.Fatalf("Host = %q, want http:// scheme (TLS terminates at agent proxy now per #59)", cfg.Host)
+	}
 	if !strings.Contains(cfg.Host, "prod-eu") {
 		t.Fatalf("Host = %q, want it to embed the cluster name", cfg.Host)
 	}


### PR DESCRIPTION
Adds the trace points the agent was missing for operators to debug
auth / RBAC / proxy issues from the agent log alone. Bundled with
the #59 auth fix so rc10 ships proxy + observability together.

PERISCOPE_LOG_LEVEL env var (cmd/periscope-agent/observability.go):
- Default `info`. Accepts debug/info/warn/error (case-insensitive).
- Drives slog default handler — stdout JSON.
- Garbage values fall back to info (safe default).

Per-request access log middleware (loggingMiddleware):
- DEBUG  proxy.request_in   method, path, impersonate-user, request_id
- DEBUG  proxy.request_out  method, path, status, latency_ms, bytes, request_id
- WARN   proxy.apiserver_error  fires on status >= 400, ALWAYS-ON even
         at INFO. The line that would have made #59 obvious from day one
         ("status=401 every request, no Authorization header inbound").
- Authorization header value NEVER logged at any level.

Request-id correlation:
- Reads X-Request-Id from inbound (set by the central server's chi
  middleware). Same id appears on the server's audit row (RFC 0003 §6
  requestId). One id grepped across server audit DB + server stdout
  slog + agent stdout slog gives a single end-to-end trace per click.

Boot diagnostic dump (logBootDiagnostic):
- One INFO line at startup with apiserver_url, ca_bundle_len,
  ca_fingerprint (sha256: short), sa_token_present, sa_token_expires_in_seconds
- Critical for "why did auth start failing 60 minutes after install" —
  projected SA tokens default to 1-hour TTL with auto-rotation; the
  expiry timestamp predicts the failure window.
- Token VALUE never logged; only the JWT exp claim.

ResponseRecorder wraps the proxy's ResponseWriter to capture status
+ bytes while preserving Flusher (SSE/watch streaming). Hijack
deferred to v1.x.1 alongside exec (#43) — has compile-time guard.

7 new tests (15 subtests):
- parseLogLevel boundary cases (10 subtests including unknown→safe-default)
- access logs fire at debug, suppressed at info
- error logs fire at every level (3 subtests: debug/info/warn)
- Authorization header value never appears in logs (security guard)
- SA token JWT exp parsing (5 subtests: future / past / missing / non-JWT / empty)
- CA fingerprint format + stability

Docs:
- docs/setup/environment-variables.md: removes the v1.x.+ "future"
  entry for PERISCOPE_LOG_LEVEL, replaces with a real §11 Agent
  backend entry; glance table row added; §12 forward-roadmap notes
  server-side parity as a v1.x.+ follow-up.
- docs/setup/agent-onboarding.md: new "Turn on debug logging on the
  agent" subsection in Troubleshooting with the kubectl set env
  recipe + the request-id correlation pattern.

Server-side log-level parity tracked separately; agent-only this PR
(server's logs are already richer; agent was the binary that's blind).