### PR TITLE
feat(web): bulk-select + YAML download on ReplicaSets and CustomResources

### DIFF
--- a/web/src/components/table/BulkActionsToolbar.tsx
+++ b/web/src/components/table/BulkActionsToolbar.tsx
@@ -30,6 +30,16 @@ export interface BulkActionsToolbarProps<T> {
   rows: T[];
   /** Same row-key fn the DataTable uses; needed to resolve IDs → rows. */
   rowKey: (row: T) => string;
+
+  /**
+   * Optional explicit list of currently-rendered row IDs in
+   * render order. Defaults to `rows.map(rowKey)` — correct for
+   * flat tables. Grouped layouts (e.g. ReplicaSetsPage's
+   * deployment groupings) should pass this so the "(N hidden)"
+   * qualifier accounts for collapsed groups, not just filter
+   * chips.
+   */
+  visibleIds?: readonly string[];
   /** Cluster name — used in the filename. */
   cluster: string;
   /** Lowercase plural kind (e.g. "pods", "configmaps"). Used in the filename. */
@@ -37,11 +47,13 @@ export interface BulkActionsToolbarProps<T> {
   /** Per-row YAML fetcher. */
   fetchYaml: (row: T, signal: AbortSignal) => Promise<string>;
   /**
-   * Returns true if the row contains user secrets (i.e. downloading
-   * the YAML reveals base64 secret data). When any selected row is a
-   * Secret, we surface a confirm dialog before downloading.
+   * Returns true when downloading the row's YAML reveals sensitive data
+   * (base64 secret payloads, encrypted ciphertext, etc.). Any selected
+   * row matching `confirmReveal` triggers a confirm dialog before the
+   * download proceeds. Pass `() => true` for kinds where every row is
+   * sensitive (Secrets); use a per-row predicate for mixed kinds.
    */
-  isSecret?: (row: T) => boolean;
+  confirmReveal?: (row: T) => boolean;
 }
 
 export function BulkActionsToolbar<T>({
@@ -50,8 +62,9 @@ export function BulkActionsToolbar<T>({
   rowKey,
   cluster,
   kindLabel,
+  visibleIds,
   fetchYaml,
-  isSecret,
+  confirmReveal,
 }: BulkActionsToolbarProps<T>) {
   const [stripServerFields, setStripServerFields] = useState(true);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
@@ -144,15 +157,15 @@ export function BulkActionsToolbar<T>({
         4500,
       );
     }
-    const secretCount = isSecret
-      ? selectedRows.filter(isSecret).length
+    const secretCount = confirmReveal
+      ? selectedRows.filter(confirmReveal).length
       : 0;
     if (secretCount > 0) {
       setConfirmSecrets({ selectedRows, secretCount });
       return;
     }
     void runDownload(selectedRows);
-  }, [resolveSelected, isSecret, runDownload]);
+  }, [resolveSelected, confirmReveal, runDownload]);
 
   const onConfirmSecrets = useCallback(() => {
     const pending = confirmSecrets;
@@ -167,7 +180,8 @@ export function BulkActionsToolbar<T>({
   if (selection.count === 0 && progress === null) return null;
 
   const downloading = progress !== null;
-  const visibleSelected = countVisible(selection, rows, rowKey);
+  const effectiveVisibleIds = visibleIds ?? rows.map(rowKey);
+  const visibleSelected = countVisible(selection, effectiveVisibleIds);
   const hidden = selection.count - visibleSelected;
 
   return (
@@ -247,13 +261,12 @@ export function BulkActionsToolbar<T>({
   );
 }
 
-function countVisible<T>(
+function countVisible(
   selection: TableSelection,
-  rows: T[],
-  rowKey: (row: T) => string,
+  visibleIds: readonly string[],
 ): number {
   let n = 0;
-  for (const row of rows) if (selection.has(rowKey(row))) n += 1;
+  for (const id of visibleIds) if (selection.has(id)) n += 1;
   return n;
 }
 
@@ -295,6 +308,7 @@ function SecretsRevealConfirm({
           <button
             type="button"
             onClick={onCancel}
+            autoFocus
             className="rounded border border-border-strong bg-surface px-3 py-1.5 text-[12px] text-ink hover:bg-surface-2"
           >
             Cancel
@@ -303,7 +317,6 @@ function SecretsRevealConfirm({
             type="button"
             onClick={onConfirm}
             className="rounded border border-red/60 bg-red px-3 py-1.5 text-[12px] font-medium text-bg hover:bg-red/90"
-            autoFocus
           >
             Reveal & download
           </button>

--- a/web/src/components/table/DataTable.tsx
+++ b/web/src/components/table/DataTable.tsx
@@ -323,6 +323,7 @@ function RowCheckbox({ checked, rowId }: { checked: boolean; rowId: string }) {
       // will warn about a controlled input without a handler.
       onChange={() => {}}
       aria-label={`select row ${rowId}`}
+      tabIndex={-1}
       className="h-3.5 w-3.5 cursor-pointer accent-accent"
     />
   );

--- a/web/src/components/table/SelectableDataTable.tsx
+++ b/web/src/components/table/SelectableDataTable.tsx
@@ -17,7 +17,10 @@ export interface BulkOptions<T> {
   kindLabel: string;
   fetchYaml: (row: T, signal: AbortSignal) => Promise<string>;
   /** Optional — used to gate the secret-reveal confirm dialog. */
-  isSecret?: (row: T) => boolean;
+  /** Mirrors `BulkActionsToolbar.confirmReveal`. Pass `() => true` for
+   *  kinds where every row is sensitive (Secrets); use a per-row
+   *  predicate for mixed kinds. */
+  confirmReveal?: (row: T) => boolean;
   /** Override the default 100-row cap. */
   cap?: number;
 }
@@ -52,7 +55,7 @@ export function SelectableDataTable<T>({
         cluster={bulk.cluster}
         kindLabel={bulk.kindLabel}
         fetchYaml={bulk.fetchYaml}
-        isSecret={bulk.isSecret}
+        confirmReveal={bulk.confirmReveal}
       />
       {tableNode}
     </div>

--- a/web/src/lib/multiYaml.ts
+++ b/web/src/lib/multiYaml.ts
@@ -140,9 +140,9 @@ export function buildFilename(
 ): string {
   const safeCluster = sanitize(cluster);
   const safeKind = sanitize(kindLabel);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
+  const yyyy = date.getUTCFullYear();
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
   return `${safeCluster}-${safeKind}-${yyyy}-${mm}-${dd}-${count}.yaml`;
 }
 

--- a/web/src/pages/CustomResourcesPage.tsx
+++ b/web/src/pages/CustomResourcesPage.tsx
@@ -12,10 +12,9 @@ import { cn } from "../lib/cn";
 import { queryKeys } from "../lib/queryKeys";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
-import {
-  DataTable,
-  type Column,
-} from "../components/table/DataTable";
+import { type Column } from "../components/table/DataTable";
+import { SelectableDataTable } from "../components/table/SelectableDataTable";
+import { api } from "../lib/api";
 import {
   EmptyState,
   ErrorState,
@@ -334,12 +333,26 @@ export function CustomResourcesPage({ cluster }: { cluster: string }) {
           ) : filtered.length === 0 ? (
             <EmptyState resource={crd?.kind?.toLowerCase() ?? "items"} namespace={namespace} />
           ) : (
-            <DataTable<CustomResource>
+            <SelectableDataTable<CustomResource>
               columns={columns}
               rows={filtered}
               rowKey={(r) => `${r.namespace ?? ""}/${r.name}`}
               onRowClick={onRowClick}
               selectedKey={selectedKey}
+              bulk={{
+                cluster,
+                kindLabel: crd?.plural ?? plural ?? "items",
+                fetchYaml: (r, signal) =>
+                  api.getCustomResourceYAML(
+                    cluster,
+                    group ?? "",
+                    version ?? "",
+                    plural ?? "",
+                    isClusterScoped ? null : r.namespace ?? null,
+                    r.name,
+                    signal,
+                  ),
+              }}
             />
           )
         }

--- a/web/src/pages/ReplicaSetsPage.tsx
+++ b/web/src/pages/ReplicaSetsPage.tsx
@@ -1,13 +1,16 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type MouseEvent } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useResource } from "../hooks/useResource";
 import type { ReplicaSet, ReplicaSetList } from "../lib/types";
 import { ageFrom, nameMatches } from "../lib/format";
 import { cn } from "../lib/cn";
+import { api } from "../lib/api";
 import { PageHeader } from "../components/page/PageHeader";
 import { SplitPane } from "../components/page/SplitPane";
 import { EmptyState, ErrorState, ForbiddenState, LoadingState } from "../components/table/states";
 import { isForbidden } from "../components/table/isForbidden";
+import { BulkActionsToolbar } from "../components/table/BulkActionsToolbar";
+import { useTableSelection } from "../hooks/useTableSelection";
 import { DetailPane } from "../components/detail/DetailPane";
 import { ReplicaSetDescribe } from "../components/detail/describe/ReplicaSetDescribe";
 import { YamlView } from "../components/detail/YamlView";
@@ -16,6 +19,8 @@ import { useConfirmDiscard } from "../hooks/useConfirmDiscard";
 import { ResourceActions } from "../components/edit/ResourceActions";
 import { EventsView } from "../components/detail/EventsView";
 import { NamespacePicker } from "../components/shell/NamespacePicker";
+
+const rsKey = (rs: ReplicaSet) => `${rs.namespace}/${rs.name}`;
 
 function isActiveRS(rs: ReplicaSet) {
   return rs.desired > 0;
@@ -129,6 +134,28 @@ export function ReplicaSetsPage({ cluster }: { cluster: string }) {
   const selectedKey = selectedNs && selectedName ? `${selectedNs}/${selectedName}` : null;
   const selectRS = (rs: ReplicaSet) => setMany({ sel: rs.name, selNs: rs.namespace, tab: "describe" });
 
+  // Bulk-download selection. Lives at page level so the toolbar above
+  // the grouped list shares state with checkboxes inside RSRows. The
+  // grouped layout means visibleIds isn't simply `filtered.map(rsKey)` —
+  // dormant revisions are only "visible" when their group is expanded
+  // (or the user is searching, which auto-expands every group).
+  const selection = useTableSelection({ kindLabel: "replicasets" });
+  const visibleIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const g of groups) {
+      if (g.activeRS) ids.push(rsKey(g.activeRS));
+      if (expandedGroups.has(g.key) || !!search) {
+        for (const rs of g.dormantRS) ids.push(rsKey(rs));
+      }
+    }
+    for (const rs of standalone) ids.push(rsKey(rs));
+    return ids;
+  }, [groups, standalone, expandedGroups, search]);
+  const onRowCheckboxClick = (id: string, e: MouseEvent) => {
+    if (e.shiftKey) selection.toggleRange(id, visibleIds);
+    else selection.toggle(id);
+  };
+
   const editFlag = useEditorDirty(cluster, "replicasets", selectedNs ?? undefined, selectedName);
   const confirmDiscard = useConfirmDiscard(editFlag.dirty);
 
@@ -158,25 +185,43 @@ export function ReplicaSetsPage({ cluster }: { cluster: string }) {
     ) : null;
 
   const groupedList = (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-      {groups.map((group) => (
-        <DeploymentGroup
-          key={group.key}
-          group={group}
-          isExpanded={expandedGroups.has(group.key) || !!search}
-          onToggle={() => toggleGroup(group.key)}
-          selectedKey={selectedKey}
-          onSelectRS={selectRS}
-          onNavigateToDeployment={() =>
-            navigate(
-              `/clusters/${cluster}/deployments?sel=${encodeURIComponent(group.deploymentName)}&selNs=${encodeURIComponent(group.namespace)}&tab=describe`,
-            )
-          }
-        />
-      ))}
-      {standalone.length > 0 && (
-        <StandaloneSection rsList={standalone} selectedKey={selectedKey} onSelectRS={selectRS} />
-      )}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <BulkActionsToolbar
+        selection={selection}
+        rows={filtered}
+        rowKey={rsKey}
+        cluster={cluster}
+        kindLabel="replicasets"
+        fetchYaml={(rs, signal) => api.yaml(cluster, "replicasets", rs.namespace, rs.name, signal)}
+      />
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {groups.map((group) => (
+          <DeploymentGroup
+            key={group.key}
+            group={group}
+            isExpanded={expandedGroups.has(group.key) || !!search}
+            onToggle={() => toggleGroup(group.key)}
+            selectedKey={selectedKey}
+            onSelectRS={selectRS}
+            onNavigateToDeployment={() =>
+              navigate(
+                `/clusters/${cluster}/deployments?sel=${encodeURIComponent(group.deploymentName)}&selNs=${encodeURIComponent(group.namespace)}&tab=describe`,
+              )
+            }
+            isChecked={(rs) => selection.has(rsKey(rs))}
+            onCheckboxClick={onRowCheckboxClick}
+          />
+        ))}
+        {standalone.length > 0 && (
+          <StandaloneSection
+            rsList={standalone}
+            selectedKey={selectedKey}
+            onSelectRS={selectRS}
+            isChecked={(rs) => selection.has(rsKey(rs))}
+            onCheckboxClick={onRowCheckboxClick}
+          />
+        )}
+      </div>
     </div>
   );
 
@@ -245,6 +290,8 @@ function DeploymentGroup({
   selectedKey,
   onSelectRS,
   onNavigateToDeployment,
+  isChecked,
+  onCheckboxClick,
 }: {
   group: RSGroup;
   isExpanded: boolean;
@@ -252,6 +299,8 @@ function DeploymentGroup({
   selectedKey: string | null;
   onSelectRS: (rs: ReplicaSet) => void;
   onNavigateToDeployment: () => void;
+  isChecked: (rs: ReplicaSet) => boolean;
+  onCheckboxClick: (id: string, e: MouseEvent) => void;
 }) {
   const { deploymentName, namespace, activeRS, dormantRS } = group;
   const hasDormant = dormantRS.length > 0;
@@ -318,6 +367,8 @@ function DeploymentGroup({
           isActive
           isSelected={selectedKey === `${activeRS.namespace}/${activeRS.name}`}
           onClick={() => onSelectRS(activeRS)}
+          isChecked={isChecked(activeRS)}
+          onCheckboxClick={onCheckboxClick}
         />
       )}
 
@@ -333,6 +384,8 @@ function DeploymentGroup({
                 isActive={false}
                 isSelected={selectedKey === `${rs.namespace}/${rs.name}`}
                 onClick={() => onSelectRS(rs)}
+                isChecked={isChecked(rs)}
+                onCheckboxClick={onCheckboxClick}
               />
             ))
           ) : (
@@ -360,14 +413,19 @@ function RSRow({
   isActive,
   isSelected,
   onClick,
+  isChecked,
+  onCheckboxClick,
 }: {
   rs: ReplicaSet;
   ownerName: string;
   isActive: boolean;
   isSelected: boolean;
   onClick: () => void;
+  isChecked: boolean;
+  onCheckboxClick: (id: string, e: MouseEvent) => void;
 }) {
   const { base, hash } = splitRSName(rs.name, ownerName);
+  const id = rsKey(rs);
 
   return (
     <div
@@ -376,13 +434,31 @@ function RSRow({
       onClick={onClick}
       onKeyDown={(e) => e.key === "Enter" && onClick()}
       className={cn(
-        "flex cursor-pointer items-center gap-3 py-1.5 pl-10 pr-6 text-[12.5px] transition-colors",
+        "flex cursor-pointer items-center gap-2 py-1.5 pl-4 pr-6 text-[12.5px] transition-colors",
         isSelected
-          ? "bg-accent/8 border-l-2 border-l-accent pl-[38px]"
+          ? "bg-accent/8 border-l-2 border-l-accent pl-[14px]"
           : "hover:bg-surface-2/30",
         !isActive && "opacity-55",
       )}
     >
+      {/* Wrapper handles the click so we can read shiftKey and stop
+          propagation before the row-click navigation fires. */}
+      <span
+        className="flex size-4 shrink-0 items-center justify-center"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCheckboxClick(id, e);
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={() => {}}
+          aria-label={`select replicaset ${rs.name}`}
+          className="h-3.5 w-3.5 cursor-pointer accent-accent"
+        />
+      </span>
+
       {/* Status dot */}
       <div
         className={cn(
@@ -428,10 +504,14 @@ function StandaloneSection({
   rsList,
   selectedKey,
   onSelectRS,
+  isChecked,
+  onCheckboxClick,
 }: {
   rsList: ReplicaSet[];
   selectedKey: string | null;
   onSelectRS: (rs: ReplicaSet) => void;
+  isChecked: (rs: ReplicaSet) => boolean;
+  onCheckboxClick: (id: string, e: MouseEvent) => void;
 }) {
   return (
     <div className="border-b border-border/50">
@@ -449,6 +529,8 @@ function StandaloneSection({
           isActive={isActiveRS(rs)}
           isSelected={selectedKey === `${rs.namespace}/${rs.name}`}
           onClick={() => onSelectRS(rs)}
+          isChecked={isChecked(rs)}
+          onCheckboxClick={onCheckboxClick}
         />
       ))}
     </div>

--- a/web/src/pages/ReplicaSetsPage.tsx
+++ b/web/src/pages/ReplicaSetsPage.tsx
@@ -190,6 +190,7 @@ export function ReplicaSetsPage({ cluster }: { cluster: string }) {
         selection={selection}
         rows={filtered}
         rowKey={rsKey}
+        visibleIds={visibleIds}
         cluster={cluster}
         kindLabel="replicasets"
         fetchYaml={(rs, signal) => api.yaml(cluster, "replicasets", rs.namespace, rs.name, signal)}
@@ -455,6 +456,7 @@ function RSRow({
           checked={isChecked}
           onChange={() => {}}
           aria-label={`select replicaset ${rs.name}`}
+          tabIndex={-1}
           className="h-3.5 w-3.5 cursor-pointer accent-accent"
         />
       </span>

--- a/web/src/pages/SecretsPage.tsx
+++ b/web/src/pages/SecretsPage.tsx
@@ -149,7 +149,7 @@ export function SecretsPage({ cluster }: { cluster: string }) {
                 cluster,
                 kindLabel: "secrets",
                 fetchYaml: (s, signal) => api.yaml(cluster, "secrets", s.namespace, s.name, signal),
-                isSecret: () => true,
+                confirmReveal: () => true,
               }}
             />
           )


### PR DESCRIPTION
## Summary

Follow-up to #56. The original PR (commit `46d651d`) landed checkbox + multi-doc YAML download on every list page that used `DataTable`, but explicitly deferred two pages because they don't use the standard table primitive. This PR completes them:

- **`CustomResourcesPage.tsx`** — already a `DataTable<CustomResource>`, so this is just the `SelectableDataTable` swap. `fetchYaml` uses the existing `api.getCustomResourceYAML`. `kindLabel` falls back to the CRD's plural so downloads are auto-named e.g. `prod-eu-certificates-2026-05-04-5.yaml`. Cluster-scoped CRDs correctly pass `null` for namespace.
- **`ReplicaSetsPage.tsx`** — keeps the grouped renderer (deployment header → active RS row + dormant RS rows). `useTableSelection` is hoisted to the page, `BulkActionsToolbar` mounts above the grouped list, and `isChecked`/`onCheckboxClick` thread through `DeploymentGroup` and `StandaloneSection` into `RSRow`. `visibleIds` is computed in render order (active first, then dormant only when the group is expanded) so shift-click range-select honors what the operator actually sees, and the existing search-auto-expands behavior carries over.

Both pages reuse the existing 100-row cap, secret-confirm dialog (no-op here, neither kind is a Secret), strip-server-fields toggle, partial-failure handling, and abort/cancel from the toolbar — no new infrastructure, no backend changes.

**`CRDsPage.tsx` is intentionally out of scope** — it uses a card-grid grouped by API group, which is a different layout primitive and a separate design discussion (checkbox-on-cards vs. switching to a table vs. per-group "download all").

## Related issue / RFC

Follows up #56 (the original bulk-download PR). Same locked decisions apply: per-tab selection, SPA fan-out, 100-row cap, no audit on non-Secret bulk reads.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (user-visible API, config shape, or Helm values)
- [ ] Docs only
- [ ] Refactor / internal cleanup
- [ ] Test or CI only

## Surfaces touched

- [ ] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
- [ ] Helm values — see `deploy/helm/periscope/values.yaml` schema
- [ ] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [x] SPA / frontend
- [ ] Documentation
- [ ] None of the above

## How was this tested?

- `tsc -b` — clean
- `vitest run src/lib/multiYaml.test.ts` — 8/8 pass (existing tests still cover the bulk-fetch / multi-doc code path, which neither page changed)
- `eslint` — clean on both modified files

**Not yet verified in a browser** (headless dev environment): visual alignment of the new checkbox in `RSRow` against the deployment-header row, and the secret-confirm/cancel/progress UX feel on the grouped layout. Worth a manual smoke before merge:

- [ ] ReplicaSets: select an active RS → toolbar appears → Download YAML produces a multi-doc file with the right names
- [ ] ReplicaSets: expand a group with dormant revisions → shift-click range-selects across active + dormant
- [ ] ReplicaSets: collapsed groups exclude dormant rows from range-select (expected)
- [ ] CustomResources: open any CRD list (e.g. cert-manager `Certificates`) → bulk-download produces `<cluster>-<plural>-<date>-<n>.yaml`
- [ ] CustomResources: cluster-scoped CRD (e.g. `ClusterIssuer`) → no namespace in the fetch URL, file still names correctly

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests added or updated where it makes sense. (No new tests — existing `multiYaml.test.ts` covers the bulk pipeline; the new code is wiring only.)
- [ ] Docs updated (`docs/`, `README.md`, or `CHANGELOG.md` under `[Unreleased]`). — *Worth a one-liner under `[Unreleased]` noting RS+CR coverage; happy to add if desired.*
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.


Closes #24

Follow-up: #82 (audit asymmetry — bulk-download verb)
