### PR TITLE
Add bulk YAML download with selection and audit logging

### DIFF
--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -761,11 +761,12 @@ func main() {
 				return k8s.GetConfigMapYAML(ctx, p, k8s.GetConfigMapArgs{Cluster: c, Namespace: ns, Name: name})
 			})))
 
+	// secrets /yaml is special-cased: the manifest contains every
+	// base64-encoded data key, so each fetch is audited as
+	// `secret_reveal` (parallel to /data/{key}). All other kinds
+	// share the generic yamlHandler below.
 	router.Get("/api/clusters/{cluster}/secrets/{ns}/{name}/yaml", credentials.Wrap(factory,
-		yamlHandler(registry, "secret",
-			func(ctx context.Context, p credentials.Provider, c clusters.Cluster, ns, name string) (string, error) {
-				return k8s.GetSecretYAML(ctx, p, k8s.GetSecretArgs{Cluster: c, Namespace: ns, Name: name})
-			})))
+		secretYamlHandler(registry, auditEmitter)))
 
 	router.Get("/api/clusters/{cluster}/jobs/{ns}/{name}/yaml", credentials.Wrap(factory,
 		yamlHandler(registry, "job",
@@ -1603,6 +1604,59 @@ func secretRevealHandler(reg *clusters.Registry, auditer *audit.Emitter) credent
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(value)
+	}
+}
+
+// secretYamlHandler serves the Secret manifest as YAML and audits
+// the read as a `secret_reveal` event. The /yaml payload contains
+// every base64-encoded data key, so a download is materially the
+// same exposure as N calls to /data/{key} — and the bulk YAML
+// download flow on the frontend now leans on this to surface "alice
+// revealed N secrets via bulk download" trails. We record the
+// (sorted) key list in `Extra.keys` so reviewers can see exactly
+// which keys were exposed, not just that "some secret was read".
+func secretYamlHandler(reg *clusters.Registry, auditer *audit.Emitter) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		ns := chi.URLParam(r, "ns")
+		name := chi.URLParam(r, "name")
+		evt := audit.Event{
+			Actor:   actorFromContext(r.Context()),
+			Verb:    audit.VerbSecretReveal,
+			Cluster: c.Name,
+			Resource: audit.ResourceRef{
+				Group: "", Version: "v1", Resource: "secrets",
+				Namespace: ns, Name: name,
+			},
+			Extra: map[string]any{"via": "yaml"},
+		}
+		yaml, keys, err := k8s.GetSecretYAMLWithKeys(r.Context(), p, k8s.GetSecretArgs{
+			Cluster: c, Namespace: ns, Name: name,
+		})
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			evt.Outcome = outcomeFor(err)
+			evt.Reason = err.Error()
+			auditer.Record(r.Context(), evt)
+			slog.ErrorContext(r.Context(), "secret yaml fetch failed",
+				"err", err, "cluster", c.Name, "ns", ns, "name", name, "actor", p.Actor())
+			http.Error(w, "operation failed", httpStatusFor(err))
+			return
+		}
+		evt.Outcome = audit.OutcomeSuccess
+		evt.Extra["keys"] = keys
+		evt.Extra["key_count"] = len(keys)
+		auditer.Record(r.Context(), evt)
+		w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(yaml))
 	}
 }
 

--- a/internal/k8s/secrets.go
+++ b/internal/k8s/secrets.go
@@ -67,18 +67,36 @@ func GetSecret(ctx context.Context, p credentials.Provider, args GetSecretArgs) 
 	}, nil
 }
 
-func GetSecretYAML(ctx context.Context, p credentials.Provider, args GetSecretArgs) (string, error) {
+// GetSecretYAMLWithKeys returns the Secret manifest as YAML plus the
+// sorted list of data keys present on the Secret. The handler layer
+// (cmd/periscope.secretYamlHandler) uses the key list to populate
+// the `secret_reveal` audit row so operators see *which* keys were
+// exposed by a YAML download, not just that "some secret" was read.
+func GetSecretYAMLWithKeys(
+	ctx context.Context,
+	p credentials.Provider,
+	args GetSecretArgs,
+) (string, []string, error) {
 	cs, err := newClientFn(ctx, p, args.Cluster)
 	if err != nil {
-		return "", fmt.Errorf("build clientset: %w", err)
+		return "", nil, fmt.Errorf("build clientset: %w", err)
 	}
 	raw, err := cs.CoreV1().Secrets(args.Namespace).Get(ctx, args.Name, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("get secret %s/%s: %w", args.Namespace, args.Name, err)
+		return "", nil, fmt.Errorf("get secret %s/%s: %w", args.Namespace, args.Name, err)
 	}
+	keys := make([]string, 0, len(raw.Data))
+	for k := range raw.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	raw.APIVersion = "v1"
 	raw.Kind = "Secret"
-	return formatYAML(raw)
+	yaml, err := formatYAML(raw)
+	if err != nil {
+		return "", nil, err
+	}
+	return yaml, keys, nil
 }
 
 // GetSecretValueArgs identifies a single key of a single secret to read.

--- a/internal/k8s/secrets_test.go
+++ b/internal/k8s/secrets_test.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+func TestGetSecretYAMLWithKeys(t *testing.T) {
+	fakeCS := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+			Type:       corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"password": []byte("hunter2"),
+				"username": []byte("alice"),
+				"token":    []byte("xyz"),
+			},
+		},
+	)
+
+	orig := newClientFn
+	newClientFn = func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (kubernetes.Interface, error) {
+		return fakeCS, nil
+	}
+	t.Cleanup(func() { newClientFn = orig })
+
+	yaml, keys, err := GetSecretYAMLWithKeys(context.Background(), stubProvider{}, GetSecretArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Namespace: "default", Name: "creds",
+	})
+	if err != nil {
+		t.Fatalf("GetSecretYAMLWithKeys: %v", err)
+	}
+
+	// Keys must be sorted — the audit row depends on stable ordering
+	// so duplicate calls produce identical Extra payloads.
+	want := []string{"password", "token", "username"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys len: got %v, want %v", keys, want)
+	}
+	for i, k := range want {
+		if keys[i] != k {
+			t.Fatalf("keys[%d]: got %q, want %q (full %v)", i, keys[i], k, keys)
+		}
+	}
+
+	if !strings.Contains(yaml, "kind: Secret") {
+		t.Fatalf("yaml missing kind: Secret\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "apiVersion: v1") {
+		t.Fatalf("yaml missing apiVersion: v1\n%s", yaml)
+	}
+}
+
+func TestGetSecretYAMLWithKeysEmpty(t *testing.T) {
+	fakeCS := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
+			Type:       corev1.SecretTypeOpaque,
+		},
+	)
+	orig := newClientFn
+	newClientFn = func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (kubernetes.Interface, error) {
+		return fakeCS, nil
+	}
+	t.Cleanup(func() { newClientFn = orig })
+
+	_, keys, err := GetSecretYAMLWithKeys(context.Background(), stubProvider{}, GetSecretArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Namespace: "default", Name: "empty",
+	})
+	if err != nil {
+		t.Fatalf("GetSecretYAMLWithKeys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected empty keys, got %v", keys)
+	}
+}

