### PR TITLE
docs: add architecture overview, Helm values reference, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The more of the fields below you can fill in, the
+        faster we can reproduce. If a field genuinely doesn't apply, write "n/a".
+
+        For security vulnerabilities, please follow the process in
+        [SECURITY.md](../../SECURITY.md) instead of opening a public issue.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug, plus what you expected to happen.
+      placeholder: |
+        I clicked "Open Shell" on a pod and got an instant disconnect.
+        I expected an interactive shell.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps. Include the cluster name in the registry, namespace, and pod where relevant.
+      placeholder: |
+        1. Sign in via Auth0
+        2. Open `prod-eu` cluster, navigate to pods in `default`
+        3. Click "Open Shell" on `nginx-abc-xyz`
+        4. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Periscope version
+      description: Output of the `/healthz` endpoint, the GitHub release tag, or the chart version.
+      placeholder: "v1.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Cluster backend
+      description: How Periscope reaches the cluster where the bug appears.
+      options:
+        - eks (Pod Identity / IRSA)
+        - kubeconfig
+        - in-cluster
+        - agent
+        - n/a (not cluster-specific)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: auth
+    attributes:
+      label: OIDC provider
+      options:
+        - Auth0
+        - Okta
+        - Other
+        - n/a (not auth-related)
+    validations:
+      required: true
+
+  - type: input
+    id: k8s-version
+    attributes:
+      label: Kubernetes version
+      description: `kubectl version --short` of the affected cluster.
+      placeholder: "v1.30.4"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Pod logs from `kubectl -n periscope logs deploy/periscope` and (if applicable)
+        `deploy/periscope-agent`. Redact tokens, cookies, and SA secrets.
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config
+      description: |
+        Helm values, the `clusters[]` entry for the affected cluster, and any
+        `PERISCOPE_*` env overrides — minus secrets.
+      render: yaml
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I have searched [existing issues](https://github.com/gnana997/periscope/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: I am not reporting a security vulnerability (those go through SECURITY.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/gnana997/periscope/discussions
+    about: For usage questions, deployment help, or open-ended discussion, please use Discussions instead of Issues.
+  - name: Security vulnerability
+    url: https://github.com/gnana997/periscope/security/policy
+    about: Do NOT open a public issue. See SECURITY.md for the responsible-disclosure process.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature request
+description: Propose a new feature or enhancement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Open an issue describing the use case before writing the code, especially for
+        anything that affects the backend API, auth model, or audit shape — see
+        [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: |
+        The use case, not the proposed solution. "I want to do X but the SPA does Y" is
+        more useful than "add button Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like Periscope to do. Sketches / mockups welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why this one wins.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface affected
+      multiple: true
+      options:
+        - SPA (browser UI)
+        - HTTP API
+        - Helm chart / operator config
+        - Agent
+        - Audit / observability
+        - Auth / RBAC
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I have searched [existing issues](https://github.com/gnana997/periscope/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@ Thanks for the PR. A few notes before you submit:
 - [ ] Audit / RBAC
 - [ ] Agent backend / tunnel
 - [ ] SPA / frontend
+- [ ] Documentation
 - [ ] None of the above
 
 ## How was this tested?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+<!--
+Thanks for the PR. A few notes before you submit:
+
+- For larger work, please link to the issue / RFC where the design was discussed.
+- For backend or auth/audit changes, please re-read CONTRIBUTING.md's "Coding
+  conventions" section before opening.
+- CI will run golangci-lint, go test, npm lint/test/build, helm lint+template,
+  and an embedded-binary build. Locally: `make test` + `make build` covers most.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What changed and why. -->
+
+## Related issue / RFC
+
+<!-- Closes #N, refs #M. If there's no issue, briefly justify why. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (user-visible API, config shape, or Helm values)
+- [ ] Docs only
+- [ ] Refactor / internal cleanup
+- [ ] Test or CI only
+
+## Surfaces touched
+
+- [ ] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
+- [ ] Helm values — see `deploy/helm/periscope/values.yaml` schema
+- [ ] OIDC / auth / authz
+- [ ] Audit / RBAC
+- [ ] Agent backend / tunnel
+- [ ] SPA / frontend
+- [ ] None of the above
+
+## How was this tested?
+
+<!--
+Describe the test plan. For bugs, what was the repro and what does the fix
+exhibit now. For features, the golden path + edge cases you exercised.
+-->
+
+## Checklist
+
+- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] Tests added or updated where it makes sense.
+- [ ] Docs updated (`docs/`, `README.md`, or `CHANGELOG.md` under `[Unreleased]`).
+- [ ] No secrets, real cluster names, or real OIDC client IDs in committed files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,41 @@ tag.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Documentation
+
+- Added [`docs/architecture/README.md`](docs/architecture/README.md) —
+  top-level architecture overview: component map, source-tree
+  guide, suggested reading order for new contributors, and
+  cross-cutting design choices (single binary + embedded SPA,
+  stateless w.r.t. credentials, impersonation everywhere,
+  pre-flight RBAC, audit-before-action).
+- Added [`docs/setup/values.md`](docs/setup/values.md) — flat
+  reference for every value in the periscope and periscope-agent
+  Helm charts, organised by section, with type / default / notes
+  per field. Single page operators can grep during a `helm upgrade`.
+- Extended [`docs/setup/pod-exec.md`](docs/setup/pod-exec.md) with a
+  dedicated "Operator notes for agent-backed clusters" section
+  (transport path, RBAC, audit, latency, disconnect behavior) and
+  an agent-specific troubleshooting bullet for the
+  `cmd/periscope-agent/observability.go` Hijack shim regression.
+- Stamped [RFC 0004](docs/rfcs/0004-exec-over-agent-tunnel-poc.md)
+  status as "Implemented in v1.0.0".
+- Normalized version nomenclature in operator-facing docs: `v1.x.0`
+  / `v1.x.+` / `v1.x.1` collapsed to `v1.0` / `post-1.0` / `v1.x`
+  per consistency.
+- Tightened the `POST /api/agents/register` description in
+  [`docs/api.md`](docs/api.md) to clarify "before registration"
+  rather than the ambiguous "does not yet."
+- README: explicit note that pod exec works on every backend
+  including `agent`; new top-level architecture-overview link.
+
+### Repository
+
+- Added GitHub issue templates (`bug_report.yml`,
+  `feature_request.yml`) and a pull-request template under
+  `.github/`. Bug reports require backend, OIDC provider, and
+  Periscope version up front; PR template prompts surfaces
+  touched and a tested-paths summary.
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ tag.
 
 ## [Unreleased]
 
+### Added
+
+- Agent: per-connection idle timeout (`agent.execIdleSeconds`,
+  default `600`) for hijacked exec WS / SPDY streams. Defense-in-
+  depth so a stuck exec stream gets reaped on the agent side if
+  the server crashes / partitions mid-session, even if the
+  server-side cascade close doesn't fire.
+
 ### Documentation
 
 - Added [`docs/architecture/README.md`](docs/architecture/README.md) —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,8 @@ See [`docs/architecture/watch-streams.md`](docs/architecture/watch-streams.md) f
 
 1. Read it via `os.Getenv` or a small `parseIntEnv` / `parseDurationEnv` helper in `main.go`. Document the default in a comment next to the parse call.
 2. Surface it in the Helm chart: add the value to [`deploy/helm/periscope/values.yaml`](deploy/helm/periscope/values.yaml) (with a comment block explaining what it does and when to override), the schema in [`deploy/helm/periscope/values.schema.json`](deploy/helm/periscope/values.schema.json), and the env-var injection in [`deploy/helm/periscope/templates/deployment.yaml`](deploy/helm/periscope/templates/deployment.yaml).
-3. Document it in the relevant `docs/setup/*.md` guide.
+3. Add a row to the flat reference at [`docs/setup/values.md`](docs/setup/values.md) (single grep-friendly page operators reach for during `helm upgrade` — keep it in lockstep with `values.yaml` or it rots).
+4. Document the operator-facing rationale in the relevant `docs/setup/*.md` guide.
 
 ## Pull request process
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 **Browsing & inspection**
 - Common resources (pods, deployments, services, configmaps, secrets, jobs, ingresses, RBAC, …) plus full Custom Resource catalog
 - Live events, describe view, logs (with follow + filtering)
-- In-browser pod shell (`exec`) with reconnect on transient disconnects
+- In-browser pod shell (`exec`) with reconnect on transient disconnects — works on every backend (eks, kubeconfig, in-cluster, agent)
 - Cmd+K palette: search resources by name across the active cluster
 
 **Real-time updates (watch streams)**
@@ -124,6 +124,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 
 **Setup**
 - [Configuration & deployment](docs/setup/deploy.md)
+- [Helm values reference](docs/setup/values.md)
 - [Environment variables reference](docs/setup/environment-variables.md)
 - [OIDC setup — Auth0](docs/setup/auth0.md)
 - [OIDC setup — Okta](docs/setup/okta.md)
@@ -136,6 +137,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 - [Multi-cluster onboarding (agent)](docs/setup/agent-onboarding.md) — register a managed cluster via the periscope-agent tunnel
 
 **Architecture**
+- [Architecture overview](docs/architecture/README.md) — component map, source-tree guide, reading order for new contributors
 - [Watch streams — push model, fallback, RBAC](docs/architecture/watch-streams.md)
 - [Agent tunnel — multi-cluster transport, PKI, registration](docs/architecture/agent-tunnel.md)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -408,16 +408,18 @@ Errors:
 - `403 Forbidden` — session present but not admin tier (`admin tier required`)
 
 The token is stored in process memory on the server. Single-replica
-deployments are supported in v1.x.0; multi-replica with shared
-persistence lands in v1.x.+.
+deployments are supported in v1.0; multi-replica with shared
+persistence is a post-1.0 follow-up.
 
 ### `POST /api/agents/register`
 
 Agent-side endpoint. Validates the bootstrap token, signs the
 agent's CSR, returns the cert + the server's CA bundle. **Not
 authenticated** — the bootstrap token IS the proof of authorization.
-Mounted unauthenticated specifically because the agent does not yet
-have a long-lived identity at this point in the flow.
+Mounted unauthenticated specifically because the agent has not yet
+obtained its long-lived mTLS identity at this point in the bootstrap
+flow — the redeemed token is the only proof of authorization it can
+present until the CSR is signed.
 
 ```json
 POST /api/agents/register
@@ -442,7 +444,7 @@ POST /api/agents/register
 | `csr` | Base64-encoded DER. The agent generates the keypair locally; only the public key + name claim cross the wire. The CN inside the CSR is informational — the server overwrites it with the cluster name from the token at signing time. |
 | `cert` | PEM-encoded signed client cert. CN = cluster name, EKU = clientAuth. Default validity 90 days. |
 | `caBundle` | PEM-encoded server CA cert. The agent uses this to validate the server's TLS cert on every reconnect to the tunnel listener. |
-| `expiresAt` | When the client cert expires. Operators currently re-register manually; auto-rotation is a v1.x.+ follow-up. |
+| `expiresAt` | When the client cert expires. Operators currently re-register manually; auto-rotation is a post-1.0 follow-up. |
 
 Errors are deliberately uniform:
 
@@ -609,7 +611,7 @@ without re-fetching the whole object.
 
 Helm write operations (rollback / upgrade / install / uninstall)
 are deliberately **not** in v1.0 — they need the compound SAR
-fan-out layer to land first. v1.x.
+fan-out layer to land first. Targeted for the v1.x train.
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,164 @@
+# Architecture
+
+Contributor-facing design notes. The audience is someone changing
+Periscope's internals, reviewing a PR that touches a load-bearing
+seam, or trying to understand "why is this wired this way?"
+
+For operator-facing how-tos (install, configure, troubleshoot), see
+[`../setup/`](../setup/). For the wire contract between the SPA and
+the backend, see [`../api.md`](../api.md). For accepted design
+proposals (with full rationale and alternatives considered), see
+[`../rfcs/`](../rfcs/).
+
+## Component map
+
+```
+                       ┌──────────────────┐
+                       │  Browser (SPA)   │
+                       │  React + Vite +  │
+                       │  Monaco          │
+                       └────────┬─────────┘
+                                │ HTTPS / SSE / WS
+                                ▼
+   ┌────────────────────────────────────────────────────────┐
+   │  periscope (single Go binary, single pod by default)   │
+   │                                                        │
+   │  ┌──────────────────────────────────────────────────┐  │
+   │  │ HTTP router (:8080)                              │  │
+   │  │  ├ /api/auth/*       OIDC PKCE, session cookies  │  │
+   │  │  ├ /api/whoami       resolved identity + tier    │  │
+   │  │  ├ /api/clusters     registry + per-cluster API  │  │
+   │  │  ├ /api/fleet        cross-cluster aggregator    │  │
+   │  │  ├ /api/audit        SQLite-backed audit reads   │  │
+   │  │  ├ /api/agents/*     token mint + register       │  │
+   │  │  └ /                 embedded SPA assets         │  │
+   │  └────────────────────┬─────────────────────────────┘  │
+   │                       │                                │
+   │  ┌────────────────────▼────────────────────────────┐   │
+   │  │ Per-cluster handler (apply / list / watch /     │   │
+   │  │ delete / can-i / exec / logs / helm)            │   │
+   │  └────────────────────┬────────────────────────────┘   │
+   │                       │ rest.Config built per request  │
+   │                       │ with Impersonate-User =        │
+   │                       │ <human's OIDC sub>             │
+   │  ┌────────────────────▼────────────────────────────┐   │
+   │  │ Backend factory (internal/k8s/client.go):       │   │
+   │  │   eks         → EKS bearer via IRSA / Pod ID    │   │
+   │  │   kubeconfig  → file-loaded kubeconfig          │   │
+   │  │   in-cluster  → kubelet-mounted SA              │   │
+   │  │   agent       → tunnel-bound RoundTripper       │   │
+   │  └─────────────────────────────────────────────────┘   │
+   │                                                        │
+   │  ┌─────────────────────────────────────────────────┐   │
+   │  │ TLS listener (:8443)                            │   │
+   │  │  └ /api/agents/connect    mTLS-required         │   │
+   │  │    (only mounted when agent.enabled=true)       │   │
+   │  └─────────────────────────────────────────────────┘   │
+   │                                                        │
+   │  ┌─────────────────────────────────────────────────┐   │
+   │  │ Audit pipeline (internal/audit)                 │   │
+   │  │  ├ stdout JSON sink                             │   │
+   │  │  └ SQLite sink (retention + size caps)          │   │
+   │  └─────────────────────────────────────────────────┘   │
+   └────────────────────────────────────────────────────────┘
+```
+
+The binary is **stateless w.r.t. user credentials**: OIDC sessions
+live in memory only; no kubeconfigs or AWS keys persist on disk.
+Audit rows in SQLite are the only durable state on the server pod.
+
+## Source tree
+
+| Path | What it is |
+|---|---|
+| [`cmd/periscope/`](../../cmd/periscope/) | Server binary entry, route mounting, handler wiring |
+| [`cmd/periscope-agent/`](../../cmd/periscope-agent/) | Agent binary: tunnel client + local reverse proxy |
+| [`internal/auth/`](../../internal/auth/) | OIDC PKCE flow, session cookies, identity resolution |
+| [`internal/authz/`](../../internal/authz/) | Tier mode (shared / tier / raw), IdP-group → impersonated identity mapping |
+| [`internal/audit/`](../../internal/audit/) | Verb taxonomy, sinks (stdout + SQLite), retention enforcement |
+| [`internal/clusters/`](../../internal/clusters/) | Cluster registry (YAML), per-cluster overrides, validation |
+| [`internal/credentials/`](../../internal/credentials/) | IRSA / Pod Identity bearer-token factory for `backend: eks` |
+| [`internal/exec/`](../../internal/exec/) | Pod exec session lifecycle, idle / heartbeat / cap timers |
+| [`internal/k8s/`](../../internal/k8s/) | rest.Config factory per backend, list/watch/apply/delete/exec primitives |
+| [`internal/tunnel/`](../../internal/tunnel/) | Agent transport (rancher/remotedialer wrap, mTLS authorizer) |
+| [`internal/sse/`](../../internal/sse/) | SSE writer, `Last-Event-ID` resume |
+| [`internal/secrets/`](../../internal/secrets/) | Secret reveal (audited), envelope unwrap |
+| [`internal/spa/`](../../internal/spa/) | Embedded SPA bundle, asset serving |
+| [`internal/httpx/`](../../internal/httpx/) | Middleware (request id, logging, CSRF / origin checks) |
+| [`web/`](../../web/) | React + TypeScript + Vite SPA (Monaco editor, React Query, Tailwind) |
+| [`deploy/helm/`](../../deploy/helm/) | Server + agent Helm charts |
+
+## Reading order for new contributors
+
+If you're new to the codebase, the fastest path to context:
+
+1. **`cmd/periscope/main.go`** — the route table is the index. Skim
+   it once and you know what every URL maps to.
+2. **`internal/k8s/client.go::buildRestConfig`** — the load-bearing
+   per-request factory. Every backend, every impersonation header,
+   every transport substitution flows through here.
+3. **[RFC 0002 — Authentication](../rfcs/0002-auth.md)** — how user
+   identity gets from an OIDC IdP into an `Impersonate-User` header.
+4. **[RFC 0003 — Audit log](../rfcs/0003-audit-log.md)** — verb
+   taxonomy and what every privileged handler emits.
+5. **One concrete handler** — `cmd/periscope/pods_handler.go` is a
+   good first read; it exercises the registry → factory →
+   impersonation → handler → audit chain end-to-end.
+
+## Deep dives in this directory
+
+- **[`watch-streams.md`](./watch-streams.md)** — how live list pages
+  push updates over SSE. Covers list-then-watch semantics, the
+  `kindReg` extension point, per-user concurrency caps, polling
+  fallback for restrictive proxies, `Last-Event-ID` resume.
+- **[`agent-tunnel.md`](./agent-tunnel.md)** — how the central
+  server reaches managed clusters when `backend: agent`. Covers
+  topology, PKI lifecycle, registration handshake, mTLS session
+  lifecycle, the `rest.Config.Transport` substitution that keeps
+  existing handlers unchanged, identity propagation through the
+  tunnel, audit shape, and failure modes.
+
+Other surfaces (auth, audit, exec) currently live as RFCs in
+[`../rfcs/`](../rfcs/) rather than separate architecture docs —
+the RFCs were written as design proposals but read as accurate
+design references. New architecture docs may carve them out
+post-1.0 if the divergence between "as-shipped" and "as-RFC'd"
+grows.
+
+## Cross-cutting design choices worth knowing
+
+- **Single binary, embedded SPA.** No separate frontend deployment.
+  `make build` produces `bin/periscope` with the Vite-built SPA
+  embedded via `embed.FS`.
+- **Stateless w.r.t. credentials.** OIDC sessions are in-memory
+  only. Restart drops sessions; users sign in again. Multi-replica
+  deploys share no session state in v1.0 (a post-1.0 concern).
+- **Impersonation everywhere.** No handler talks to apiserver "as
+  Periscope." Every K8s call sets `Impersonate-User` to the human's
+  OIDC sub. The bridge identity (EKS / SA token) is only the
+  transport credential; per-call authz is the human's RBAC.
+- **Pre-flight RBAC.** Disabled SPA actions explain themselves
+  via SAR / SSRR pre-flight rather than failing on click.
+- **Audit before action.** Privileged handlers emit
+  `*.attempted` before the K8s call and `*.succeeded` /
+  `*.failed` after. So a denied / errored action still leaves a
+  row.
+- **Stability tiers on the API.** Not every endpoint is semver-
+  stable. See [`../api.md`](../api.md) §2 for the three-tier
+  classification.
+
+## Where things deliberately aren't
+
+A few things you might expect to find but won't:
+
+- **No central database.** SQLite for audit; in-memory for
+  everything else. Postgres support is post-1.0.
+- **No kubeconfig persistence.** kubeconfig-backed clusters load
+  on demand; nothing is cached on disk.
+- **No agent-side audit emission.** Audit happens server-side, in
+  the same handlers, regardless of backend. The agent is a dumb
+  transport.
+- **No cluster-mutating operations from the SPA without the
+  user's RBAC.** The agent's SA (or the EKS bridge identity) is
+  the ceiling for what's *physically possible*, but every
+  individual action runs as the impersonated user.

--- a/docs/architecture/agent-tunnel.md
+++ b/docs/architecture/agent-tunnel.md
@@ -118,7 +118,7 @@ without configuration.
 Why a single CA over per-cluster CAs: makes validation a single
 trust anchor and keeps the key material surface tiny. We sacrifice
 the ability to revoke "all certs for cluster X" by burning the
-issuer (we'd burn every cluster's cert instead). For v1.x.0 this
+issuer (we'd burn every cluster's cert instead). For v1.0 this
 is the right tradeoff; per-cluster issuers can layer in additively
 when threat model demands.
 
@@ -138,7 +138,7 @@ Three cert kinds the CA mints:
 | **Agent client cert** | `clientAuth` | the registered cluster name | `periscope-agent-state` Secret on the managed cluster |
 
 Default validity: 90 days for client + server, 10 years for the CA.
-Auto-rotation is a v1.x.+ follow-up; for now operators re-register
+Auto-rotation is a post-1.0 follow-up; for now operators re-register
 agents whose certs expire (no client outage; the agent surfaces the
 expiry as a connect failure with a clear log line).
 
@@ -176,7 +176,7 @@ endpoints:
 with `{"cluster": "<name>"}`. The server mints a 32-byte random
 opaque token, base64url-encoded, with TTL 15 min and bound to the
 named cluster. Stored in a `tunnel.TokenStore` (in-memory single-
-writer for v1.x.0; Postgres-backed for HA in v1.x.+). Returns
+writer for v1.0; Postgres-backed for HA is a post-1.0 follow-up). Returns
 `{token, cluster, expiresAt}`.
 
 **Step 2.** The operator runs `helm install periscope-agent ...
@@ -412,7 +412,7 @@ human user (`actor.sub`), the verb, the outcome, and `cluster:
 same shape regardless of how `prod-eu` is reached.
 
 A future `clusterBackend: agent` field on audit rows is being
-considered for the v1.x.+ audit RFC update, so SIEM consumers can
+considered for a post-1.0 audit RFC update, so SIEM consumers can
 filter by transport type. Additive change to RFC 0003 6, no wire-
 breaking impact.
 
@@ -421,7 +421,7 @@ breaking impact.
 | What happens | What the user sees | Recovery |
 |---|---|---|
 | Agent disconnects mid-request (network blip) | The `tunnel.RoundTripper` returns an error wrapped with `ErrAgentDisconnected`; the handler surfaces it as the standard upstream error class. SPA shows "cluster transient error, retry." | remotedialer reconnects with jittered backoff (1s → 30s); next request goes through. |
-| Cert expires unattended | Agent's reconnect attempts fail with `bad certificate`. Cluster goes "unreachable" in fleet view. | Operator deletes the agent's state Secret, mints a fresh token, re-installs. (90d default lifetime; auto-rotation is a v1.x.+ follow-up.) |
+| Cert expires unattended | Agent's reconnect attempts fail with `bad certificate`. Cluster goes "unreachable" in fleet view. | Operator deletes the agent's state Secret, mints a fresh token, re-installs. (90d default lifetime; auto-rotation is a post-1.0 follow-up.) |
 | Server restart | All agent connections drop. Agents reconnect on jittered backoff; sessions re-register, fleet view re-populates within ~10s. | Automatic. |
 | WS idle through corp proxy | Connection closes silently, agent reconnect kicks in. | remotedialer's keepalive frame keeps idle proxies happy; default <30s ping. |
 | Wrong-cluster registration attempt | Token redemption returns `cluster mismatch`; token burns; HTTP returns uniform 401. Server log carries the real reason. | Operator mints fresh token with the correct cluster name. |
@@ -431,7 +431,7 @@ breaking impact.
 
 ## 11. What's intentionally not here
 
-- **HA peer routing.** v1.x.0 is single-replica; documented
+- **HA peer routing.** v1.0 is single-replica; documented
   ~100-cluster ceiling per server pod (Rancher's empirically
   defensible number). Multi-replica with peer routing
   (request lands on replica A, agent's session is on replica B,
@@ -441,12 +441,12 @@ breaking impact.
   modal mints a token but assumes the operator has already added
   `backend: agent` to `clusters[]` in YAML and `helm upgrade`d
   the central server. Dynamic registry overlay (Secret-backed,
-  merged with YAML) is a v1.x.1 follow-up; tracked in the same
-  v1.x.0 epic [#42](https://github.com/gnana997/periscope/issues/42)
+  merged with YAML) is a post-1.0 follow-up; tracked in the same
+  v1.0 epic [#42](https://github.com/gnana997/periscope/issues/42)
   as Phase 2.
 
 - **Cert auto-rotation.** Agent re-registration is operator-driven
-  in v1.x.0 (90-day cert, manual mint + re-install). Auto-rotate-
+  in v1.0 (90-day cert, manual mint + re-install). Auto-rotate-
   at-2/3-lifetime is a small follow-up — the agent already has the
   in-cluster RBAC to update its own state Secret.
 
@@ -458,9 +458,9 @@ breaking impact.
   for the central server's stdout audit stream.
 
 - **Per-tunnel rate limits.** A buggy or malicious agent could
-  open many concurrent dials through its tunnel. v1.x.0 relies on
+  open many concurrent dials through its tunnel. v1.0 relies on
   the apiserver's own rate limits. Per-tunnel watch / connection
-  caps are tracked for v1.x.+.
+  caps are tracked for post-1.0.
 
 - **Multi-tenant shared CA.** Every Periscope deployment has its
   own CA; agents from one deployment cannot register against
@@ -498,6 +498,6 @@ Background:
 - [Issue #41](https://github.com/gnana997/periscope/issues/41) —
   design discussion (agent-vs-central-IAM)
 - [Issue #42](https://github.com/gnana997/periscope/issues/42) —
-  v1.x.0 multi-cluster epic
+  v1.0 multi-cluster epic
 - [Issue #43](https://github.com/gnana997/periscope/issues/43) —
   exec POC + integration (closed in v1.0.0)

--- a/docs/rfcs/0004-exec-over-agent-tunnel-poc.md
+++ b/docs/rfcs/0004-exec-over-agent-tunnel-poc.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Status** | Landed — Tiers 1+2 green; both production bugs fixed; closes #42 + #43 |
+| **Status** | Implemented in v1.0.0 — Tiers 1+2 green; both production bugs fixed; closed #42 + #43 |
 | **Owner** | @gnana997 |
 | **Started** | 2026-05-04 |
-| **Targets** | v1.x.0 (collapse #43 into #42 if the harness passes) |
+| **Shipped** | v1.0.0 (collapsed #43 into #42; no separate v1.x.1) |
 | **Related** | #42 (agent-backend epic), #43 (exec-on-agent POC), PR #46 (agent-backend implementation), RFC 0001 (Pod Exec Support), `docs/architecture/agent-tunnel.md` |
 
 ---

--- a/docs/setup/agent-onboarding.md
+++ b/docs/setup/agent-onboarding.md
@@ -420,7 +420,7 @@ from different accounts / clouds / regions in one fleet view.
 The Periscope SPA includes a **+ Onboard cluster** button on the
 fleet page that walks through the token mint + install command
 flow. Phase 2 (live polling, runtime registry mutations,
-re-mint/decommission) lands in v1.x.1.
+re-mint/decommission) is a post-1.0 follow-up on the v1.x train.
 
 ## See also
 
@@ -435,7 +435,7 @@ re-mint/decommission) lands in v1.x.1.
 - [Issue #41](https://github.com/gnana997/periscope/issues/41) —
   agent-vs-central-IAM design discussion
 - [Issue #42](https://github.com/gnana997/periscope/issues/42) —
-  v1.x.0 multi-cluster epic
+  v1.0 multi-cluster epic
 - [Issue #48](https://github.com/gnana997/periscope/issues/48) —
   the ALB+NLB bootstrap chicken-and-egg this guide's Topology B
   fixes

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -547,7 +547,7 @@ on every API call. Same id appears on the server's audit row (RFC
 server stdout slog + agent stdout slog gives a single end-to-end
 trace for any user click.
 
-Server-side `PERISCOPE_LOG_LEVEL` parity is a v1.x.+ follow-up — the
+Server-side `PERISCOPE_LOG_LEVEL` parity is a post-1.0 follow-up — the
 agent is the binary that's currently blind to per-request issues, so
 it ships observability first.
 

--- a/docs/setup/pod-exec.md
+++ b/docs/setup/pod-exec.md
@@ -27,7 +27,66 @@ cluster you want to lock down.
 | `eks` (Pod Identity / IRSA) | Yes | Direct apiserver dial; standard WS / SPDY upgrade |
 | `kubeconfig` | Yes | Same as eks |
 | `in-cluster` | Yes | Same |
-| `agent` | Yes (since v1.0.0) | Routes via the loopback CONNECT proxy through the agent tunnel; transparent to the operator. See [`docs/architecture/agent-tunnel.md`](../architecture/agent-tunnel.md) for the integration details and [RFC 0004](../rfcs/0004-exec-over-agent-tunnel-poc.md) for the validation harness. |
+| `agent` | Yes (since v1.0.0) | Routes via the loopback CONNECT proxy through the agent tunnel; transparent to the operator. See [Operator notes for agent-backed clusters](#operator-notes-for-agent-backed-clusters) below, [`docs/architecture/agent-tunnel.md`](../architecture/agent-tunnel.md) for the integration details, and [RFC 0004](../rfcs/0004-exec-over-agent-tunnel-poc.md) for the validation harness. |
+
+### Operator notes for agent-backed clusters
+
+Pod exec on `backend: agent` clusters works through the same Helm
+values, RBAC, audit, and SPA flow as any other backend — but the
+transport path is longer, so a few operator-facing implications are
+worth knowing.
+
+**The same toggles apply.** All settings under §2 and §3 — global
+defaults, per-cluster overrides, `exec.enabled: false`,
+`maxSessionsPerUser`, `serverIdleSeconds` — work identically on
+agent-backed clusters. There is no separate `agent.exec.*` block.
+
+**Transport path.** A pod-exec request on an agent-backed cluster
+flows: browser → server WS handler → `internal/k8s/exec.go` builds
+a `remotecommand.NewWebSocketExecutor` (or SPDY) → a loopback HTTP
+CONNECT proxy in `internal/k8s/agent_exec_proxy.go` translates the
+per-cluster CONNECT into a tunnel dial → `rancher/remotedialer`
+multiplexes it onto the agent's long-lived WebSocket → the agent's
+`httputil.ReverseProxy` (with a `Hijack()` shim for upgrade traffic)
+re-issues the request to the local apiserver with the agent SA
+bearer token. WS v5 vs SPDY transport selection (§4) and circuit-
+breaker behavior happen on the *server* end; the agent is unaware.
+
+**Why the loopback CONNECT proxy.** client-go's WS / SPDY exec
+executors bypass `rest.Config.Transport` entirely (they dial via
+DNS), so the same trick that makes list/watch/apply transparent
+to handlers — substituting `rest.Config.Transport` — does not
+work for exec. The CONNECT proxy is the additive seam that closes
+that gap. Operators don't configure it; the server registers a
+loopback listener at startup.
+
+**RBAC is unchanged.** `pods/exec` create permission still applies
+in the *target* cluster's namespace, evaluated under the human's
+impersonated identity. The agent's SA needs only its standard
+`impersonate` lever (see [`docs/setup/cluster-rbac.md`](./cluster-rbac.md)
+§ "Agent backend"). No additional RBAC for exec specifically.
+
+**Audit is unchanged.** `pod.exec.session_start` /
+`pod.exec.session_end` records emit on the central server, with
+the same fields described in §7. The `cluster:` field carries the
+agent-backed cluster's registry name.
+
+**Latency.** First-exec latency on an agent-backed cluster is
+typically ~100ms higher than a direct backend (the extra hop
+through the tunnel and the agent's reverse proxy). Steady-state
+keystroke latency is dominated by the agent → apiserver hop, which
+is in-cluster on the managed side, so it's usually negligible. If
+you regularly see >500ms keystroke latency, the bottleneck is
+between the central server and the agent — investigate the WS
+path through proxies / NLBs.
+
+**Disconnect behavior.** If the agent tunnel drops mid-session,
+the WebSocket exec stream dies with it; the SPA shows the standard
+"session ended" UI. Reconnect requires a fresh shell — the exec
+session is not resumable across tunnel reconnects (this is the
+same behavior as a direct-backend `kubectl exec` losing its TCP
+connection). The agent itself reconnects on jittered backoff
+within 1–30s; subsequent shell opens succeed normally.
 
 ### Per-cluster opt-out
 
@@ -270,6 +329,37 @@ The breaker self-heals after 30 min. To force-reset, restart the
 Periscope pod. There's no operator-facing knob for this — pinning
 that long means real WebSocket failure that needs investigation
 upstream of Periscope.
+
+### Exec fails immediately on an agent-backed cluster
+
+Direct backends (`eks` / `kubeconfig` / `in-cluster`) work but
+shells on `backend: agent` clusters fail to upgrade. Most likely
+causes, in order:
+
+1. **Agent tunnel is down.** Check the fleet view — if the cluster
+   card is "unreachable", the tunnel is the problem, not exec.
+   See [`docs/setup/agent-onboarding.md`](./agent-onboarding.md)
+   troubleshooting.
+2. **Agent is on a pre-1.0.0 image.** The `Hijack()` shim in
+   `cmd/periscope-agent/observability.go` shipped in v1.0.0; older
+   agents fail every WS / SPDY upgrade with `"can't switch
+   protocols using non-Hijacker ResponseWriter"` in the agent log.
+   Fix: `helm upgrade periscope-agent` to ≥ v1.0.0.
+3. **Agent SA lacks `pods/exec` create on the target namespace.**
+   Different from the *user's* RBAC: the agent's reverse proxy
+   re-issues the request as itself (with Impersonate-* preserved),
+   and the apiserver checks both the agent's RBAC and the
+   impersonated user's RBAC. Default agent ClusterRole grants
+   this; verify if you tightened it.
+4. **Tunnel WS path strips upgrade headers.** Same root cause as
+   the §8 "WebSocket upgrade fails" bullet, but on the central-
+   server-to-agent leg. Check `agent.tunnelSANs` and any
+   intermediate LB.
+
+Enable agent debug logging
+(`helm upgrade ... --set agent.logLevel=debug` on the managed
+cluster) and grep for `proxy.request_in` / `proxy.apiserver_error`
+lines around the failed upgrade.
 
 ---
 

--- a/docs/setup/values.md
+++ b/docs/setup/values.md
@@ -1,0 +1,352 @@
+# Helm values reference
+
+Canonical reference for every value in the Periscope and
+periscope-agent Helm charts. For walkthroughs and the "why" behind
+each block, follow the per-topic links — this page is the
+exhaustive flat list operators reach for during a `helm upgrade`.
+
+The source of truth is each chart's `values.yaml`. This doc is
+re-derived from those files; if a value here disagrees with the
+chart, the chart wins and please file a docs bug.
+
+- Chart: [`deploy/helm/periscope/values.yaml`](../../deploy/helm/periscope/values.yaml)
+- Agent chart: [`deploy/helm/periscope-agent/values.yaml`](../../deploy/helm/periscope-agent/values.yaml)
+- Schema validators (run on every `helm install` / `template`):
+  [`values.schema.json`](../../deploy/helm/periscope/values.schema.json)
+  and the agent's
+  [`values.schema.json`](../../deploy/helm/periscope-agent/values.schema.json)
+
+## Stability
+
+Every value documented here is part of the **v1.0 public
+configuration surface** and covered by semver: breaking changes
+(rename, type change, removal) require a major bump (v2). New
+values may land additively in any minor release with safe defaults.
+
+---
+
+# Server chart (`periscope`)
+
+## image
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `image.repository` | string | `ghcr.io/gnana997/periscope` | OCI repo for the server image. |
+| `image.tag` | string | `""` (defaults to `Chart.AppVersion`) | Pin to a specific release tag in production. |
+| `image.pullPolicy` | string | `IfNotPresent` | Standard K8s pull policy. |
+| `imagePullSecrets` | list | `[]` | `[{name: <secret>}]` entries for private registries. |
+
+## replicaCount
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `replicaCount` | int | `1` | v1.0 is single-replica only — the in-memory session store is per-pod. HA / multi-replica is a post-1.0 follow-up. |
+
+## serviceAccount / podIdentity
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `serviceAccount.create` | bool | `true` | When false, set `serviceAccount.name` to an existing SA. |
+| `serviceAccount.name` | string | `""` (derived from release name) | The SA the Deployment runs as. |
+| `serviceAccount.annotations` | map | `{}` | IRSA path: set `eks.amazonaws.com/role-arn` here. |
+| `podIdentity.enabled` | bool | `false` | Pod Identity path (preferred for new EKS). When true, no IRSA annotation is rendered — create the association out-of-band. |
+
+See [`deploy.md`](./deploy.md) for the IRSA vs Pod Identity decision.
+
+## auth
+
+OIDC, session, and authorization settings. Written verbatim into
+the rendered `auth.yaml` ConfigMap. See [`auth0.md`](./auth0.md) /
+[`okta.md`](./okta.md) for IdP-specific values, and
+[`cluster-rbac.md`](./cluster-rbac.md) for authorization mode
+trade-offs.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `auth.oidc.issuer` | string | `""` | OIDC discovery URL. |
+| `auth.oidc.clientID` | string | `""` | OIDC client ID. |
+| `auth.oidc.clientSecret` | string | `${OIDC_CLIENT_SECRET}` | Reference into the chosen `secrets.mode`. |
+| `auth.oidc.redirectURL` | string | `""` | Periscope's `/api/auth/callback` URL. |
+| `auth.oidc.scopes` | list | `[openid, profile, email, offline_access]` | Standard scopes; usually leave as-is. |
+| `auth.oidc.audience` | string | `""` | Auth0 only; leave empty for Okta and most IdPs. |
+| `auth.oidc.postLogoutRedirect` | string | `""` | URL the browser lands on after IdP logout. |
+| `auth.session.cookieName` | string | `periscope_session` | Session cookie name. |
+| `auth.session.idleTimeout` | duration | `30m` | Idle timeout before the session is invalidated. |
+| `auth.session.absoluteTimeout` | duration | `8h` | Hard cap on session lifetime. |
+| `auth.session.cookieDomain` | string | unset | Optional explicit `Domain=` attribute on the cookie. |
+| `auth.authorization.mode` | enum | `shared` | `shared` \| `tier` \| `raw`. See RFC 0002 §4 and [`cluster-rbac.md`](./cluster-rbac.md). |
+| `auth.authorization.groupTiers` | map | `{}` | tier-mode only: IdP group → tier (`read`\|`triage`\|`write`\|`maintain`\|`admin`). |
+| `auth.authorization.defaultTier` | string | `""` | tier-mode only: tier applied when no group matches. `""` = deny. |
+| `auth.authorization.groupPrefix` | string | `periscope:` | raw-mode only: prefix prepended to each impersonated group. |
+| `auth.authorization.groupsClaim` | string | `groups` | IdP token claim that holds the groups list. Auth0 needs a custom namespaced claim. |
+| `auth.authorization.allowedGroups` | list | `[]` | All modes: gate on these IdP groups. Empty = any authenticated user. |
+| `auth.authorization.auditAdminGroups` | list | `[]` | IdP groups granted full `/api/audit` visibility across all users. |
+| `auth.dev.subject` | string | `dev@local` | Local-dev only; identity used when no OIDC is configured. |
+| `auth.dev.email` | string | `dev@local` | Local-dev only. |
+| `auth.dev.groups` | list | `[dev]` | Local-dev only. |
+
+## clusters
+
+The cluster registry. Written verbatim into the rendered
+`clusters.yaml` ConfigMap. Three backends — see
+[`deploy.md`](./deploy.md) and
+[`agent-onboarding.md`](./agent-onboarding.md).
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `clusters` | list | `[]` | Each entry has `name` + `backend` plus backend-specific fields. |
+
+Per-entry fields by backend:
+
+**`backend: eks`** — `name`, `backend: eks`, `region`, `arn`.
+
+**`backend: kubeconfig`** — `name`, `backend: kubeconfig`, `kubeconfigPath`, optional `kubeconfigContext`.
+
+**`backend: in-cluster`** — `name`, `backend: in-cluster`. The chart auto-binds the Periscope SA to the impersonator role.
+
+**`backend: agent`** — `name`, `backend: agent`. No other backend-specific fields; the agent dialing in with a matching mTLS CN supplies the connection.
+
+**Per-cluster overrides** (any backend):
+
+| Field | Type | Notes |
+|---|---|---|
+| `exec.enabled` | bool | `false` disables exec entirely on this cluster. |
+| `exec.serverIdleSeconds` | int | Overrides global idle timeout for this cluster. |
+| `exec.idleWarnSeconds` | int | Overrides global idle-warn lead. |
+| `exec.heartbeatSeconds` | int | Overrides global heartbeat. |
+| `exec.maxSessionsPerUser` | int | Overrides global per-user cap. |
+| `exec.maxSessionsTotal` | int | Overrides global per-cluster cap. |
+| `environment` | string | Free-form label, surfaced on the fleet card (e.g. `prod`, `staging`). |
+
+## secrets
+
+How the OIDC client secret reaches the pod. Pick exactly one mode.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `secrets.mode` | enum | `existing` | `existing` \| `plain` \| `external` \| `native`. |
+| `secrets.existing.name` | string | `periscope-oidc` | Name of the pre-applied K8s Secret. |
+| `secrets.existing.key` | string | `OIDC_CLIENT_SECRET` | Key in the Secret + env-var name on the pod. |
+| `secrets.plain.clientSecret` | string | `""` | Used only when `mode=plain`. Renders a `kind: Secret` from values — fine for kind/minikube, never for prod. |
+| `secrets.external.storeName` | string | `""` | External Secrets Operator: SecretStore / ClusterSecretStore name. |
+| `secrets.external.storeKind` | enum | `ClusterSecretStore` | Or `SecretStore`. |
+| `secrets.external.refreshInterval` | duration | `1h` | Resync interval on the rendered ExternalSecret. |
+| `secrets.external.remoteKey` | string | `""` | Upstream secret path / name. |
+| `secrets.external.remoteProperty` | string | `""` | JSON key to extract when the upstream value is JSON-shaped. |
+| `secrets.native.enabled` | bool | `true` | No K8s Secret at all; Periscope's resolver fetches from AWS Secrets Manager / SSM at startup. Point `auth.oidc.clientSecret` at e.g. `aws-secretsmanager://periscope/oidc#client_secret`. |
+
+## env
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `env` | list | `[]` | Extra `name: value` pairs. Rarely needed — the chart maps documented `PERISCOPE_*` vars from typed values. |
+
+## service / ingress
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `service.type` | string | `ClusterIP` | Standard K8s Service type. |
+| `service.port` | int | `8080` | Periscope listens on `:8080` inside the pod. |
+| `ingress.enabled` | bool | `false` | When true, an Ingress resource is rendered. |
+| `ingress.className` | string | `""` | IngressClass name (`nginx`, `alb`, …). |
+| `ingress.annotations` | map | `{}` | Controller-specific annotations. |
+| `ingress.host` | string | `""` | Hostname the Ingress matches. |
+| `ingress.path` | string | `/` | Path to match. |
+| `ingress.pathType` | string | `Prefix` | Standard pathType. |
+| `ingress.tls.enabled` | bool | `false` | Render a TLS section. |
+| `ingress.tls.secretName` | string | `""` | TLS Secret name when enabled. |
+
+## Pod / container specs
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `resources.requests.cpu` | quantity | `100m` | |
+| `resources.requests.memory` | quantity | `128Mi` | |
+| `resources.limits.cpu` | quantity | `500m` | |
+| `resources.limits.memory` | quantity | `512Mi` | |
+| `podAnnotations` | map | `{}` | Extra annotations on the Deployment's pod template. |
+| `podSecurityContext.runAsNonRoot` | bool | `true` | |
+| `podSecurityContext.runAsUser` | int | `65532` | Distroless `nonroot` UID. |
+| `podSecurityContext.runAsGroup` | int | `65532` | |
+| `podSecurityContext.fsGroup` | int | `65532` | |
+| `podSecurityContext.seccompProfile.type` | string | `RuntimeDefault` | |
+| `containerSecurityContext.allowPrivilegeEscalation` | bool | `false` | |
+| `containerSecurityContext.readOnlyRootFilesystem` | bool | `true` | |
+| `containerSecurityContext.capabilities.drop` | list | `[ALL]` | |
+| `nodeSelector` | map | `{}` | Standard. |
+| `tolerations` | list | `[]` | Standard. |
+| `affinity` | map | `{}` | Standard. |
+
+## audit
+
+Audit log persistence. See [`audit.md`](./audit.md) for retention
+sizing and the "stdout always on, SQLite optional" model.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `audit.enabled` | bool | `false` | When true, also writes audit events to a local SQLite DB. stdout JSON emission is unconditional. |
+| `audit.retentionDays` | int | `30` | Time-based retention. `0` disables time-based pruning. |
+| `audit.maxSizeMB` | int | `1024` | Application-level on-disk cap. `0` disables size-based pruning. |
+| `audit.vacuumInterval` | duration | `24h` | How often the prune+VACUUM loop runs. |
+| `audit.storage.type` | enum | `pvc` | `pvc` (persistent) \| `emptyDir` (ephemeral). |
+| `audit.storage.size` | quantity | `5Gi` | PVC request size. Used only when `type=pvc`. |
+| `audit.storage.storageClass` | string | `""` | Empty = cluster default StorageClass. |
+| `audit.storage.accessMode` | string | `ReadWriteOnce` | v1.0 single-replica needs only RWO. |
+
+## exec
+
+Pod-exec global defaults. Per-cluster overrides go under
+`clusters[].exec`. See [`pod-exec.md`](./pod-exec.md) for the
+operator guide.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `exec.serverIdleSeconds` | int | `600` | Server-side idle timeout. |
+| `exec.idleWarnSeconds` | int | `30` | Browser warning lead before the cut. |
+| `exec.heartbeatSeconds` | int | `20` | WebSocket heartbeat ping interval. |
+| `exec.maxSessionsPerUser` | int | `5` | Concurrent sessions per OIDC subject. |
+| `exec.maxSessionsTotal` | int | `50` | Concurrent sessions per cluster. |
+| `exec.probeClustersOnBoot` | bool | `false` | Pre-warm IAM creds + exec policy at startup. |
+
+There is intentionally no global `exec.enabled` switch. Disable
+exec per-cluster via `clusters[i].exec.enabled: false`.
+
+## watchStreams
+
+SSE live-list configuration. See
+[`watch-streams.md`](./watch-streams.md) for the kind registry,
+group aliases, and fallback behavior.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `watchStreams.kinds` | string | `""` | Empty / `all` / `off` / `none` / comma-separated kinds / group aliases. |
+| `watchStreams.perUserLimit` | int | `60` | Per-user concurrent stream cap. `0` disables (not recommended). |
+
+Group aliases: `core`, `workloads`, `networking`, `storage`,
+`cluster`. Per-kind tokens: see `watchStreams:` block in
+`values.yaml`.
+
+## pdb
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `pdb.enabled` | bool | `true` | Render a PodDisruptionBudget. |
+| `pdb.maxUnavailable` | int | `1` | v1.0 single-replica: `1` allows drains. Switch to `minAvailable` per replica when HA lands post-1.0. |
+
+## networkPolicy
+
+See [`networkpolicy.md`](./networkpolicy.md) for the full recipe.
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `networkPolicy.enabled` | bool | `false` | Render a NetworkPolicy. |
+| `networkPolicy.ingress.fromNamespaces` | list | `[]` | `namespaceSelector` matchLabels for permitted ingress sources. |
+| `networkPolicy.ingress.extra` | list | `[]` | Raw `NetworkPolicyIngressRule` entries appended. |
+| `networkPolicy.egress.extra` | list | `[]` | Raw `NetworkPolicyEgressRule` entries (e.g. IdP CIDRs, EKS endpoints). DNS to kube-dns is always added. |
+
+## clusterRBAC
+
+Tier-mode RBAC manifests rendered for the central cluster. See
+[`cluster-rbac.md`](./cluster-rbac.md).
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `clusterRBAC.enabled` | bool | `false` | Render the periscope-tier ClusterRoles + bindings. |
+| `clusterRBAC.bridgeGroup` | string | `periscope-bridge` | K8s group your EKS Access Entry binds the pod principal to. |
+
+## agent
+
+Server-side agent backend (#42) — opens the mTLS tunnel listener
+and the registration endpoints. See
+[`agent-onboarding.md`](./agent-onboarding.md) and
+[`../architecture/agent-tunnel.md`](../architecture/agent-tunnel.md).
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `agent.enabled` | bool | `false` | Master switch — opens `:8443`, mounts `/api/agents/*` routes, pre-creates the CA Secret. |
+| `agent.listenAddr` | string | `:8443` | Bind address for the mTLS tunnel listener. |
+| `agent.tunnelSANs` | string | `localhost` | Comma-separated SANs baked into the server cert agents present on the tunnel. |
+| `agent.caSecretName` | string | `periscope-agent-ca` | K8s Secret holding the per-deployment CA. |
+| `agent.tunnelService.enabled` | bool | `false` | Render a second Service to expose the tunnel listener externally. |
+| `agent.tunnelService.type` | string | `LoadBalancer` | NLB recommended (TLS-passthrough). |
+| `agent.tunnelService.port` | int | `8443` | External port for the tunnel Service. |
+| `agent.tunnelService.annotations` | map | `{}` | Cloud-LB-specific annotations. |
+
+---
+
+# Agent chart (`periscope-agent`)
+
+Each managed cluster runs ONE periscope-agent Deployment. Most
+fields are install-time identity; the rest can stay at defaults.
+See [`agent-onboarding.md`](./agent-onboarding.md) for the
+topology decision matrix.
+
+## image
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `image.repository` | string | `ghcr.io/gnana997/periscope-agent` | |
+| `image.tag` | string | `""` (defaults to `Chart.AppVersion`) | |
+| `image.pullPolicy` | string | `IfNotPresent` | |
+| `imagePullSecrets` | list | `[]` | |
+
+## agent
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `agent.serverURL` | string | `""` | **Required.** WebSocket URL of the central tunnel listener (`wss://...:8443/api/agents/connect`). |
+| `agent.clusterName` | string | `""` | **Required.** Must match a `clusters[].name` of `backend: agent` on the server. |
+| `agent.registrationToken` | string | `""` | **Required on first install only.** Bootstrap token from `POST /api/agents/tokens`. Single-use, 15-min TTL. |
+| `agent.registrationURL` | string | `""` | Set when registration uses a different LB than the tunnel (Topology B — split ALB+NLB). Empty = derive from `serverURL`. |
+| `agent.serverCAHash` | string | `""` | SPKI hash (`sha256:...`) for self-signed registration endpoints (Topology C). |
+| `agent.stateSecretName` | string | `periscope-agent-state` | Persisted mTLS cert + key + server CA. |
+| `agent.healthAddr` | string | `:8081` | Liveness / readiness probe port. |
+| `agent.logLevel` | enum | `""` (binary default = `info`) | `debug` \| `info` \| `warn` \| `error`. Set `debug` for per-request access logs. |
+
+## deployment shape
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `replicaCount` | int | `1` | Tunnel sessions are 1:1 with agent pods. HA needs server-side peer routing (post-1.0). |
+| `serviceAccount.create` | bool | `true` | |
+| `serviceAccount.name` | string | `""` | |
+| `serviceAccount.annotations` | map | `{}` | |
+
+## RBAC
+
+| Value | Type | Default | Notes |
+|---|---|---|---|
+| `clusterRole.enabled` | bool | `true` | Bind the agent SA to a ClusterRole granting `get/list/watch` on every kind + `impersonate` on users/groups/SAs. |
+| `clusterRBAC.enabled` | bool | `true` | Install tier ClusterRoleBindings on the managed cluster (`periscope-tier-read/write/admin/triage/maintain`). Required for impersonation to actually authorize. |
+
+## resources / security context
+
+Mirrors the server chart's defaults; same fields, just with
+agent-appropriate request/limit values.
+
+| Value | Type | Default |
+|---|---|---|
+| `resources.requests.cpu` | quantity | `50m` |
+| `resources.requests.memory` | quantity | `64Mi` |
+| `resources.limits.cpu` | quantity | `500m` |
+| `resources.limits.memory` | quantity | `256Mi` |
+| `podSecurityContext.runAsNonRoot` | bool | `true` |
+| `podSecurityContext.runAsUser` | int | `65532` |
+| `podSecurityContext.runAsGroup` | int | `65532` |
+| `podSecurityContext.seccompProfile.type` | string | `RuntimeDefault` |
+| `containerSecurityContext.allowPrivilegeEscalation` | bool | `false` |
+| `containerSecurityContext.readOnlyRootFilesystem` | bool | `true` |
+| `containerSecurityContext.capabilities.drop` | list | `[ALL]` |
+| `nodeSelector` | map | `{}` |
+| `tolerations` | list | `[]` |
+| `affinity` | map | `{}` |
+| `podAnnotations` | map | `{}` |
+| `env` | list | `[]` |
+
+---
+
+## See also
+
+- [`environment-variables.md`](./environment-variables.md) — `PERISCOPE_*` env vars the binary reads (one-to-one mapping with most typed values above).
+- [`deploy.md`](./deploy.md) — full install walkthrough.
+- [`agent-onboarding.md`](./agent-onboarding.md) — multi-cluster agent install with topology decision matrix.

--- a/docs/setup/values.md
+++ b/docs/setup/values.md
@@ -302,6 +302,7 @@ topology decision matrix.
 | `agent.stateSecretName` | string | `periscope-agent-state` | Persisted mTLS cert + key + server CA. |
 | `agent.healthAddr` | string | `:8081` | Liveness / readiness probe port. |
 | `agent.logLevel` | enum | `""` (binary default = `info`) | `debug` \| `info` \| `warn` \| `error`. Set `debug` for per-request access logs. |
+| `agent.execIdleSeconds` | int | `600` | Per-connection idle timeout (seconds) for hijacked exec WS / SPDY streams. Mirrors the server's `PERISCOPE_EXEC_IDLE_SECONDS`; set the same value here so stuck streams get reaped on the agent side if the server crashes mid-session. Activity = any successful read; only idle streams are killed. `0` disables (relies entirely on server-side cascade close + OS TCP keepalive — not recommended). |
 
 ## deployment shape
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for operators and contributors, along with GitHub issue and PR templates to streamline community contributions.

## Key changes

**Documentation**
- Added `docs/architecture/README.md` — top-level architecture overview with component map, source-tree guide, suggested reading order for new contributors, and cross-cutting design choices (single binary + embedded SPA, stateless credentials, impersonation everywhere, pre-flight RBAC, audit-before-action)
- Added `docs/setup/values.md` — exhaustive flat reference for every Helm value in both periscope and periscope-agent charts, organized by section with type/default/notes per field for easy grepping during `helm upgrade`
- Extended `docs/setup/pod-exec.md` with dedicated "Operator notes for agent-backed clusters" section covering transport path, RBAC, audit, latency, and disconnect behavior; added agent-specific troubleshooting for the `Hijack()` shim regression
- Updated RFC 0004 status to "Implemented in v1.0.0"
- Normalized version nomenclature across operator-facing docs (`v1.x.0` → `v1.0`, `v1.x.+` → `post-1.0`)
- Tightened `POST /api/agents/register` description in `docs/api.md` for clarity
- Updated README with explicit note that pod exec works on all backends including `agent` and added architecture-overview link

**Repository**
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug reports requiring backend, OIDC provider, and Periscope version upfront
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` — feature requests with problem/proposal/alternatives structure
- Added `.github/ISSUE_TEMPLATE/config.yml` — GitHub issue config directing questions to Discussions and security issues to the security policy
- Added `.github/pull_request_template.md` — PR template prompting for related issues/RFCs, change type, surfaces touched, and testing approach

**Changelog**
- Updated `CHANGELOG.md` with all documentation and repository additions under `[Unreleased]`

## Notable implementation details

- The Helm values reference (`docs/setup/values.md`) is positioned as a derived document from the canonical `values.yaml` files, with explicit note that the chart wins in case of disagreement
- Architecture docs establish a clear reading order for new contributors: route table → rest.Config factory → RFC 0002 (auth) → RFC 0003 (audit) → concrete handler example
- Issue templates use GitHub's YAML format with required fields to capture essential context upfront (version, backend, OIDC provider for bugs; surface affected for features)
- All documentation updates maintain consistency with v1.0 release nomenclature and post-1.0 roadmap references

https://claude.ai/code/session_01LPMNAQRZPSvaTTFbUDJEYQ