### PR TITLE
Fix log stream resize oscillation with text wrapping enabled

### DIFF
--- a/web/src/components/logs/LogStream.tsx
+++ b/web/src/components/logs/LogStream.tsx
@@ -84,9 +84,47 @@ export function LogStream(props: LogStreamProps) {
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: (i) => (rows[i]?.kind === "divider" ? 14 : 22),
+    // When wrap is enabled, estimate larger so the initial fixed-size
+    // pass is closer to the wrapped reality. This dramatically reduces
+    // the volume of measureElement→resizeItem corrections that flow
+    // through TanStack Virtual on first paint, which is one of the
+    // ingredients in the resize-loop described by issue #65.
+    estimateSize: (i) => {
+      if (rows[i]?.kind === "divider") return 14;
+      return wrap ? 66 : 22;
+    },
     overscan: 24,
   });
+
+  // Width oscillation guard. measureElement uses a ResizeObserver under
+  // the hood; with `wrap` on at narrow pane widths, the act of measuring
+  // can change container width (scrollbar appears), which feeds back as
+  // another resize, ad infinitum (React error #185). We watch the parent
+  // and freeze dynamic measurement during active resize, then trigger a
+  // single virtualizer.measure() once the container settles.
+  const [resizing, setResizing] = useState(false);
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    let timer: number | undefined;
+    let lastWidth = el.clientWidth;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? lastWidth;
+      if (w === lastWidth) return;
+      lastWidth = w;
+      setResizing(true);
+      if (timer !== undefined) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        setResizing(false);
+        virtualizer.measure();
+      }, 150);
+    });
+    ro.observe(el);
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      ro.disconnect();
+    };
+  }, [virtualizer]);
 
   // Auto-stick to bottom while follow is on. wasAtBottomRef drives the
   // auto-scroll decision (avoids re-renders); isAtBottom mirrors it as
@@ -241,7 +279,7 @@ export function LogStream(props: LogStreamProps) {
     <div className="relative min-h-0 flex-1 bg-bg">
       <div
         ref={parentRef}
-        className="absolute inset-0 overflow-y-auto"
+        className="absolute inset-0 overflow-y-scroll"
       >
       <div
         style={{
@@ -256,7 +294,7 @@ export function LogStream(props: LogStreamProps) {
             <div
               key={vi.key}
               data-index={vi.index}
-              ref={virtualizer.measureElement}
+              ref={resizing ? undefined : virtualizer.measureElement}
               style={{
                 position: "absolute",
                 top: 0,

--- a/web/src/components/page/SplitPane.tsx
+++ b/web/src/components/page/SplitPane.tsx
@@ -12,7 +12,9 @@ interface SplitPaneProps {
    *  look the same regardless of monitor size. */
   initial?: number;
   /** Minimum detail-pane width in pixels. Drag-resize honors this.
-   *  Default 480 — below this the chip grid collapses to one column. */
+   *  Default 520 — below this the chip grid collapses to one column,
+   *  and the Logs tab's wrap mode + dynamic row measurement starts
+   *  oscillating against scrollbar appearance (issue #65). */
   min?: number;
   /** Maximum detail-pane width in pixels. Default 1100 — wide enough
    *  for YAML and event tables while still leaving room for the table. */
@@ -49,7 +51,7 @@ export function SplitPane({
   right,
   storageKey,
   initial = 640,
-  min = 480,
+  min = 520,
   max = 1100,
   minLeft = 320,
 }: SplitPaneProps) {


### PR DESCRIPTION
## Summary
Fixes a resize loop issue (#65) that occurs in the LogStream component when text wrapping is enabled at narrow pane widths. The problem stems from dynamic row measurement triggering scrollbar appearance changes, which feed back as resize events in an infinite loop.

## Key Changes

- **LogStream virtualization improvements**:
  - Increased initial row height estimate when `wrap` is enabled (66px vs 22px) to better match wrapped text reality on first paint, reducing measurement corrections
  - Added a ResizeObserver-based width oscillation guard that freezes dynamic measurement during active resize events and triggers a single `virtualizer.measure()` once the container settles (150ms debounce)
  - Changed overflow behavior from `overflow-y-auto` to `overflow-y-scroll` to prevent scrollbar flashing during measurement
  - Conditionally disable `virtualizer.measureElement` ref during resize to prevent feedback loops

- **SplitPane minimum width adjustment**:
  - Increased default `min` width from 480px to 520px to provide adequate space for the Logs tab's wrap mode and dynamic measurement without triggering oscillation

## Implementation Details

The resize guard uses a ResizeObserver to detect width changes on the parent container. When a resize is detected, it sets a `resizing` flag and schedules a debounced callback. During the resizing state, the virtualizer's `measureElement` ref is set to `undefined`, preventing measurement-triggered layout shifts. Once the container settles (no resize events for 150ms), the flag is cleared and a single `measure()` call reconciles the virtualizer with the final layout.

This approach prevents the cascading effect where measuring elements → scrollbar appearance → width change → measure again cycle that was causing React error #185.

https://claude.ai/code/session_01LKeiXCNxk4WK74xaKoF4CA