--- a/web/src/components/table/BulkActionsToolbar.tsx
+++ b/web/src/components/table/BulkActionsToolbar.tsx
@@ -1,0 +1,314 @@
+// BulkActionsToolbar — surface for bulk operations on a DataTable.
+//
+// Renders nothing when nothing is selected, so pages can mount it
+// unconditionally above their table without reserving space.
+//
+// Owns the YAML-download workflow end-to-end:
+//   - "Strip server fields" toggle (default ON; produces re-applyable
+//     YAML by feeding each fetched doc through stripForEdit)
+//   - Confirm dialog for selections containing Secrets — the existing
+//     /yaml endpoint returns base64 secret data, so a bulk download is
+//     a reveal. Operators see how many will be revealed before commit
+//   - In-flight progress + Cancel button (each in-flight fetch is
+//     wired to a single AbortController)
+//   - Best-effort partial-failure reporting: failed rows surface as a
+//     `# FAILED:` comment block at the head of the file plus a toast
+
+import { useCallback, useState } from "react";
+import { cn } from "../../lib/cn";
+import { showToast } from "../../lib/toastBus";
+import {
+  bulkFetchYaml,
+  buildFilename,
+  triggerYamlDownload,
+} from "../../lib/multiYaml";
+import type { TableSelection } from "../../hooks/useTableSelection";
+
+export interface BulkActionsToolbarProps<T> {
+  selection: TableSelection;
+  /** Currently-rendered rows. */
+  rows: T[];
+  /** Same row-key fn the DataTable uses; needed to resolve IDs → rows. */
+  rowKey: (row: T) => string;
+  /** Cluster name — used in the filename. */
+  cluster: string;
+  /** Lowercase plural kind (e.g. "pods", "configmaps"). Used in the filename. */
+  kindLabel: string;
+  /** Per-row YAML fetcher. */
+  fetchYaml: (row: T, signal: AbortSignal) => Promise<string>;
+  /**
+   * Returns true if the row contains user secrets (i.e. downloading
+   * the YAML reveals base64 secret data). When any selected row is a
+   * Secret, we surface a confirm dialog before downloading.
+   */
+  isSecret?: (row: T) => boolean;
+}
+
+export function BulkActionsToolbar<T>({
+  selection,
+  rows,
+  rowKey,
+  cluster,
+  kindLabel,
+  fetchYaml,
+  isSecret,
+}: BulkActionsToolbarProps<T>) {
+  const [stripServerFields, setStripServerFields] = useState(true);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [abortController, setAbortController] = useState<AbortController | null>(null);
+  const [confirmSecrets, setConfirmSecrets] = useState<{
+    selectedRows: T[];
+    secretCount: number;
+  } | null>(null);
+
+  // Resolve selected IDs → row references against the *current* rows
+  // array. IDs that aren't currently visible (filtered out, or removed
+  // by a watch-stream delete) are dropped from this download — we
+  // can't fetch what we don't have.
+  const resolveSelected = useCallback((): {
+    selectedRows: T[];
+    missing: number;
+  } => {
+    const byId = new Map<string, T>();
+    for (const row of rows) byId.set(rowKey(row), row);
+    const selectedRows: T[] = [];
+    let missing = 0;
+    for (const id of selection.ids) {
+      const row = byId.get(id);
+      if (row) selectedRows.push(row);
+      else missing += 1;
+    }
+    return { selectedRows, missing };
+  }, [rows, rowKey, selection.ids]);
+
+  const runDownload = useCallback(
+    async (selectedRows: T[]) => {
+      const ctrl = new AbortController();
+      setAbortController(ctrl);
+      setProgress({ done: 0, total: selectedRows.length });
+      try {
+        const result = await bulkFetchYaml({
+          items: selectedRows.map((row) => ({ id: rowKey(row), row })),
+          fetchYaml,
+          stripServerFields,
+          signal: ctrl.signal,
+          onProgress: (done, total) => setProgress({ done, total }),
+        });
+        if (ctrl.signal.aborted) {
+          showToast("download canceled", "info");
+          return;
+        }
+        if (result.successCount === 0) {
+          showToast(
+            `download failed — 0 of ${selectedRows.length} fetched`,
+            "error",
+            5000,
+          );
+          return;
+        }
+        const filename = buildFilename(cluster, kindLabel, result.successCount);
+        triggerYamlDownload(result.yaml, filename);
+        if (result.failures.length > 0) {
+          showToast(
+            `downloaded ${result.successCount} — ${result.failures.length} failed (see file header)`,
+            "warn",
+            5000,
+          );
+        } else {
+          showToast(`downloaded ${result.successCount} ${kindLabel}`, "success");
+        }
+        selection.clear();
+      } finally {
+        setProgress(null);
+        setAbortController(null);
+      }
+    },
+    [cluster, fetchYaml, kindLabel, rowKey, selection, stripServerFields],
+  );
+
+  const onDownloadClick = useCallback(() => {
+    const { selectedRows, missing } = resolveSelected();
+    if (selectedRows.length === 0) {
+      showToast(
+        missing > 0
+          ? "selected rows are no longer visible — clear and re-select"
+          : "nothing selected",
+        "info",
+      );
+      return;
+    }
+    if (missing > 0) {
+      showToast(
+        `${missing} selected row(s) no longer in view — downloading the remaining ${selectedRows.length}`,
+        "info",
+        4500,
+      );
+    }
+    const secretCount = isSecret
+      ? selectedRows.filter(isSecret).length
+      : 0;
+    if (secretCount > 0) {
+      setConfirmSecrets({ selectedRows, secretCount });
+      return;
+    }
+    void runDownload(selectedRows);
+  }, [resolveSelected, isSecret, runDownload]);
+
+  const onConfirmSecrets = useCallback(() => {
+    const pending = confirmSecrets;
+    setConfirmSecrets(null);
+    if (pending) void runDownload(pending.selectedRows);
+  }, [confirmSecrets, runDownload]);
+
+  const onCancel = useCallback(() => {
+    abortController?.abort();
+  }, [abortController]);
+
+  if (selection.count === 0 && progress === null) return null;
+
+  const downloading = progress !== null;
+  const visibleSelected = countVisible(selection, rows, rowKey);
+  const hidden = selection.count - visibleSelected;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex shrink-0 items-center gap-3 border-b border-border bg-accent-soft/40 px-6 py-2 text-[12px]",
+        )}
+        role="region"
+        aria-label="bulk actions"
+      >
+        <span className="font-mono text-ink">
+          {selection.count} selected
+          {hidden > 0 && (
+            <span className="ml-1 text-ink-muted">
+              ({hidden} hidden by filter)
+            </span>
+          )}
+        </span>
+
+        <label className="flex cursor-pointer items-center gap-1.5 text-ink-muted">
+          <input
+            type="checkbox"
+            checked={stripServerFields}
+            onChange={(e) => setStripServerFields(e.target.checked)}
+            disabled={downloading}
+            className="h-3.5 w-3.5 cursor-pointer accent-accent disabled:cursor-not-allowed"
+          />
+          <span>strip server fields</span>
+        </label>
+
+        <div className="ml-auto flex items-center gap-2">
+          {downloading && progress && (
+            <span className="font-mono text-[11px] text-ink-muted">
+              {progress.done}/{progress.total}
+            </span>
+          )}
+          {downloading ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded border border-border-strong bg-surface px-2.5 py-1 text-[11.5px] text-ink hover:bg-surface-2"
+            >
+              cancel
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onDownloadClick}
+                disabled={selection.count === 0}
+                className="rounded border border-accent/60 bg-accent px-3 py-1 text-[11.5px] font-medium text-bg hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Download YAML
+              </button>
+              <button
+                type="button"
+                onClick={selection.clear}
+                className="rounded border border-border-strong bg-surface px-2.5 py-1 text-[11.5px] text-ink-muted hover:bg-surface-2 hover:text-ink"
+              >
+                clear
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {confirmSecrets && (
+        <SecretsRevealConfirm
+          secretCount={confirmSecrets.secretCount}
+          totalCount={confirmSecrets.selectedRows.length}
+          onConfirm={onConfirmSecrets}
+          onCancel={() => setConfirmSecrets(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function countVisible<T>(
+  selection: TableSelection,
+  rows: T[],
+  rowKey: (row: T) => string,
+): number {
+  let n = 0;
+  for (const row of rows) if (selection.has(rowKey(row))) n += 1;
+  return n;
+}
+
+function SecretsRevealConfirm({
+  secretCount,
+  totalCount,
+  onConfirm,
+  onCancel,
+}: {
+  secretCount: number;
+  totalCount: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulk-secret-confirm-title"
+      onClick={onCancel}
+    >
+      <div
+        className="w-full max-w-md rounded-md border border-border-strong bg-bg p-5 text-[13px] shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="bulk-secret-confirm-title"
+          className="mb-2 font-mono text-[14px] font-medium text-ink"
+        >
+          Reveal {secretCount} secret{secretCount === 1 ? "" : "s"}?
+        </h2>
+        <p className="mb-4 text-ink-muted">
+          The YAML for {secretCount === totalCount ? "these" : `${secretCount} of these ${totalCount}`} resource
+          {secretCount === 1 ? " contains" : "s contains"} base64-encoded secret data. Each
+          revealed secret will be recorded in the audit log.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-border-strong bg-surface px-3 py-1.5 text-[12px] text-ink hover:bg-surface-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded border border-red/60 bg-red px-3 py-1.5 text-[12px] font-medium text-bg hover:bg-red/90"
+            autoFocus
+          >
+            Reveal & download
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/table/DataTable.tsx
+++ b/web/src/components/table/DataTable.tsx
@@ -1,5 +1,6 @@
-import { memo, useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
+import { memo, useLayoutEffect, useMemo, useRef, type ReactNode, type MouseEvent } from "react";
 import { cn } from "../../lib/cn";
+import type { TableSelection } from "../../hooks/useTableSelection";
 
 export type RowTint = "red" | "yellow" | null;
 
@@ -21,9 +22,17 @@ export interface DataTableProps<T> {
   rowTint?: (row: T) => RowTint;
   onRowClick?: (row: T) => void;
   selectedKey?: string | null;
+  /**
+   * Opt-in bulk-selection state. When provided, a checkbox column is
+   * prepended to the table; the header checkbox toggles select-all-on-
+   * page. Click vs. shift-click on a row checkbox toggles a single row
+   * vs. range-extends from the last anchor.
+   */
+  selection?: TableSelection;
 }
 
 const ROW_HEIGHT = 32;
+const CHECKBOX_COL_WIDTH = 36;
 
 export function DataTable<T>({
   columns,
@@ -32,6 +41,7 @@ export function DataTable<T>({
   rowTint,
   onRowClick,
   selectedKey,
+  selection,
 }: DataTableProps<T>) {
   // Sync onRowClick into a ref so the row-level handler can read the
   // latest closure without participating in memo equality.
@@ -47,12 +57,68 @@ export function DataTable<T>({
     [],
   );
 
+  // Visible IDs in render order — feeds shift-click range and the
+  // header select-all. Stable identity until rows or rowKey changes.
+  const visibleIds = useMemo(() => rows.map(rowKey), [rows, rowKey]);
+
+  // Selected count restricted to currently-visible rows. The selection
+  // model itself can hold IDs that the active filter has hidden; the
+  // header checkbox shows the on-page state, not the global state.
+  const visibleSelectedCount = useMemo(() => {
+    if (!selection) return 0;
+    let n = 0;
+    for (const id of visibleIds) if (selection.has(id)) n += 1;
+    return n;
+  }, [selection, visibleIds]);
+
+  const headerCheckboxState: "off" | "indeterminate" | "all" = !selection
+    ? "off"
+    : visibleSelectedCount === 0
+      ? "off"
+      : visibleSelectedCount === visibleIds.length
+        ? "all"
+        : "indeterminate";
+
+  const onHeaderCheckboxClick = () => {
+    if (!selection) return;
+    if (headerCheckboxState === "all") {
+      // Deselect only the visible rows; keep hidden-by-filter rows.
+      for (const id of visibleIds) {
+        if (selection.has(id)) selection.toggle(id);
+      }
+    } else {
+      selection.selectAll(visibleIds);
+    }
+  };
+
+  const onRowCheckboxClick = (id: string, e: MouseEvent) => {
+    if (!selection) return;
+    if (e.shiftKey) {
+      selection.toggleRange(id, visibleIds);
+    } else {
+      selection.toggle(id);
+    }
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div
         className="sticky top-0 z-10 flex h-7 shrink-0 items-center border-b border-border bg-bg/80 px-6 backdrop-blur-sm"
         role="row"
       >
+        {selection && (
+          <div
+            className="flex shrink-0 items-center justify-center pr-2"
+            style={{ width: CHECKBOX_COL_WIDTH }}
+            role="columnheader"
+          >
+            <HeaderCheckbox
+              state={headerCheckboxState}
+              onClick={onHeaderCheckboxClick}
+              total={visibleIds.length}
+            />
+          </div>
+        )}
         {columns.map((col) => (
           <div
             key={col.key}
@@ -79,14 +145,19 @@ export function DataTable<T>({
           const key = rowKey(row);
           const tint = rowTint?.(row) ?? null;
           const isSelected = selectedKey === key;
+          const isChecked = selection ? selection.has(key) : false;
           return (
             <DataTableRow
               key={key}
               row={row}
+              rowId={key}
               columns={columns}
               isSelected={isSelected}
               tint={tint}
               onClick={onRowClick ? handleRowClick : undefined}
+              showCheckbox={!!selection}
+              isChecked={isChecked}
+              onCheckboxClick={selection ? onRowCheckboxClick : undefined}
             />
           );
         })}
@@ -97,6 +168,7 @@ export function DataTable<T>({
 
 interface DataTableRowProps<T> {
   row: T;
+  rowId: string;
   columns: Column<T>[];
   isSelected: boolean;
   tint: RowTint;
@@ -107,6 +179,9 @@ interface DataTableRowProps<T> {
    * never participates in row-equality misses.
    */
   onClick?: (row: T) => void;
+  showCheckbox: boolean;
+  isChecked: boolean;
+  onCheckboxClick?: (id: string, e: MouseEvent) => void;
 }
 
 /**
@@ -116,19 +191,27 @@ interface DataTableRowProps<T> {
  * unchanged rows, so reference equality on `row` is exactly what we
  * want for the equality check: a single delta re-renders one row, not
  * the whole list.
+ *
+ * The checkbox cell is rendered as a sibling <span> rather than a
+ * nested <button>: nested buttons are invalid HTML and break
+ * keyboard / a11y semantics. We catch the click on the wrapper and
+ * stop propagation so the row-level navigation doesn't fire.
  */
 function DataTableRowImpl<T>({
   row,
+  rowId,
   columns,
   isSelected,
   tint,
   onClick,
+  showCheckbox,
+  isChecked,
+  onCheckboxClick,
 }: DataTableRowProps<T>) {
   return (
-    <button
-      onClick={onClick ? () => onClick(row) : undefined}
+    <div
       className={cn(
-        "group flex w-full items-center px-6 text-left text-[12.5px] transition-colors",
+        "group flex w-full items-center text-left text-[12.5px] transition-colors",
         "border-l-2",
         tint === "red" && "bg-red-soft/60",
         tint === "yellow" && "bg-yellow-soft/60",
@@ -138,40 +221,109 @@ function DataTableRowImpl<T>({
         !isSelected && !tint && "hover:bg-surface-2/50",
         !isSelected && tint === "red" && "hover:bg-red-soft",
         !isSelected && tint === "yellow" && "hover:bg-yellow-soft",
-        onClick && "cursor-pointer",
       )}
       style={{ height: ROW_HEIGHT, minHeight: ROW_HEIGHT }}
-      type="button"
       role="row"
     >
-      {columns.map((col) => (
-        <div
-          key={col.key}
-          className={cn(
-            "min-w-0 truncate pr-4",
-            col.align === "right" && "text-right",
-            col.cellClassName,
-          )}
-          style={{ flex: col.weight ?? 1 }}
-          role="cell"
+      {showCheckbox && (
+        <span
+          className="flex shrink-0 items-center justify-center pl-6 pr-2"
+          style={{ width: CHECKBOX_COL_WIDTH + 24 /* 24 = pl-6 */ }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCheckboxClick?.(rowId, e);
+          }}
         >
-          {col.accessor(row)}
-        </div>
-      ))}
-    </button>
+          <RowCheckbox checked={isChecked} rowId={rowId} />
+        </span>
+      )}
+      <button
+        onClick={onClick ? () => onClick(row) : undefined}
+        className={cn(
+          "flex h-full min-w-0 flex-1 items-center text-left",
+          !showCheckbox && "pl-6",
+          "pr-6",
+          onClick && "cursor-pointer",
+        )}
+        type="button"
+      >
+        {columns.map((col) => (
+          <div
+            key={col.key}
+            className={cn(
+              "min-w-0 truncate pr-4",
+              col.align === "right" && "text-right",
+              col.cellClassName,
+            )}
+            style={{ flex: col.weight ?? 1 }}
+            role="cell"
+          >
+            {col.accessor(row)}
+          </div>
+        ))}
+      </button>
+    </div>
   );
 }
 
-// Memo equality: only the four observable props that affect render
-// output. `onClick` is intentionally excluded — DataTable wraps it in
-// a stable ref-backed handler whose identity never changes for the
-// row's lifetime, so the row never re-renders due to a callback
-// identity churn at the page level.
+// Memo equality: only the observable props that affect render output.
+// `onClick` and `onCheckboxClick` are intentionally excluded —
+// DataTable wraps them in stable ref-backed handlers whose identity
+// never changes for the row's lifetime, so the row never re-renders
+// due to a callback identity churn at the page level.
 const DataTableRow = memo(
   DataTableRowImpl,
   (prev, next) =>
     prev.row === next.row &&
+    prev.rowId === next.rowId &&
     prev.isSelected === next.isSelected &&
     prev.tint === next.tint &&
-    prev.columns === next.columns,
+    prev.columns === next.columns &&
+    prev.showCheckbox === next.showCheckbox &&
+    prev.isChecked === next.isChecked,
 ) as typeof DataTableRowImpl;
+
+function HeaderCheckbox({
+  state,
+  onClick,
+  total,
+}: {
+  state: "off" | "indeterminate" | "all";
+  onClick: () => void;
+  total: number;
+}) {
+  const ref = useRef<HTMLInputElement | null>(null);
+  useLayoutEffect(() => {
+    if (ref.current) ref.current.indeterminate = state === "indeterminate";
+  }, [state]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={state === "all"}
+      onChange={onClick}
+      disabled={total === 0}
+      aria-label={
+        state === "all"
+          ? "deselect all rows on this page"
+          : "select all rows on this page"
+      }
+      className="h-3.5 w-3.5 cursor-pointer accent-accent disabled:cursor-not-allowed disabled:opacity-40"
+    />
+  );
+}
+
+function RowCheckbox({ checked, rowId }: { checked: boolean; rowId: string }) {
+  return (
+    <input
+      type="checkbox"
+      checked={checked}
+      // The wrapper <span> handles the click (so it can read shiftKey
+      // and stop propagation). onChange must still be present or React
+      // will warn about a controlled input without a handler.
+      onChange={() => {}}
+      aria-label={`select row ${rowId}`}
+      className="h-3.5 w-3.5 cursor-pointer accent-accent"
+    />
+  );
+}

--- a/web/src/components/table/SelectableDataTable.tsx
+++ b/web/src/components/table/SelectableDataTable.tsx
@@ -1,0 +1,60 @@
+// SelectableDataTable — DataTable + bulk-actions toolbar wired to a
+// per-instance selection model.
+//
+// Pages swap their existing <DataTable> for this when they want a
+// checkbox column and YAML bulk download. The component owns the
+// selection state internally so pages don't need to thread anything
+// through props beyond the bulk-fetch parameters.
+
+import { useMemo } from "react";
+import { DataTable, type DataTableProps } from "./DataTable";
+import { BulkActionsToolbar } from "./BulkActionsToolbar";
+import { useTableSelection } from "../../hooks/useTableSelection";
+
+export interface BulkOptions<T> {
+  cluster: string;
+  /** Lowercase plural kind. Drives the filename and toast wording. */
+  kindLabel: string;
+  fetchYaml: (row: T, signal: AbortSignal) => Promise<string>;
+  /** Optional — used to gate the secret-reveal confirm dialog. */
+  isSecret?: (row: T) => boolean;
+  /** Override the default 100-row cap. */
+  cap?: number;
+}
+
+export interface SelectableDataTableProps<T>
+  extends Omit<DataTableProps<T>, "selection"> {
+  bulk: BulkOptions<T>;
+}
+
+export function SelectableDataTable<T>({
+  bulk,
+  ...tableProps
+}: SelectableDataTableProps<T>) {
+  const selection = useTableSelection({
+    kindLabel: bulk.kindLabel,
+    cap: bulk.cap,
+  });
+
+  // Memoize so DataTable's column/row memoization stays intact when
+  // selection state mutates — the table doesn't re-render unnecessarily.
+  const tableNode = useMemo(
+    () => <DataTable {...tableProps} selection={selection} />,
+    [tableProps, selection],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <BulkActionsToolbar
+        selection={selection}
+        rows={tableProps.rows}
+        rowKey={tableProps.rowKey}
+        cluster={bulk.cluster}
+        kindLabel={bulk.kindLabel}
+        fetchYaml={bulk.fetchYaml}
+        isSecret={bulk.isSecret}
+      />
+      {tableNode}
+    </div>
+  );
+}

--- a/web/src/hooks/useTableSelection.ts
+++ b/web/src/hooks/useTableSelection.ts
@@ -1,0 +1,163 @@
+// useTableSelection — per-tab row selection state for bulk operations.
+//
+// Selection is keyed by an opaque string ID (whatever the page already
+// uses for `rowKey`). Because we store IDs (not row references), state
+// survives transient row turnover from the watch stream and from
+// client-side filtering: a row that drops out of the visible list and
+// returns later stays selected.
+//
+// Cap: refuses inserts past `cap` and surfaces a toast. The cap exists
+// so "select all on a 5,000-pod list" can't construct a multi-MB
+// browser download that freezes the tab.
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { showToast } from "../lib/toastBus";
+
+export interface UseTableSelectionArgs {
+  /** Hard cap on selected rows. Defaults to 100. */
+  cap?: number;
+  /** Human-readable kind label for the cap toast (e.g. "pods"). */
+  kindLabel?: string;
+}
+
+export interface TableSelection {
+  /** Set of currently-selected row IDs. */
+  ids: ReadonlySet<string>;
+  /** True when `id` is currently selected. */
+  has: (id: string) => boolean;
+  /** Number of selected rows. */
+  count: number;
+  /** Toggle a single row. Refuses if the cap would be exceeded. */
+  toggle: (id: string) => void;
+  /**
+   * Range-select between the last-toggled row and `id`, restricted to
+   * `visibleIds` (the currently rendered rows in order). Used by
+   * shift-click. Refuses inserts past the cap; partial range is fine.
+   */
+  toggleRange: (id: string, visibleIds: readonly string[]) => void;
+  /**
+   * Select every visible ID up to the cap. If `visibleIds.length` is
+   * over `cap` we select the first `cap` and toast.
+   */
+  selectAll: (visibleIds: readonly string[]) => void;
+  /** Drop everything. */
+  clear: () => void;
+  /** Cap value in effect. */
+  cap: number;
+}
+
+const DEFAULT_CAP = 100;
+
+export function useTableSelection({
+  cap = DEFAULT_CAP,
+  kindLabel,
+}: UseTableSelectionArgs = {}): TableSelection {
+  const [ids, setIds] = useState<ReadonlySet<string>>(() => new Set());
+  // Anchor for shift-click range selection.
+  const anchorRef = useRef<string | null>(null);
+
+  const capWarning = useCallback(() => {
+    showToast(
+      `max ${cap} ${kindLabel ?? "rows"} selected for download — refine your filter or download in batches`,
+      "warn",
+      4500,
+    );
+  }, [cap, kindLabel]);
+
+  const toggle = useCallback(
+    (id: string) => {
+      setIds((prev) => {
+        if (prev.has(id)) {
+          const next = new Set(prev);
+          next.delete(id);
+          anchorRef.current = id;
+          return next;
+        }
+        if (prev.size >= cap) {
+          capWarning();
+          return prev;
+        }
+        const next = new Set(prev);
+        next.add(id);
+        anchorRef.current = id;
+        return next;
+      });
+    },
+    [cap, capWarning],
+  );
+
+  const toggleRange = useCallback(
+    (id: string, visibleIds: readonly string[]) => {
+      const anchor = anchorRef.current;
+      if (anchor === null || anchor === id) {
+        toggle(id);
+        return;
+      }
+      const a = visibleIds.indexOf(anchor);
+      const b = visibleIds.indexOf(id);
+      if (a === -1 || b === -1) {
+        toggle(id);
+        return;
+      }
+      const [lo, hi] = a < b ? [a, b] : [b, a];
+      const range = visibleIds.slice(lo, hi + 1);
+      // Range-select adds (never deselects) — Excel/GMail convention.
+      // Stops at cap and toasts once if any were dropped.
+      setIds((prev) => {
+        const next = new Set(prev);
+        let dropped = 0;
+        for (const rid of range) {
+          if (next.has(rid)) continue;
+          if (next.size >= cap) {
+            dropped += 1;
+            continue;
+          }
+          next.add(rid);
+        }
+        if (dropped > 0) capWarning();
+        anchorRef.current = id;
+        return next;
+      });
+    },
+    [cap, capWarning, toggle],
+  );
+
+  const selectAll = useCallback(
+    (visibleIds: readonly string[]) => {
+      setIds((prev) => {
+        const next = new Set(prev);
+        let dropped = 0;
+        for (const rid of visibleIds) {
+          if (next.has(rid)) continue;
+          if (next.size >= cap) {
+            dropped += 1;
+            continue;
+          }
+          next.add(rid);
+        }
+        if (dropped > 0) capWarning();
+        return next;
+      });
+    },
+    [cap, capWarning],
+  );
+
+  const clear = useCallback(() => {
+    setIds(new Set());
+    anchorRef.current = null;
+  }, []);
+
+  return useMemo<TableSelection>(
+    () => ({
+      ids,
+      has: (id) => ids.has(id),
+      count: ids.size,
+      toggle,
+      toggleRange,
+      selectAll,
+      clear,
+      cap,
+    }),
+    [ids, toggle, toggleRange, selectAll, clear, cap],
+  );
+}

--- a/web/src/lib/multiYaml.test.ts
+++ b/web/src/lib/multiYaml.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { bulkFetchYaml, buildFilename } from "./multiYaml";
+
+describe("buildFilename", () => {
+  const fixedDate = new Date(Date.UTC(2026, 4, 4, 12, 0, 0));
+
+  it("composes <cluster>-<kind>-<date>-<count>.yaml", () => {
+    expect(buildFilename("prod-eu", "pods", 5, fixedDate)).toMatch(
+      /^prod-eu-pods-2026-05-04-5\.yaml$/,
+    );
+  });
+
+  it("sanitizes context names containing slashes / colons", () => {
+    expect(buildFilename("gke_proj/zone:cluster-1", "deployments", 3, fixedDate))
+      .toMatch(/^gke_proj_zone_cluster-1-deployments-2026-05-04-3\.yaml$/);
+  });
+
+  it("falls back to k8s when the cluster sanitizes to empty", () => {
+    expect(buildFilename("///", "pods", 1, fixedDate)).toMatch(
+      /^k8s-pods-2026-05-04-1\.yaml$/,
+    );
+  });
+});
+
+describe("bulkFetchYaml", () => {
+  const ctrl = () => new AbortController();
+
+  it("concatenates docs with --- separators in input order", async () => {
+    const items = [
+      { id: "a", row: "doc-a" },
+      { id: "b", row: "doc-b" },
+      { id: "c", row: "doc-c" },
+    ];
+    const result = await bulkFetchYaml({
+      items,
+      fetchYaml: async (row) => `${row}: 1\n`,
+      stripServerFields: false,
+      signal: ctrl().signal,
+    });
+    expect(result.successCount).toBe(3);
+    expect(result.failures).toEqual([]);
+    expect(result.yaml).toBe("doc-a: 1\n---\ndoc-b: 1\n---\ndoc-c: 1\n");
+  });
+
+  it("collects failures into a header comment and downloads the rest", async () => {
+    const items = [
+      { id: "ok", row: "ok" },
+      { id: "fail", row: "fail" },
+    ];
+    const result = await bulkFetchYaml({
+      items,
+      fetchYaml: async (row) => {
+        if (row === "fail") throw new Error("403 forbidden");
+        return `${row}: 1\n`;
+      },
+      stripServerFields: false,
+      signal: ctrl().signal,
+    });
+    expect(result.successCount).toBe(1);
+    expect(result.failures).toEqual([{ id: "fail", reason: "403 forbidden" }]);
+    expect(result.yaml).toContain("# Bulk YAML download — 1 resource(s) failed");
+    expect(result.yaml).toContain("#   - fail: 403 forbidden");
+    expect(result.yaml).toContain("ok: 1");
+  });
+
+  it("returns an empty result when aborted", async () => {
+    const c = ctrl();
+    c.abort();
+    const result = await bulkFetchYaml({
+      items: [{ id: "a", row: "a" }],
+      fetchYaml: async () => "x: 1\n",
+      stripServerFields: false,
+      signal: c.signal,
+    });
+    expect(result.yaml).toBe("");
+    expect(result.successCount).toBe(0);
+  });
+
+  it("strips server fields when the toggle is on", async () => {
+    const yamlWithStatus =
+      "apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\nstatus:\n  phase: Running\n";
+    const result = await bulkFetchYaml({
+      items: [{ id: "foo", row: yamlWithStatus }],
+      fetchYaml: async (row) => row,
+      stripServerFields: true,
+      signal: ctrl().signal,
+    });
+    expect(result.yaml).not.toContain("status:");
+    expect(result.yaml).toContain("kind: Pod");
+  });
+
+  it("reports progress as fetches resolve", async () => {
+    const events: Array<[number, number]> = [];
+    await bulkFetchYaml({
+      items: [
+        { id: "a", row: "a" },
+        { id: "b", row: "b" },
+      ],
+      fetchYaml: async (row) => `${row}: 1\n`,
+      stripServerFields: false,
+      signal: ctrl().signal,
+      onProgress: (done, total) => events.push([done, total]),
+    });
+    expect(events.length).toBe(2);
+    expect(events[events.length - 1]).toEqual([2, 2]);
+  });
+});

--- a/web/src/lib/multiYaml.ts
+++ b/web/src/lib/multiYaml.ts
@@ -1,0 +1,170 @@
+// multiYaml — bulk-fetch resource YAML, concat as a multi-document
+// stream, and trigger a browser download.
+//
+// Concurrency is capped at MAX_PARALLEL because browsers limit ~6
+// simultaneous connections per origin, and a 100-row fan-out without
+// throttling will queue against the live data streams the rest of the
+// UI depends on.
+//
+// Failures are best-effort: a row that 403s or 404s during the fetch
+// is collected into `failures` and emitted as a `# FAILED:` comment
+// block at the head of the file. The operator gets the snapshot they
+// can get — partial results beat all-or-nothing for "GitOps export"
+// and "pre-migration dump" use cases.
+
+import { stripForEdit } from "./stripForEdit";
+
+const MAX_PARALLEL = 6;
+
+export interface BulkFetchItem<T> {
+  /** Stable ID — used in failure reporting. */
+  id: string;
+  /** Page-supplied row, opaque to this lib. */
+  row: T;
+}
+
+export interface BulkFetchFailure {
+  id: string;
+  reason: string;
+}
+
+export interface BulkFetchResult {
+  yaml: string;
+  successCount: number;
+  failures: BulkFetchFailure[];
+}
+
+export interface BulkFetchArgs<T> {
+  items: BulkFetchItem<T>[];
+  /** Per-row YAML fetcher. Receives an AbortSignal for cancellation. */
+  fetchYaml: (row: T, signal: AbortSignal) => Promise<string>;
+  /** When true, run each fetched YAML through `stripForEdit`. */
+  stripServerFields: boolean;
+  signal: AbortSignal;
+  /** Optional progress callback (`done` / `total`). */
+  onProgress?: (done: number, total: number) => void;
+}
+
+export async function bulkFetchYaml<T>(
+  args: BulkFetchArgs<T>,
+): Promise<BulkFetchResult> {
+  const { items, fetchYaml, stripServerFields, signal, onProgress } = args;
+  const docs: (string | null)[] = new Array(items.length).fill(null);
+  const failures: BulkFetchFailure[] = [];
+  let done = 0;
+
+  // Simple worker-pool concurrency limiter. Each worker pulls the next
+  // index off `cursor` until exhausted. Avoids a Promise.all with N
+  // outstanding fetches blowing through the connection pool.
+  let cursor = 0;
+  const total = items.length;
+
+  const worker = async () => {
+    while (true) {
+      if (signal.aborted) return;
+      const idx = cursor++;
+      if (idx >= total) return;
+      const it = items[idx];
+      try {
+        const raw = await fetchYaml(it.row, signal);
+        docs[idx] = stripServerFields ? stripForEdit(raw) : raw;
+      } catch (err) {
+        if (signal.aborted) return;
+        failures.push({ id: it.id, reason: errorMessage(err) });
+      } finally {
+        if (!signal.aborted) {
+          done += 1;
+          onProgress?.(done, total);
+        }
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(MAX_PARALLEL, total) }, worker),
+  );
+
+  if (signal.aborted) {
+    return { yaml: "", successCount: 0, failures: [] };
+  }
+
+  const successDocs = docs.filter((d): d is string => d !== null);
+  const header = failures.length > 0 ? buildFailuresHeader(failures) : "";
+  // Each /yaml response already ends with a newline from the server's
+  // YAML serializer, but be defensive — concat with `---\n` separators
+  // and ensure each doc ends in exactly one newline before the marker.
+  const body = successDocs.map(ensureTrailingNewline).join("---\n");
+
+  return {
+    yaml: header + body,
+    successCount: successDocs.length,
+    failures,
+  };
+}
+
+function ensureTrailingNewline(s: string): string {
+  if (s.length === 0) return s;
+  return s.endsWith("\n") ? s : s + "\n";
+}
+
+function buildFailuresHeader(failures: BulkFetchFailure[]): string {
+  const lines = failures.map((f) => `#   - ${f.id}: ${f.reason}`);
+  return [
+    `# Bulk YAML download — ${failures.length} resource(s) failed to fetch:`,
+    ...lines,
+    "#",
+    "",
+  ].join("\n");
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+// --- filename ---
+
+/**
+ * buildFilename — `<cluster>-<kind>-YYYY-MM-DD-<count>.yaml`, with
+ * each segment sanitized so Windows / macOS won't reject the download.
+ *
+ * K8s context names regularly contain `/` (`gke_proj_zone_name`),
+ * `:` (EKS ARNs), and other shell-unfriendly characters. We replace
+ * runs of unsafe chars with `_` and trim leading/trailing dashes.
+ */
+export function buildFilename(
+  cluster: string,
+  kindLabel: string,
+  count: number,
+  date: Date = new Date(),
+): string {
+  const safeCluster = sanitize(cluster);
+  const safeKind = sanitize(kindLabel);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${safeCluster}-${safeKind}-${yyyy}-${mm}-${dd}-${count}.yaml`;
+}
+
+function sanitize(s: string): string {
+  return s
+    .replace(/[^a-zA-Z0-9._-]+/g, "_")
+    .replace(/^[-_.]+|[-_.]+$/g, "")
+    .slice(0, 64) || "k8s";
+}
+
+// --- download trigger ---
+
+export function triggerYamlDownload(yaml: string, filename: string): void {
+  const blob = new Blob([yaml], { type: "application/yaml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Defer revoke so Safari has time to start the download. 0ms tick
+  // is enough; no need for setTimeout(_, 1000) overkill.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/web/src/pages/ClusterRoleBindingsPage.tsx
+++ b/web/src/pages/ClusterRoleBindingsPage.tsx
@@ -5,7 +5,9 @@ import type { ClusterRoleBinding, ClusterRoleBindingList } from "../lib/types";
 import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -107,12 +109,17 @@ export function ClusterRoleBindingsPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="clusterrolebindings" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="clusterrolebindings" /> : isForbidden(query.error) ? <ForbiddenState resource="clusterrolebindings" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="clusterrolebindings" namespace={null} /> :
-          <DataTable<ClusterRoleBinding>
+          <SelectableDataTable<ClusterRoleBinding>
             columns={columns}
             rows={filtered}
             rowKey={(r) => r.name}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, tab: "describe" }))}
             selectedKey={selectedName}
+            bulk={{
+              cluster,
+              kindLabel: "clusterrolebindings",
+              fetchYaml: (r, signal) => api.clusterScopedYaml(cluster, "clusterrolebindings", r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/ClusterRolesPage.tsx
+++ b/web/src/pages/ClusterRolesPage.tsx
@@ -5,7 +5,9 @@ import type { ClusterRole, ClusterRoleList } from "../lib/types";
 import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -106,12 +108,17 @@ export function ClusterRolesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="clusterroles" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="clusterroles" /> : isForbidden(query.error) ? <ForbiddenState resource="clusterroles" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="clusterroles" namespace={null} /> :
-          <DataTable<ClusterRole>
+          <SelectableDataTable<ClusterRole>
             columns={columns}
             rows={filtered}
             rowKey={(r) => r.name}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, tab: "describe" }))}
             selectedKey={selectedName}
+            bulk={{
+              cluster,
+              kindLabel: "clusterroles",
+              fetchYaml: (r, signal) => api.clusterScopedYaml(cluster, "clusterroles", r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/ConfigMapsPage.tsx
+++ b/web/src/pages/ConfigMapsPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -125,12 +127,17 @@ export function ConfigMapsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="configmaps" namespace={namespace} />
           ) : (
-            <DataTable<ConfigMap>
+            <SelectableDataTable<ConfigMap>
               columns={columns}
               rows={filtered}
               rowKey={(c) => `${c.namespace}/${c.name}`}
               onRowClick={(c) => confirmDiscard(() => setMany({ sel: c.name, selNs: c.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "configmaps",
+                fetchYaml: (c, signal) => api.yaml(cluster, "configmaps", c.namespace, c.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/CronJobsPage.tsx
+++ b/web/src/pages/CronJobsPage.tsx
@@ -8,10 +8,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -198,13 +199,18 @@ export function CronJobsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="cronjobs" namespace={namespace} />
           ) : (
-            <DataTable<CronJob>
+            <SelectableDataTable<CronJob>
               columns={columns}
               rows={filtered}
               rowKey={(c) => `${c.namespace}/${c.name}`}
               rowTint={rowTint}
               onRowClick={(c) => confirmDiscard(() => setMany({ sel: c.name, selNs: c.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "cronjobs",
+                fetchYaml: (c, signal) => api.yaml(cluster, "cronjobs", c.namespace, c.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/DaemonSetsPage.tsx
+++ b/web/src/pages/DaemonSetsPage.tsx
@@ -7,10 +7,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -164,13 +165,18 @@ export function DaemonSetsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="daemonsets" namespace={namespace} />
           ) : (
-            <DataTable<DaemonSet>
+            <SelectableDataTable<DaemonSet>
               columns={columns}
               rows={filtered}
               rowKey={(d) => `${d.namespace}/${d.name}`}
               rowTint={rowTint}
               onRowClick={(d) => confirmDiscard(() => setMany({ sel: d.name, selNs: d.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "daemonsets",
+                fetchYaml: (d, signal) => api.yaml(cluster, "daemonsets", d.namespace, d.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/DeploymentsPage.tsx
+++ b/web/src/pages/DeploymentsPage.tsx
@@ -7,10 +7,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -151,13 +152,18 @@ export function DeploymentsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="deployments" namespace={namespace} />
           ) : (
-            <DataTable<Deployment>
+            <SelectableDataTable<Deployment>
               columns={columns}
               rows={filtered}
               rowKey={(d) => `${d.namespace}/${d.name}`}
               rowTint={rowTint}
               onRowClick={(d) => confirmDiscard(() => setMany({ sel: d.name, selNs: d.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "deployments",
+                fetchYaml: (d, signal) => api.yaml(cluster, "deployments", d.namespace, d.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/EndpointSlicesPage.tsx
+++ b/web/src/pages/EndpointSlicesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -123,12 +125,17 @@ export function EndpointSlicesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="endpointslices" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="endpointslices" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="endpointslices" namespace={namespace} /> :
-          <DataTable<EndpointSlice>
+          <SelectableDataTable<EndpointSlice>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "endpointslices",
+              fetchYaml: (r, signal) => api.yaml(cluster, "endpointslices", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/HorizontalPodAutoscalersPage.tsx
+++ b/web/src/pages/HorizontalPodAutoscalersPage.tsx
@@ -7,7 +7,9 @@ import { cn } from "../lib/cn";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -113,12 +115,17 @@ export function HorizontalPodAutoscalersPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="horizontalpodautoscalers" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="horizontalpodautoscalers" /> : isForbidden(query.error) ? <ForbiddenState resource="horizontalpodautoscalers" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="horizontalpodautoscalers" namespace={namespace} /> :
-          <DataTable<HPA>
+          <SelectableDataTable<HPA>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "horizontalpodautoscalers",
+              fetchYaml: (r, signal) => api.yaml(cluster, "horizontalpodautoscalers", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/IngressClassesPage.tsx
+++ b/web/src/pages/IngressClassesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { cn } from "../lib/cn";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -117,12 +119,17 @@ export function IngressClassesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="ingressclasses" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="ingressclasses" /> : isForbidden(query.error) ? <ForbiddenState resource="ingressclasses" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="ingressclasses" namespace={null} /> :
-          <DataTable<IngressClass>
+          <SelectableDataTable<IngressClass>
             columns={columns}
             rows={filtered}
             rowKey={(r) => r.name}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, tab: "describe" }))}
             selectedKey={selectedName}
+            bulk={{
+              cluster,
+              kindLabel: "ingressclasses",
+              fetchYaml: (r, signal) => api.clusterScopedYaml(cluster, "ingressclasses", r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/IngressesPage.tsx
+++ b/web/src/pages/IngressesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -153,12 +155,17 @@ export function IngressesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="ingresses" namespace={namespace} />
           ) : (
-            <DataTable<Ingress>
+            <SelectableDataTable<Ingress>
               columns={columns}
               rows={filtered}
               rowKey={(i) => `${i.namespace}/${i.name}`}
               onRowClick={(i) => confirmDiscard(() => setMany({ sel: i.name, selNs: i.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "ingresses",
+                fetchYaml: (i, signal) => api.yaml(cluster, "ingresses", i.namespace, i.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/JobsPage.tsx
+++ b/web/src/pages/JobsPage.tsx
@@ -7,10 +7,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -213,13 +214,18 @@ export function JobsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="jobs" namespace={namespace} />
           ) : (
-            <DataTable<Job>
+            <SelectableDataTable<Job>
               columns={columns}
               rows={filtered}
               rowKey={(j) => `${j.namespace}/${j.name}`}
               rowTint={rowTint}
               onRowClick={(j) => confirmDiscard(() => setMany({ sel: j.name, selNs: j.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "jobs",
+                fetchYaml: (j, signal) => api.yaml(cluster, "jobs", j.namespace, j.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/LimitRangesPage.tsx
+++ b/web/src/pages/LimitRangesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -100,12 +102,17 @@ export function LimitRangesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="limitranges" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="limitranges" /> : isForbidden(query.error) ? <ForbiddenState resource="limitranges" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="limitranges" namespace={namespace} /> :
-          <DataTable<LimitRange>
+          <SelectableDataTable<LimitRange>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "limitranges",
+              fetchYaml: (r, signal) => api.yaml(cluster, "limitranges", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/NamespacesPage.tsx
+++ b/web/src/pages/NamespacesPage.tsx
@@ -6,10 +6,11 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { PhaseTag } from "../components/table/StatusDot";
 import {
   EmptyState,
@@ -133,13 +134,18 @@ export function NamespacesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="namespaces" namespace={null} />
           ) : (
-            <DataTable<Namespace>
+            <SelectableDataTable<Namespace>
               columns={columns}
               rows={filtered}
               rowKey={(n) => n.name}
               rowTint={rowTint}
               onRowClick={(n) => confirmDiscard(() => setMany({ sel: n.name, tab: "describe" }))}
               selectedKey={selectedName}
+              bulk={{
+                cluster,
+                kindLabel: "namespaces",
+                fetchYaml: (n, signal) => api.namespaceYaml(cluster, n.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/NetworkPoliciesPage.tsx
+++ b/web/src/pages/NetworkPoliciesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -101,12 +103,17 @@ export function NetworkPoliciesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="networkpolicies" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="networkpolicies" /> : isForbidden(query.error) ? <ForbiddenState resource="networkpolicies" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="networkpolicies" namespace={namespace} /> :
-          <DataTable<NetworkPolicy>
+          <SelectableDataTable<NetworkPolicy>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "networkpolicies",
+              fetchYaml: (r, signal) => api.yaml(cluster, "networkpolicies", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/NodesPage.tsx
+++ b/web/src/pages/NodesPage.tsx
@@ -6,10 +6,11 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { StatusDot } from "../components/table/StatusDot";
 import {
   EmptyState,
@@ -222,13 +223,18 @@ export function NodesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="nodes" namespace={null} />
           ) : (
-            <DataTable<Node>
+            <SelectableDataTable<Node>
               columns={columns}
               rows={filtered}
               rowKey={(n) => n.name}
               rowTint={rowTint}
               onRowClick={(n) => setMany({ sel: n.name })}
               selectedKey={selectedName}
+              bulk={{
+                cluster,
+                kindLabel: "nodes",
+                fetchYaml: (n, signal) => api.clusterScopedYaml(cluster, "nodes", n.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/PVCsPage.tsx
+++ b/web/src/pages/PVCsPage.tsx
@@ -7,7 +7,9 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { NamespacePicker } from "../components/shell/NamespacePicker";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { PhaseTag } from "../components/table/StatusDot";
 import { DetailPane } from "../components/detail/DetailPane";
 import { YamlView } from "../components/detail/YamlView";
@@ -136,13 +138,18 @@ export function PVCsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="pvcs" namespace={namespace} />
           ) : (
-            <DataTable<PVC>
+            <SelectableDataTable<PVC>
               columns={columns}
               rows={filtered}
               rowKey={(p) => `${p.namespace}/${p.name}`}
               rowTint={rowTint}
               onRowClick={(p) => confirmDiscard(() => setMany({ sel: p.name, selNs: p.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "pvcs",
+                fetchYaml: (p, signal) => api.yaml(cluster, "pvcs", p.namespace, p.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/PVsPage.tsx
+++ b/web/src/pages/PVsPage.tsx
@@ -6,7 +6,9 @@ import type { PV, PVList } from "../lib/types";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { PhaseTag } from "../components/table/StatusDot";
 import { DetailPane } from "../components/detail/DetailPane";
 import { YamlView } from "../components/detail/YamlView";
@@ -129,13 +131,18 @@ export function PVsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="pvs" namespace={null} />
           ) : (
-            <DataTable<PV>
+            <SelectableDataTable<PV>
               columns={columns}
               rows={filtered}
               rowKey={(p) => p.name}
               rowTint={rowTint}
               onRowClick={(p) => confirmDiscard(() => setMany({ sel: p.name, tab: "describe" }))}
               selectedKey={selectedName}
+              bulk={{
+                cluster,
+                kindLabel: "pvs",
+                fetchYaml: (p, signal) => api.clusterScopedYaml(cluster, "pvs", p.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/PodDisruptionBudgetsPage.tsx
+++ b/web/src/pages/PodDisruptionBudgetsPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -104,12 +106,17 @@ export function PodDisruptionBudgetsPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="poddisruptionbudgets" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="poddisruptionbudgets" /> : isForbidden(query.error) ? <ForbiddenState resource="poddisruptionbudgets" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="poddisruptionbudgets" namespace={namespace} /> :
-          <DataTable<PDB>
+          <SelectableDataTable<PDB>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "poddisruptionbudgets",
+              fetchYaml: (r, signal) => api.yaml(cluster, "poddisruptionbudgets", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/PodsPage.tsx
+++ b/web/src/pages/PodsPage.tsx
@@ -7,10 +7,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { PhaseTag } from "../components/table/StatusDot";
 import { phaseTone } from "../components/table/phaseTone";
 import {
@@ -228,13 +229,18 @@ export function PodsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="pods" namespace={namespace} />
           ) : (
-            <DataTable<Pod>
+            <SelectableDataTable<Pod>
               columns={columns}
               rows={filtered}
               rowKey={(p) => `${p.namespace}/${p.name}`}
               rowTint={rowTint}
               onRowClick={(p) => confirmDiscard(() => setMany({ sel: p.name, selNs: p.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "pods",
+                fetchYaml: (p, signal) => api.yaml(cluster, "pods", p.namespace, p.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/PriorityClassesPage.tsx
+++ b/web/src/pages/PriorityClassesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { cn } from "../lib/cn";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -118,12 +120,17 @@ export function PriorityClassesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="priorityclasses" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="priorityclasses" /> : isForbidden(query.error) ? <ForbiddenState resource="priorityclasses" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="priorityclasses" namespace={null} /> :
-          <DataTable<PriorityClass>
+          <SelectableDataTable<PriorityClass>
             columns={columns}
             rows={filtered}
             rowKey={(r) => r.name}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, tab: "describe" }))}
             selectedKey={selectedName}
+            bulk={{
+              cluster,
+              kindLabel: "priorityclasses",
+              fetchYaml: (r, signal) => api.clusterScopedYaml(cluster, "priorityclasses", r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/ResourceQuotasPage.tsx
+++ b/web/src/pages/ResourceQuotasPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -100,12 +102,17 @@ export function ResourceQuotasPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="resourcequotas" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="resourcequotas" /> : isForbidden(query.error) ? <ForbiddenState resource="resourcequotas" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="resourcequotas" namespace={namespace} /> :
-          <DataTable<ResourceQuota>
+          <SelectableDataTable<ResourceQuota>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "resourcequotas",
+              fetchYaml: (r, signal) => api.yaml(cluster, "resourcequotas", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/RoleBindingsPage.tsx
+++ b/web/src/pages/RoleBindingsPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -99,12 +101,17 @@ export function RoleBindingsPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="rolebindings" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="rolebindings" /> : isForbidden(query.error) ? <ForbiddenState resource="rolebindings" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="rolebindings" namespace={namespace} /> :
-          <DataTable<RoleBinding>
+          <SelectableDataTable<RoleBinding>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "rolebindings",
+              fetchYaml: (r, signal) => api.yaml(cluster, "rolebindings", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/RolesPage.tsx
+++ b/web/src/pages/RolesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -98,12 +100,17 @@ export function RolesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="roles" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="roles" /> : isForbidden(query.error) ? <ForbiddenState resource="roles" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="roles" namespace={namespace} /> :
-          <DataTable<Role>
+          <SelectableDataTable<Role>
             columns={columns}
             rows={filtered}
             rowKey={(r) => `${r.namespace}/${r.name}`}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, selNs: r.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "roles",
+              fetchYaml: (r, signal) => api.yaml(cluster, "roles", r.namespace, r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/RuntimeClassesPage.tsx
+++ b/web/src/pages/RuntimeClassesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { cn } from "../lib/cn";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -108,12 +110,17 @@ export function RuntimeClassesPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="runtimeclasses" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="runtimeclasses" /> : isForbidden(query.error) ? <ForbiddenState resource="runtimeclasses" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="runtimeclasses" namespace={null} /> :
-          <DataTable<RuntimeClass>
+          <SelectableDataTable<RuntimeClass>
             columns={columns}
             rows={filtered}
             rowKey={(r) => r.name}
             onRowClick={(r) => confirmDiscard(() => setMany({ sel: r.name, tab: "describe" }))}
             selectedKey={selectedName}
+            bulk={{
+              cluster,
+              kindLabel: "runtimeclasses",
+              fetchYaml: (r, signal) => api.clusterScopedYaml(cluster, "runtimeclasses", r.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/SecretsPage.tsx
+++ b/web/src/pages/SecretsPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -137,12 +139,18 @@ export function SecretsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="secrets" namespace={namespace} />
           ) : (
-            <DataTable<Secret>
+            <SelectableDataTable<Secret>
               columns={columns}
               rows={filtered}
               rowKey={(s) => `${s.namespace}/${s.name}`}
               onRowClick={(s) => confirmDiscard(() => setMany({ sel: s.name, selNs: s.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "secrets",
+                fetchYaml: (s, signal) => api.yaml(cluster, "secrets", s.namespace, s.name, signal),
+                isSecret: () => true,
+              }}
             />
           )
         }

--- a/web/src/pages/ServiceAccountsPage.tsx
+++ b/web/src/pages/ServiceAccountsPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
 import { DetailPane } from "../components/detail/DetailPane";
@@ -98,12 +100,17 @@ export function ServiceAccountsPage({ cluster }: { cluster: string }) {
           query.isLoading ? <LoadingState resource="serviceaccounts" /> :
           query.isError ? isForbidden(query.error) ? <ForbiddenState resource="serviceaccounts" /> : isForbidden(query.error) ? <ForbiddenState resource="serviceaccounts" /> : <ErrorState title="couldn't reach the cluster" message={(query.error as Error).message} /> :
           filtered.length === 0 ? <EmptyState resource="serviceaccounts" namespace={namespace} /> :
-          <DataTable<ServiceAccount>
+          <SelectableDataTable<ServiceAccount>
             columns={columns}
             rows={filtered}
             rowKey={(sa) => `${sa.namespace}/${sa.name}`}
             onRowClick={(sa) => confirmDiscard(() => setMany({ sel: sa.name, selNs: sa.namespace, tab: "describe" }))}
             selectedKey={selectedKey}
+            bulk={{
+              cluster,
+              kindLabel: "serviceaccounts",
+              fetchYaml: (sa, signal) => api.yaml(cluster, "serviceaccounts", sa.namespace, sa.name, signal),
+            }}
           />
         }
         right={detail}

--- a/web/src/pages/ServicesPage.tsx
+++ b/web/src/pages/ServicesPage.tsx
@@ -6,7 +6,9 @@ import { ageFrom, formatPorts, nameMatches } from "../lib/format";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -128,12 +130,17 @@ export function ServicesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="services" namespace={namespace} />
           ) : (
-            <DataTable<Service>
+            <SelectableDataTable<Service>
               columns={columns}
               rows={filtered}
               rowKey={(s) => `${s.namespace}/${s.name}`}
               onRowClick={(s) => confirmDiscard(() => setMany({ sel: s.name, selNs: s.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "services",
+                fetchYaml: (s, signal) => api.yaml(cluster, "services", s.namespace, s.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/StatefulSetsPage.tsx
+++ b/web/src/pages/StatefulSetsPage.tsx
@@ -7,10 +7,11 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import {
-  DataTable,
   type Column,
   type RowTint,
 } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -151,13 +152,18 @@ export function StatefulSetsPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="statefulsets" namespace={namespace} />
           ) : (
-            <DataTable<StatefulSet>
+            <SelectableDataTable<StatefulSet>
               columns={columns}
               rows={filtered}
               rowKey={(s) => `${s.namespace}/${s.name}`}
               rowTint={rowTint}
               onRowClick={(s) => confirmDiscard(() => setMany({ sel: s.name, selNs: s.namespace, tab: "describe" }))}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: "statefulsets",
+                fetchYaml: (s, signal) => api.yaml(cluster, "statefulsets", s.namespace, s.name, signal),
+              }}
             />
           )
         }

--- a/web/src/pages/StorageClassesPage.tsx
+++ b/web/src/pages/StorageClassesPage.tsx
@@ -6,7 +6,9 @@ import type { StorageClass, StorageClassList } from "../lib/types";
 import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
-import { DataTable, type Column } from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import { DetailPane } from "../components/detail/DetailPane";
 import { YamlView } from "../components/detail/YamlView";
 import { useEditorDirty } from "../hooks/useEditorDirty";
@@ -109,12 +111,17 @@ export function StorageClassesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource="storageclasses" namespace={null} />
           ) : (
-            <DataTable<StorageClass>
+            <SelectableDataTable<StorageClass>
               columns={columns}
               rows={filtered}
               rowKey={(s) => s.name}
               onRowClick={(s) => confirmDiscard(() => setMany({ sel: s.name, tab: "describe" }))}
               selectedKey={selectedName}
+              bulk={{
+                cluster,
+                kindLabel: "storageclasses",
+                fetchYaml: (s, signal) => api.clusterScopedYaml(cluster, "storageclasses", s.name, signal),
+              }}
             />
           )
         }


### PR DESCRIPTION
## Summary

Adds bulk YAML download capability to resource tables with row selection, progress tracking, and audit logging. Users can now select multiple resources and download their YAML manifests as a multi-document stream. For Secrets, a confirmation dialog surfaces the number of secrets being revealed before download proceeds. The backend audits secret reveals with the sorted list of exposed keys.

## Related issue / RFC

No issue linked; this is a feature addition for bulk resource export workflows.

## Type of change

- [x] New feature (non-breaking)

## Surfaces touched

- [x] HTTP API (`/api/...`) — `/secrets/{ns}/{name}/yaml` now audits as `secret_reveal` with key list
- [x] Audit / RBAC — Secret YAML downloads are audited with exposed key names
- [x] SPA / frontend — New bulk selection UI, toolbar, and download workflow

## How was this tested?

- Added unit tests for `buildFilename` (sanitization, date formatting) and `bulkFetchYaml` (concatenation, failure handling, progress reporting, abort behavior, stripServerFields toggle).
- Added Go tests for `GetSecretYAMLWithKeys` to verify sorted key extraction and YAML structure.
- Frontend components (DataTable, BulkActionsToolbar, SelectableDataTable) are integrated into existing pages; DataTable changes are backward-compatible (selection is opt-in).
- CI will run the new test suites and verify no regressions in existing table pages.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests added or updated where it makes sense.
- [ ] Docs updated (not applicable for this feature addition).
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.

## Details

**Frontend:**
- `BulkActionsToolbar`: Renders a sticky toolbar above tables when rows are selected. Owns the download workflow: "strip server fields" toggle, secret-reveal confirmation dialog, in-flight progress + cancel button, and best-effort failure reporting (failed rows surface as a comment block in the YAML file).
- `useTableSelection`: Per-tab selection state hook with a configurable cap (default 100 rows) to prevent runaway downloads. Supports single-row toggle, shift-click range selection, and select-all-on-page.
- `DataTable`: Extended with optional checkbox column and selection integration. Rows are memoized to avoid unnecessary re-renders when selection state changes.
- `SelectableDataTable`: Convenience wrapper combining DataTable + BulkActionsToolbar with internal selection state.
- `multiYaml`: Bulk-fetch library with concurrency limiting (6 parallel fetches), progress callbacks, abort support, and failure collection. Concatenates YAML as a multi-document stream with `---` separators.
- All resource pages updated to use `SelectableDataTable` where appropriate.

**Backend:**
- `GetSecretYAMLWithKeys`: New function returning Secret YAML plus sorted list of data keys.
- `secretYamlHandler`: Audits Secret YAML downloads as `secret_reveal` events with the exposed key list in `Extra.keys`, enabling audit trails like "alice revealed [password, token] via bulk download".
- Existing `/yaml` endpoints for other kinds remain unchanged.

**Tests:**
- `multiYaml.test.ts`: Filename composition, doc concatenation, failure header generation, abort handling, stripServerFields behavior, progress reporting.
- `secrets_test.go`: Key extraction and sorting, YAML structure validation, empty secret handling.

Closes #56 