### PR TITLE
Add comprehensive test coverage for apply resource handler

### DIFF
--- a/cmd/periscope/apply_handler_test.go
+++ b/cmd/periscope/apply_handler_test.go
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+	"github.com/gnana997/periscope/internal/k8s"
+)
+
+// recordingSink is the test-side implementation of audit.Sink — it
+// captures every Event the handler emits so tests can assert on
+// verb / outcome / resource shape without parsing slog output. Mirrors
+// the same name in internal/audit/emitter_test.go but kept private to
+// the handler tests since exporting it would couple two packages.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (r *recordingSink) Record(_ context.Context, evt audit.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, evt)
+}
+
+func (r *recordingSink) snapshot() []audit.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]audit.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// applyHandlerCall is a captured invocation of applyResourceFn — kept
+// so tests can assert the handler propagated dryRun/force/group/name
+// correctly to the apply layer.
+type applyHandlerCall struct {
+	args k8s.ApplyResourceArgs
+}
+
+// stubApplyFn replaces applyResourceFn for the test's duration with a
+// fake that records the args it was called with and returns the
+// supplied (result, err). Returns the captured-calls accessor.
+func stubApplyFn(t *testing.T, result k8s.ApplyResourceResult, err error) *[]applyHandlerCall {
+	t.Helper()
+	calls := []applyHandlerCall{}
+	mu := sync.Mutex{}
+	orig := applyResourceFn
+	applyResourceFn = func(_ context.Context, _ credentials.Provider, args k8s.ApplyResourceArgs) (k8s.ApplyResourceResult, error) {
+		mu.Lock()
+		calls = append(calls, applyHandlerCall{args: args})
+		mu.Unlock()
+		return result, err
+	}
+	t.Cleanup(func() { applyResourceFn = orig })
+	return &calls
+}
+
+// invokeApply drives the handler against a fully-formed PATCH request
+// for a Deployment in `default` namespace. Centralising the chi route
+// param injection + session attachment keeps each test focused on its
+// assertion. `query` is the raw query-string ("" for none).
+func invokeApply(t *testing.T, h func(http.ResponseWriter, *http.Request, credentials.Provider), reg *clusters.Registry, query, group, ns, name, body string) (*httptest.ResponseRecorder, *recordingSink) {
+	t.Helper()
+	url := "/api/clusters/test/resources/" + group + "/v1/deployments/" + ns + "/" + name
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodPatch, url, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/yaml")
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("cluster", "test")
+	rctx.URLParams.Add("group", group)
+	rctx.URLParams.Add("version", "v1")
+	rctx.URLParams.Add("resource", "deployments")
+	rctx.URLParams.Add("ns", ns)
+	rctx.URLParams.Add("name", name)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = credentials.WithSession(ctx, credentials.Session{Subject: "alice@example.com", Email: "alice@example.com"})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	sink := &recordingSink{}
+	emitter := audit.New(sink)
+	hh := applyResourceHandler(reg, emitter)
+	hh(rec, req, fakeProvider{actor: "alice"})
+	return rec, sink
+}
+
+// makeApplyResult constructs an ApplyResourceResult that matches the
+// kind/apiVersion of a Deployment so the handler's JSON encode path
+// gets a realistic body.
+func makeApplyResult(name, namespace string, dryRun bool) k8s.ApplyResourceResult {
+	return k8s.ApplyResourceResult{
+		DryRun: dryRun,
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{"replicas": int64(2)},
+		},
+	}
+}
+
+// minimalDeploymentYAML returns a body that satisfies the L1/L2 layers
+// — but since the handler tests stub k8s.ApplyResource, the body
+// content does not need to round-trip through the validation pipeline.
+// We still send a non-empty body so readApplyBody returns OK.
+func minimalDeploymentYAML(name, namespace string) string {
+	return "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: " + name +
+		"\n  namespace: " + namespace + "\nspec:\n  replicas: 2\n"
+}
+
+// TestApplyHandler_Create_AuditSuccess covers the create case the SPA's
+// new "Apply YAML" flow (#51) depends on: PATCH against a name that
+// doesn't exist yet should land 200 with one audit row marked
+// success and the resource ref correctly populated.
+func TestApplyHandler_Create_AuditSuccess(t *testing.T) {
+	reg := testRegistry(t)
+	calls := stubApplyFn(t, makeApplyResult("new-app", "default", false), nil)
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "new-app", minimalDeploymentYAML("new-app", "default"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := len(*calls); got != 1 {
+		t.Fatalf("applyResourceFn calls=%d, want 1", got)
+	}
+	args := (*calls)[0].args
+	if args.Group != "apps" || args.Version != "v1" || args.Resource != "deployments" {
+		t.Errorf("GVR mismatch: got %+v", args)
+	}
+	if args.Namespace != "default" || args.Name != "new-app" {
+		t.Errorf("ns/name mismatch: ns=%q name=%q", args.Namespace, args.Name)
+	}
+	if args.DryRun || args.Force {
+		t.Errorf("dryRun=%v force=%v, want both false", args.DryRun, args.Force)
+	}
+
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit events=%d, want 1", len(events))
+	}
+	e := events[0]
+	if e.Verb != audit.VerbApply {
+		t.Errorf("verb=%q, want %q", e.Verb, audit.VerbApply)
+	}
+	if e.Outcome != audit.OutcomeSuccess {
+		t.Errorf("outcome=%q, want success", e.Outcome)
+	}
+	if e.Cluster != "test" {
+		t.Errorf("cluster=%q, want test", e.Cluster)
+	}
+	if e.Resource.Group != "apps" || e.Resource.Version != "v1" || e.Resource.Resource != "deployments" {
+		t.Errorf("resource ref GVR=%+v", e.Resource)
+	}
+	if e.Resource.Namespace != "default" || e.Resource.Name != "new-app" {
+		t.Errorf("resource ref ns/name=%+v", e.Resource)
+	}
+	if e.Extra["dryRun"] != false {
+		t.Errorf("Extra[dryRun]=%v, want false", e.Extra["dryRun"])
+	}
+}
+
+// TestApplyHandler_Update_AuditSuccess is regression coverage for the
+// existing inline-editor edit path the apply endpoint already serves
+// — confirms the SSA-update audit row stays correct after we re-route
+// create through the same endpoint.
+func TestApplyHandler_Update_AuditSuccess(t *testing.T) {
+	reg := testRegistry(t)
+	stubApplyFn(t, makeApplyResult("existing", "prod", false), nil)
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "prod", "existing", minimalDeploymentYAML("existing", "prod"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Outcome != audit.OutcomeSuccess {
+		t.Fatalf("want one success event, got %+v", events)
+	}
+	// Decoded body should round-trip the apply result so the SPA can
+	// refresh its detail view with the new state.
+	var got k8s.ApplyResourceResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Object["kind"] != "Deployment" {
+		t.Errorf("response kind=%v, want Deployment", got.Object["kind"])
+	}
+}
+
+// TestApplyHandler_NamespaceNotFound_AuditFailure exercises the third
+// case from issue #52: applying into a namespace that doesn't exist
+// returns 404 from apiserver, the handler classifies as Failure (not
+// Denied — that's reserved for RBAC), and an audit row is still
+// emitted so the action is visible in the trail.
+func TestApplyHandler_NamespaceNotFound_AuditFailure(t *testing.T) {
+	reg := testRegistry(t)
+	apiErr := kerrors.NewNotFound(
+		schema.GroupResource{Resource: "namespaces"},
+		"ghost",
+	)
+	stubApplyFn(t, k8s.ApplyResourceResult{}, apiErr)
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "ghost", "orphan", minimalDeploymentYAML("orphan", "ghost"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit events=%d, want 1", len(events))
+	}
+	e := events[0]
+	if e.Outcome != audit.OutcomeFailure {
+		t.Errorf("outcome=%q, want failure", e.Outcome)
+	}
+	if e.Reason == "" {
+		t.Errorf("Reason empty, want apiserver error message")
+	}
+	if e.Resource.Namespace != "ghost" || e.Resource.Name != "orphan" {
+		t.Errorf("resource ref ns/name not preserved on failure: %+v", e.Resource)
+	}
+}
+
+// TestApplyHandler_Forbidden_AuditDenied confirms RBAC denials are
+// classified as Denied (not Failure) so operators can query them
+// distinctly. Important because the SPA's pre-flight can-i check is
+// best-effort — a true RBAC denial can still occur at apply time.
+func TestApplyHandler_Forbidden_AuditDenied(t *testing.T) {
+	reg := testRegistry(t)
+	apiErr := kerrors.NewForbidden(
+		schema.GroupResource{Group: "apps", Resource: "deployments"},
+		"locked",
+		errors.New("RBAC: forbidden"),
+	)
+	stubApplyFn(t, k8s.ApplyResourceResult{}, apiErr)
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "locked", minimalDeploymentYAML("locked", "default"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403", rec.Code)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Outcome != audit.OutcomeDenied {
+		t.Fatalf("want one denied event, got %+v", events)
+	}
+}
+
+// TestApplyHandler_DryRun_AuditWithFlag locks in the "dry-run still
+// emits an audit row" decision called out in issue #52 — Extra[dryRun]
+// flags it for downstream filters so the row remains queryable but
+// distinct from real applies.
+func TestApplyHandler_DryRun_AuditWithFlag(t *testing.T) {
+	reg := testRegistry(t)
+	calls := stubApplyFn(t, makeApplyResult("preview", "staging", true), nil)
+
+	rec, sink := invokeApply(t, nil, reg, "dryRun=true", "apps", "staging", "preview", minimalDeploymentYAML("preview", "staging"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := (*calls)[0].args.DryRun; !got {
+		t.Errorf("applyResourceFn args.DryRun=%v, want true (handler must propagate ?dryRun=true)", got)
+	}
+
+	var resp k8s.ApplyResourceResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.DryRun {
+		t.Errorf("response DryRun=%v, want true", resp.DryRun)
+	}
+
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit events=%d, want 1 (dry-run still emits)", len(events))
+	}
+	if events[0].Extra["dryRun"] != true {
+		t.Errorf("Extra[dryRun]=%v, want true", events[0].Extra["dryRun"])
+	}
+	if events[0].Outcome != audit.OutcomeSuccess {
+		t.Errorf("dry-run outcome=%q, want success", events[0].Outcome)
+	}
+}
+
+// TestApplyHandler_Force_PassedThrough confirms ?force=true reaches
+// k8s.ApplyResource so the SSA "force conflict resolution" path works
+// from the SPA's second-attempt flow.
+func TestApplyHandler_Force_PassedThrough(t *testing.T) {
+	reg := testRegistry(t)
+	calls := stubApplyFn(t, makeApplyResult("retry", "prod", false), nil)
+
+	rec, sink := invokeApply(t, nil, reg, "force=true", "apps", "prod", "retry", minimalDeploymentYAML("retry", "prod"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if got := (*calls)[0].args.Force; !got {
+		t.Errorf("args.Force=%v, want true", got)
+	}
+	if events := sink.snapshot(); events[0].Extra["force"] != true {
+		t.Errorf("Extra[force]=%v, want true", events[0].Extra["force"])
+	}
+}
+
+// TestApplyHandler_GroupCoreNormalized checks the URL contract from
+// docs/api.md §"apply": URL segment `core` is rewritten to the empty
+// API group server-side, both in the apply args and in the audit row.
+func TestApplyHandler_GroupCoreNormalized(t *testing.T) {
+	reg := testRegistry(t)
+	calls := stubApplyFn(t, k8s.ApplyResourceResult{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "cm", "namespace": "default"},
+		},
+	}, nil)
+
+	rec, sink := invokeApply(t, nil, reg, "", "core", "default", "cm", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: default\n")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := (*calls)[0].args.Group; got != "" {
+		t.Errorf("args.Group=%q, want empty (core normalized)", got)
+	}
+	if got := sink.snapshot()[0].Resource.Group; got != "" {
+		t.Errorf("audit Resource.Group=%q, want empty", got)
+	}
+}
+
+// TestApplyHandler_BadYAML_400 confirms the handler maps the stable
+// "apply: " error prefix from the validation pipeline (L1/L2) to a 400
+// rather than the default 500 — the SPA needs this distinction to
+// show "your YAML was malformed" instead of a generic backend error.
+func TestApplyHandler_BadYAML_400(t *testing.T) {
+	reg := testRegistry(t)
+	stubApplyFn(t, k8s.ApplyResourceResult{}, errors.New("apply: parse yaml: line 3: bad indent"))
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "x", "::not yaml::")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if events := sink.snapshot(); len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
+		t.Fatalf("want one failure event, got %+v", events)
+	}
+}
+
+// TestApplyHandler_Conflict_409 covers the SSA conflict path the SPA's
+// per-field conflict resolver depends on (docs/api.md §"apply").
+// The handler must surface 409 with a structured metav1.Status JSON
+// body whose causes[] array drives the resolver; failing to do so
+// breaks the second-attempt force flow tested above.
+func TestApplyHandler_Conflict_409(t *testing.T) {
+	reg := testRegistry(t)
+	conflictErr := kerrors.NewConflict(
+		schema.GroupResource{Group: "apps", Resource: "deployments"},
+		"contended",
+		errors.New("apply conflict: kustomize-controller owns spec.replicas"),
+	)
+	stubApplyFn(t, k8s.ApplyResourceResult{}, conflictErr)
+
+	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "contended", minimalDeploymentYAML("contended", "default"))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type=%q, want application/json (metav1.Status body)", ct)
+	}
+	// Decode as a metav1.Status and check the SPA-resolver-relevant
+	// shape: status="Failure", reason="Conflict", message present.
+	// Note kind/apiVersion are typically empty when client-go status
+	// errors are JSON-encoded directly (the apiserver populates them
+	// from the scheme; writeAPIError encodes the embedded ErrStatus
+	// as-is). We assert on fields the SPA resolver actually reads.
+	var status map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode metav1.Status: %v body=%s", err, rec.Body.String())
+	}
+	if status["status"] != "Failure" {
+		t.Errorf("body status=%v, want Failure", status["status"])
+	}
+	if status["reason"] != "Conflict" {
+		t.Errorf("body reason=%v, want Conflict", status["reason"])
+	}
+	if msg, _ := status["message"].(string); !strings.Contains(msg, "kustomize-controller") {
+		t.Errorf("body message=%q, want it to carry the conflict detail", msg)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
+		t.Fatalf("want one failure event for conflict, got %+v", events)
+	}
+}
+
+// TestApplyHandler_ClusterNotFound_404 confirms the cluster-routing
+// guard at the top of the handler short-circuits before the apply
+// path runs — and crucially does NOT emit an audit row, since no
+// privileged action was attempted against any real cluster.
+func TestApplyHandler_ClusterNotFound_404(t *testing.T) {
+	reg := testRegistry(t)
+	calls := stubApplyFn(t, k8s.ApplyResourceResult{}, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/clusters/missing/resources/apps/v1/deployments/default/x", bytes.NewBufferString(minimalDeploymentYAML("x", "default")))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("cluster", "missing")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	sink := &recordingSink{}
+	emitter := audit.New(sink)
+	hh := applyResourceHandler(reg, emitter)
+	hh(rec, req, fakeProvider{actor: "alice"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status=%d, want 404", rec.Code)
+	}
+	if got := len(*calls); got != 0 {
+		t.Errorf("applyResourceFn calls=%d, want 0 (handler should short-circuit)", got)
+	}
+	if got := len(sink.snapshot()); got != 0 {
+		t.Errorf("audit events=%d, want 0 (no action against real cluster)", got)
+	}
+}

--- a/cmd/periscope/apply_handler_test.go
+++ b/cmd/periscope/apply_handler_test.go
@@ -21,30 +21,6 @@ import (
 	"github.com/gnana997/periscope/internal/k8s"
 )
 
-// recordingSink is the test-side implementation of audit.Sink — it
-// captures every Event the handler emits so tests can assert on
-// verb / outcome / resource shape without parsing slog output. Mirrors
-// the same name in internal/audit/emitter_test.go but kept private to
-// the handler tests since exporting it would couple two packages.
-type recordingSink struct {
-	mu     sync.Mutex
-	events []audit.Event
-}
-
-func (r *recordingSink) Record(_ context.Context, evt audit.Event) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.events = append(r.events, evt)
-}
-
-func (r *recordingSink) snapshot() []audit.Event {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]audit.Event, len(r.events))
-	copy(out, r.events)
-	return out
-}
-
 // applyHandlerCall is a captured invocation of applyResourceFn — kept
 // so tests can assert the handler propagated dryRun/force/group/name
 // correctly to the apply layer.
@@ -70,36 +46,30 @@ func stubApplyFn(t *testing.T, result k8s.ApplyResourceResult, err error) *[]app
 	return &calls
 }
 
-// invokeApply drives the handler against a fully-formed PATCH request
-// for a Deployment in `default` namespace. Centralising the chi route
-// param injection + session attachment keeps each test focused on its
-// assertion. `query` is the raw query-string ("" for none).
-func invokeApply(t *testing.T, h func(http.ResponseWriter, *http.Request, credentials.Provider), reg *clusters.Registry, query, group, ns, name, body string) (*httptest.ResponseRecorder, *recordingSink) {
+// invokeApply drives applyResourceHandler against a fully-formed
+// PATCH request for a Deployment. Thin wrapper around the shared
+// invokeAuthenticated helper that just supplies the apply-specific
+// URL pattern + chi route params. `query` is the raw query-string
+// ("" for none).
+func invokeApply(t *testing.T, reg *clusters.Registry, query, group, ns, name, body string) (*httptest.ResponseRecorder, *recordingSink) {
 	t.Helper()
 	url := "/api/clusters/test/resources/" + group + "/v1/deployments/" + ns + "/" + name
 	if query != "" {
 		url += "?" + query
 	}
-	req := httptest.NewRequest(http.MethodPatch, url, bytes.NewBufferString(body))
-	req.Header.Set("Content-Type", "application/yaml")
-
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("cluster", "test")
-	rctx.URLParams.Add("group", group)
-	rctx.URLParams.Add("version", "v1")
-	rctx.URLParams.Add("resource", "deployments")
-	rctx.URLParams.Add("ns", ns)
-	rctx.URLParams.Add("name", name)
-	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-	ctx = credentials.WithSession(ctx, credentials.Session{Subject: "alice@example.com", Email: "alice@example.com"})
-	req = req.WithContext(ctx)
-
-	rec := httptest.NewRecorder()
-	sink := &recordingSink{}
-	emitter := audit.New(sink)
-	hh := applyResourceHandler(reg, emitter)
-	hh(rec, req, fakeProvider{actor: "alice"})
-	return rec, sink
+	return invokeAuthenticated(t,
+		func(e *audit.Emitter) credentials.Handler { return applyResourceHandler(reg, e) },
+		http.MethodPatch, url,
+		map[string]string{
+			"cluster":  "test",
+			"group":    group,
+			"version":  "v1",
+			"resource": "deployments",
+			"ns":       ns,
+			"name":     name,
+		},
+		[]byte(body),
+	)
 }
 
 // makeApplyResult constructs an ApplyResourceResult that matches the
@@ -137,7 +107,7 @@ func TestApplyHandler_Create_AuditSuccess(t *testing.T) {
 	reg := testRegistry(t)
 	calls := stubApplyFn(t, makeApplyResult("new-app", "default", false), nil)
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "new-app", minimalDeploymentYAML("new-app", "default"))
+	rec, sink := invokeApply(t, reg, "", "apps", "default", "new-app", minimalDeploymentYAML("new-app", "default"))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -188,7 +158,7 @@ func TestApplyHandler_Update_AuditSuccess(t *testing.T) {
 	reg := testRegistry(t)
 	stubApplyFn(t, makeApplyResult("existing", "prod", false), nil)
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "prod", "existing", minimalDeploymentYAML("existing", "prod"))
+	rec, sink := invokeApply(t, reg, "", "apps", "prod", "existing", minimalDeploymentYAML("existing", "prod"))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -220,7 +190,7 @@ func TestApplyHandler_NamespaceNotFound_AuditFailure(t *testing.T) {
 	)
 	stubApplyFn(t, k8s.ApplyResourceResult{}, apiErr)
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "ghost", "orphan", minimalDeploymentYAML("orphan", "ghost"))
+	rec, sink := invokeApply(t, reg, "", "apps", "ghost", "orphan", minimalDeploymentYAML("orphan", "ghost"))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
 	}
@@ -253,7 +223,7 @@ func TestApplyHandler_Forbidden_AuditDenied(t *testing.T) {
 	)
 	stubApplyFn(t, k8s.ApplyResourceResult{}, apiErr)
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "locked", minimalDeploymentYAML("locked", "default"))
+	rec, sink := invokeApply(t, reg, "", "apps", "default", "locked", minimalDeploymentYAML("locked", "default"))
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status=%d, want 403", rec.Code)
 	}
@@ -271,7 +241,7 @@ func TestApplyHandler_DryRun_AuditWithFlag(t *testing.T) {
 	reg := testRegistry(t)
 	calls := stubApplyFn(t, makeApplyResult("preview", "staging", true), nil)
 
-	rec, sink := invokeApply(t, nil, reg, "dryRun=true", "apps", "staging", "preview", minimalDeploymentYAML("preview", "staging"))
+	rec, sink := invokeApply(t, reg, "dryRun=true", "apps", "staging", "preview", minimalDeploymentYAML("preview", "staging"))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -306,7 +276,7 @@ func TestApplyHandler_Force_PassedThrough(t *testing.T) {
 	reg := testRegistry(t)
 	calls := stubApplyFn(t, makeApplyResult("retry", "prod", false), nil)
 
-	rec, sink := invokeApply(t, nil, reg, "force=true", "apps", "prod", "retry", minimalDeploymentYAML("retry", "prod"))
+	rec, sink := invokeApply(t, reg, "force=true", "apps", "prod", "retry", minimalDeploymentYAML("retry", "prod"))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d", rec.Code)
 	}
@@ -331,7 +301,7 @@ func TestApplyHandler_GroupCoreNormalized(t *testing.T) {
 		},
 	}, nil)
 
-	rec, sink := invokeApply(t, nil, reg, "", "core", "default", "cm", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: default\n")
+	rec, sink := invokeApply(t, reg, "", "core", "default", "cm", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: default\n")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -351,7 +321,7 @@ func TestApplyHandler_BadYAML_400(t *testing.T) {
 	reg := testRegistry(t)
 	stubApplyFn(t, k8s.ApplyResourceResult{}, errors.New("apply: parse yaml: line 3: bad indent"))
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "x", "::not yaml::")
+	rec, sink := invokeApply(t, reg, "", "apps", "default", "x", "::not yaml::")
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
 	}
@@ -374,7 +344,7 @@ func TestApplyHandler_Conflict_409(t *testing.T) {
 	)
 	stubApplyFn(t, k8s.ApplyResourceResult{}, conflictErr)
 
-	rec, sink := invokeApply(t, nil, reg, "", "apps", "default", "contended", minimalDeploymentYAML("contended", "default"))
+	rec, sink := invokeApply(t, reg, "", "apps", "default", "contended", minimalDeploymentYAML("contended", "default"))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status=%d, want 409", rec.Code)
 	}

--- a/cmd/periscope/audit_test_helpers_test.go
+++ b/cmd/periscope/audit_test_helpers_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// Shared test scaffolding for credentials-wrapped HTTP handlers in
+// this package. Two pieces:
+//
+//   1. recordingSink — an audit.Sink that captures every Event the
+//      handler emits, so assertions can hit verb / outcome / resource
+//      / extra without parsing slog output.
+//   2. invokeAuthenticated — boilerplate-eliminator that builds the
+//      httptest request, plants chi RouteContext +
+//      credentials.Session, runs the handler, and returns the
+//      response + the recording sink for assertions.
+//
+// Both lived inline in apply_handler_test.go and
+// bulk_download_audit_handler_test.go before this file. Consolidating
+// them here keeps every audit-emitting handler test on a single
+// scaffolding so future handlers (helm rollback, workload rollback,
+// etc.) land cleanly without copy-pasting another sink declaration
+// or re-deriving the request-construction plumbing.
+
+// ── recordingSink ────────────────────────────────────────────────────
+
+// recordingSink captures every audit.Event the handler emits.
+// Concurrency-safe so handlers that emit from goroutines (none today,
+// but future handlers might) don't trip the race detector.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (r *recordingSink) Record(_ context.Context, evt audit.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, evt)
+}
+
+// snapshot returns a copy of the captured events so tests can iterate
+// without holding the lock — and so subsequent emissions don't mutate
+// the slice the test is asserting against.
+func (r *recordingSink) snapshot() []audit.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]audit.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// ── invokeAuthenticated ──────────────────────────────────────────────
+
+// defaultTestSession is the session every handler test gets unless it
+// builds its own request. Tests that need a different actor should
+// build the request directly rather than extending this helper.
+var defaultTestSession = credentials.Session{
+	Subject: "alice@example.com",
+	Email:   "alice@example.com",
+}
+
+// defaultTestProvider is the credentials.Provider passed to the
+// handler. Reuses the package-level fakeProvider (cani_handler_test.go).
+func defaultTestProvider() credentials.Provider {
+	return fakeProvider{actor: "alice@example.com"}
+}
+
+// invokeAuthenticated drives a credentials-wrapped handler against a
+// fully-formed HTTP request and returns the response + the recording
+// sink the handler emitted into.
+//
+// The makeHandler callback is given a pre-built audit.Emitter wired to
+// the sink — the helper owns both ends of the audit pipe so callers
+// don't have to re-derive that wiring per test.
+//
+// Parameters:
+//   - makeHandler — receives the test's emitter and returns the
+//                   handler under test (typical shape:
+//                   `func(e *audit.Emitter) credentials.Handler {
+//                     return myHandler(reg, e) }`).
+//   - method, url — HTTP request method + path.
+//   - routeParams — chi.URLParam lookups; pass nil for handlers that
+//                   don't read any.
+//   - body        — request body. Pass nil for GET-style calls.
+//
+// Session + provider default to defaultTestSession /
+// defaultTestProvider; tests that need a different identity should
+// build their own request rather than extending this signature.
+func invokeAuthenticated(
+	t *testing.T,
+	makeHandler func(*audit.Emitter) credentials.Handler,
+	method, url string,
+	routeParams map[string]string,
+	body []byte,
+) (*httptest.ResponseRecorder, *recordingSink) {
+	t.Helper()
+
+	sink := &recordingSink{}
+	h := makeHandler(audit.New(sink))
+
+	var reqBody io.Reader = http.NoBody
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, url, reqBody)
+
+	rctx := chi.NewRouteContext()
+	for k, v := range routeParams {
+		rctx.URLParams.Add(k, v)
+	}
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = credentials.WithSession(ctx, defaultTestSession)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	h(rec, req, defaultTestProvider())
+	return rec, sink
+}

--- a/cmd/periscope/bulk_download_audit_handler_test.go
+++ b/cmd/periscope/bulk_download_audit_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -26,25 +25,6 @@ import (
 //
 // fakeProvider is shared with cani_handler_test.go (same package).
 
-// recordSink captures audit events for assertion.
-type recordSink struct {
-	mu     sync.Mutex
-	events []audit.Event
-}
-
-func (r *recordSink) Record(_ context.Context, evt audit.Event) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.events = append(r.events, evt)
-}
-
-func (r *recordSink) snapshot() []audit.Event {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	cp := make([]audit.Event, len(r.events))
-	copy(cp, r.events)
-	return cp
-}
 
 // bulkDownloadRegistry writes a one-cluster YAML to a temp dir and
 // loads it. Mirrors how production boots; saves us from exposing a
@@ -68,7 +48,7 @@ func bulkDownloadRegistry(t *testing.T, clusterName string) *clusters.Registry {
 
 // invokeBulkDownload posts the body to the handler with a planted
 // session in the context and the {cluster} chi URL param wired in.
-func invokeBulkDownload(t *testing.T, reg *clusters.Registry, sink *recordSink, cluster string, body []byte) *httptest.ResponseRecorder {
+func invokeBulkDownload(t *testing.T, reg *clusters.Registry, sink *recordingSink, cluster string, body []byte) *httptest.ResponseRecorder {
 	t.Helper()
 	emitter := audit.New(sink)
 	h := bulkDownloadAuditHandler(reg, emitter)
@@ -90,7 +70,7 @@ func invokeBulkDownload(t *testing.T, reg *clusters.Registry, sink *recordSink, 
 
 func TestBulkDownloadAudit_Success(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "prod-eu")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 
 	body := mustJSONBulk(t, map[string]any{
 		"kind":          "configmaps",
@@ -137,7 +117,7 @@ func TestBulkDownloadAudit_Success(t *testing.T) {
 
 func TestBulkDownloadAudit_PartialIsSuccess(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{
 		"kind": "pods", "count": 10,
 		"ids":     []string{"ns/p1"},
@@ -157,7 +137,7 @@ func TestBulkDownloadAudit_PartialIsSuccess(t *testing.T) {
 
 func TestBulkDownloadAudit_Failure(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{
 		"kind": "pods", "count": 5, "outcome": "failure", "failure_count": 5,
 	})
@@ -172,7 +152,7 @@ func TestBulkDownloadAudit_Failure(t *testing.T) {
 
 func TestBulkDownloadAudit_ClusterNotFound(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{"kind": "pods", "count": 1, "outcome": "success"})
 	rec := invokeBulkDownload(t, reg, sink, "nope", body)
 	if rec.Code != http.StatusNotFound {
@@ -185,7 +165,7 @@ func TestBulkDownloadAudit_ClusterNotFound(t *testing.T) {
 
 func TestBulkDownloadAudit_MalformedBody(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	rec := invokeBulkDownload(t, reg, sink, "c1", []byte("not json"))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
@@ -197,7 +177,7 @@ func TestBulkDownloadAudit_MalformedBody(t *testing.T) {
 
 func TestBulkDownloadAudit_UnknownKind(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{"kind": "bogusresource", "count": 1, "outcome": "success"})
 	rec := invokeBulkDownload(t, reg, sink, "c1", body)
 	if rec.Code != http.StatusBadRequest {
@@ -212,7 +192,7 @@ func TestBulkDownloadAudit_KnownKinds(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
 	for _, kind := range []string{"pods", "configmaps", "secrets", "customresources/certificates"} {
 		t.Run(kind, func(t *testing.T) {
-			sink := &recordSink{}
+			sink := &recordingSink{}
 			body := mustJSONBulk(t, map[string]any{
 				"kind": kind, "count": 1, "outcome": "success",
 			})
@@ -226,7 +206,7 @@ func TestBulkDownloadAudit_KnownKinds(t *testing.T) {
 
 func TestBulkDownloadAudit_CountOverCap(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{
 		"kind": "pods", "count": bulkDownloadCap + 1, "outcome": "success",
 	})
@@ -238,7 +218,7 @@ func TestBulkDownloadAudit_CountOverCap(t *testing.T) {
 
 func TestBulkDownloadAudit_CountZero(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	body := mustJSONBulk(t, map[string]any{"kind": "pods", "count": 0, "outcome": "success"})
 	rec := invokeBulkDownload(t, reg, sink, "c1", body)
 	if rec.Code != http.StatusBadRequest {
@@ -248,7 +228,7 @@ func TestBulkDownloadAudit_CountZero(t *testing.T) {
 
 func TestBulkDownloadAudit_IDsTruncatedServerSide(t *testing.T) {
 	reg := bulkDownloadRegistry(t, "c1")
-	sink := &recordSink{}
+	sink := &recordingSink{}
 	ids := make([]string, bulkDownloadIDCap+10)
 	for i := range ids {
 		ids[i] = "ns/r-" + strings.Repeat("x", 3)

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -1294,6 +1294,11 @@ func eventsHandler(reg *clusters.Registry, kind string) credentials.Handler {
 	}
 }
 
+// applyResourceFn is the indirection the handler dispatches through so
+// tests can stub the apply path without spinning up a fake dynamic
+// client. Mirrors caniCheckSARFn / caniListSSRRFn in cani_handler.go.
+var applyResourceFn = k8s.ApplyResource
+
 // applyResourceHandler is the HTTP front-end of k8s.ApplyResource. It
 // reads the YAML body, dispatches to the dynamic client under the
 // caller's impersonated identity, and returns the post-apply state as
@@ -1348,7 +1353,7 @@ func applyResourceHandler(reg *clusters.Registry, auditer *audit.Emitter) creden
 				"force":  args.Force,
 			},
 		}
-		result, err := k8s.ApplyResource(r.Context(), p, args)
+		result, err := applyResourceFn(r.Context(), p, args)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return

--- a/docs/api.md
+++ b/docs/api.md
@@ -571,6 +571,15 @@ conflict info — the SPA uses this for the conflict resolver.
 `group=core` is rewritten to the empty string server-side so
 core-API resources can use the same URL pattern.
 
+The pattern handles **create and update transparently**:
+Server-Side Apply against a name that does not yet exist
+creates the resource; against an existing name it updates per
+field-manager semantics. The SPA's "Apply YAML" flow reuses
+this endpoint for both cases — there is no separate `/create`
+route. `dryRun=true` still emits an audit row with
+`extra.dryRun=true` so the action is visible in the trail
+while remaining filterable from real applies.
+
 ### Pattern: delete
 
 ```

--- a/internal/k8s/apply.go
+++ b/internal/k8s/apply.go
@@ -101,6 +101,22 @@ var disallowedMetadataPaths = []string{
 	"selfLink",
 }
 
+// newDynamicClientForApply is swapped out by tests for a fake dynamic
+// client. Production path: build a rest.Config via buildRestConfig
+// (shared with meta.go) and a dynamic.Interface. Mirrors
+// newDynamicClientForMeta so apply has the same testability shape.
+var newDynamicClientForApply = func(ctx context.Context, p credentials.Provider, c clusters.Cluster) (dynamic.Interface, error) {
+	cfg, err := buildRestConfig(ctx, p, c)
+	if err != nil {
+		return nil, err
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("apply: build dynamic client: %w", err)
+	}
+	return dyn, nil
+}
+
 // ApplyResource performs the validation pipeline + dynamic-client SSA.
 // All errors are wrapped with a stable prefix the handler can use to
 // classify (apiserver errors flow through unwrapped so kerrors.IsXxx
@@ -128,13 +144,9 @@ func ApplyResource(ctx context.Context, p credentials.Provider, args ApplyResour
 	stripDisallowedMetadata(obj)
 
 	// --- build dynamic client ------------------------------------------
-	cfg, err := buildRestConfig(ctx, p, args.Cluster)
+	dyn, err := newDynamicClientForApply(ctx, p, args.Cluster)
 	if err != nil {
 		return ApplyResourceResult{}, err
-	}
-	dyn, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return ApplyResourceResult{}, fmt.Errorf("apply: build dynamic client: %w", err)
 	}
 	gvr := schema.GroupVersionResource{
 		Group:    args.Group,

--- a/internal/k8s/apply_test.go
+++ b/internal/k8s/apply_test.go
@@ -1,0 +1,301 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// applyDeploymentBody is a minimal valid Deployment YAML used as the
+// SSA payload for ApplyResource tests. Name/namespace are filled in
+// via fmt to keep each test self-describing.
+const applyDeploymentBody = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27
+`
+
+// deploymentGVR is the dynamic-client GVR for apps/v1 Deployments,
+// shared across the apply-pipeline test cases.
+var deploymentGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+// applyTestCluster is a stable Cluster value the swap-point reactor
+// can ignore — all test cases route through the fake dynamic client.
+var applyTestCluster = clusters.Cluster{Name: "test"}
+
+// fakeDynamicWithApplyReactor builds a fake dynamic client wired with a
+// PATCH reactor that simulates Server-Side Apply create-or-update
+// semantics. client-go's stock fake client returns "PatchType not
+// supported" for ApplyPatchType (kubernetes/client-go#1323), so the
+// reactor is required for any SSA path. The reactor:
+//
+//   - Returns bodyOverride if non-nil (used for e.g. Conflict / NotFound
+//     simulations).
+//   - Inspects the apply body, looks up the GVR + namespace + name in
+//     the tracker, and dispatches to Update if present, Create if not.
+//   - Honors patchOpts.DryRun by returning the would-be object without
+//     persisting to the tracker.
+//
+// All four Tier-2 audit cases the test exercises (create, update,
+// dry-run, namespace-not-found) flow through this single reactor so
+// the fake stays close to how the real apiserver routes the patch.
+func fakeDynamicWithApplyReactor(t *testing.T, errOverride error, seed ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		deploymentGVR: "DeploymentList",
+	}
+	fake := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+
+	fake.PrependReactor("patch", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if errOverride != nil {
+			return true, nil, errOverride
+		}
+		// Concrete PatchActionImpl carries PatchOptions (incl. DryRun /
+		// FieldManager / Force); the PatchAction interface alone does
+		// not. Use the concrete type so the reactor can mirror
+		// apiserver dry-run semantics.
+		patchAction, ok := action.(ktesting.PatchActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(patchAction.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		// Dry-run: return what we would have written, don't touch the
+		// tracker. Mirrors the apiserver's `?dryRun=All` semantics.
+		if hasDryRunAll(patchAction.GetPatchOptions().DryRun) {
+			return true, obj, nil
+		}
+		// Look up by name in the tracker; create-or-update.
+		ns := patchAction.GetNamespace()
+		existing, err := fake.Tracker().Get(deploymentGVR, ns, patchAction.GetName())
+		if err != nil || existing == nil {
+			if err := fake.Tracker().Create(deploymentGVR, obj, ns); err != nil {
+				return true, nil, err
+			}
+			return true, obj, nil
+		}
+		if err := fake.Tracker().Update(deploymentGVR, obj, ns); err != nil {
+			return true, nil, err
+		}
+		return true, obj, nil
+	})
+	return fake
+}
+
+// hasDryRunAll reports whether the patch options requested an
+// apiserver-side dry-run.
+func hasDryRunAll(dr []string) bool {
+	for _, v := range dr {
+		if v == metav1.DryRunAll {
+			return true
+		}
+	}
+	return false
+}
+
+// installFakeDynamicClient swaps newDynamicClientForApply for the
+// duration of the test. Restores the original on cleanup.
+func installFakeDynamicClient(t *testing.T, fake dynamic.Interface) {
+	t.Helper()
+	orig := newDynamicClientForApply
+	newDynamicClientForApply = func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (dynamic.Interface, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newDynamicClientForApply = orig })
+}
+
+// applyArgs builds an ApplyResourceArgs for a Deployment matching the
+// body produced by deploymentBody(name, namespace). Centralising this
+// keeps the URL-vs-body identity consistent across cases.
+func applyArgs(name, namespace string, dryRun bool) ApplyResourceArgs {
+	return ApplyResourceArgs{
+		Cluster:   applyTestCluster,
+		Group:     "apps",
+		Version:   "v1",
+		Resource:  "deployments",
+		Namespace: namespace,
+		Name:      name,
+		Body:      deploymentBody(name, namespace),
+		DryRun:    dryRun,
+	}
+}
+
+func deploymentBody(name, namespace string) []byte {
+	return []byte(fmt.Sprintf(applyDeploymentBody, name, namespace))
+}
+
+func TestApplyResource_CreatesNewObject(t *testing.T) {
+	fake := fakeDynamicWithApplyReactor(t, nil)
+	installFakeDynamicClient(t, fake)
+
+	got, err := ApplyResource(context.Background(), stubProvider{}, applyArgs("new-app", "prod", false))
+	if err != nil {
+		t.Fatalf("ApplyResource: %v", err)
+	}
+	if got.DryRun {
+		t.Errorf("DryRun = true, want false on real apply")
+	}
+	if got.Object["kind"] != "Deployment" {
+		t.Errorf("returned kind = %v, want Deployment", got.Object["kind"])
+	}
+	// Tracker should now hold the created object — proves SSA-create
+	// reached the apiserver-equivalent.
+	if _, err := fake.Tracker().Get(deploymentGVR, "prod", "new-app"); err != nil {
+		t.Fatalf("expected tracker to contain created object, got: %v", err)
+	}
+}
+
+func TestApplyResource_UpdatesExisting(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "existing-app",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(1)},
+		},
+	}
+	fake := fakeDynamicWithApplyReactor(t, nil, existing)
+	installFakeDynamicClient(t, fake)
+
+	got, err := ApplyResource(context.Background(), stubProvider{}, applyArgs("existing-app", "prod", false))
+	if err != nil {
+		t.Fatalf("ApplyResource: %v", err)
+	}
+	// Body has replicas=2; reactor's Update should have replaced the
+	// tracker entry.
+	stored, err := fake.Tracker().Get(deploymentGVR, "prod", "existing-app")
+	if err != nil {
+		t.Fatalf("tracker Get: %v", err)
+	}
+	u := stored.(*unstructured.Unstructured)
+	if reps, _, _ := unstructured.NestedInt64(u.Object, "spec", "replicas"); reps != 2 {
+		t.Errorf("post-update replicas = %d, want 2", reps)
+	}
+	if got.DryRun {
+		t.Errorf("DryRun unexpectedly true")
+	}
+}
+
+func TestApplyResource_DryRunDoesNotPersist(t *testing.T) {
+	fake := fakeDynamicWithApplyReactor(t, nil)
+	installFakeDynamicClient(t, fake)
+
+	got, err := ApplyResource(context.Background(), stubProvider{}, applyArgs("preview-app", "staging", true))
+	if err != nil {
+		t.Fatalf("ApplyResource: %v", err)
+	}
+	if !got.DryRun {
+		t.Errorf("DryRun = false, want true")
+	}
+	if got.Object["kind"] != "Deployment" {
+		t.Errorf("returned kind = %v, want Deployment", got.Object["kind"])
+	}
+	// Critical: dry-run must not mutate the tracker.
+	if _, err := fake.Tracker().Get(deploymentGVR, "staging", "preview-app"); !kerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound after dry-run, got err=%v", err)
+	}
+}
+
+func TestApplyResource_NamespaceNotFoundPropagatesUnwrapped(t *testing.T) {
+	// Simulate the apiserver's reply when applying into a namespace that
+	// doesn't exist. The handler's httpStatusFor relies on
+	// kerrors.IsNotFound matching, so we assert the wrapped status type
+	// is preserved end-to-end.
+	nsErr := kerrors.NewNotFound(
+		schema.GroupResource{Resource: "namespaces"},
+		"ghost",
+	)
+	fake := fakeDynamicWithApplyReactor(t, nsErr)
+	installFakeDynamicClient(t, fake)
+
+	_, err := ApplyResource(context.Background(), stubProvider{}, applyArgs("orphan", "ghost", false))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !kerrors.IsNotFound(err) {
+		t.Errorf("kerrors.IsNotFound = false, want true; err=%v", err)
+	}
+}
+
+func TestApplyResource_ConflictPropagatesUnwrapped(t *testing.T) {
+	// SSA conflicts return 409 with details.causes[] driving the SPA's
+	// per-field conflict resolver (docs/api.md §"apply" pattern). The
+	// handler depends on kerrors.IsConflict matching.
+	conflictErr := kerrors.NewConflict(
+		schema.GroupResource{Group: "apps", Resource: "deployments"},
+		"contended",
+		errors.New("apply conflict: field-manager kustomize-controller owns spec.replicas"),
+	)
+	fake := fakeDynamicWithApplyReactor(t, conflictErr)
+	installFakeDynamicClient(t, fake)
+
+	_, err := ApplyResource(context.Background(), stubProvider{}, applyArgs("contended", "prod", false))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !kerrors.IsConflict(err) {
+		t.Errorf("kerrors.IsConflict = false, want true; err=%v", err)
+	}
+}
+
+func TestApplyResource_RejectsIdentityMismatch(t *testing.T) {
+	// L2: body name doesn't match URL name. Must error before the
+	// dynamic client is touched, so the install step is intentionally
+	// omitted — if the validation regresses, the call would dial out.
+	args := applyArgs("url-name", "prod", false)
+	args.Body = deploymentBody("body-name", "prod")
+	_, err := ApplyResource(context.Background(), stubProvider{}, args)
+	if err == nil {
+		t.Fatal("expected identity-mismatch error, got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "apply: ") {
+		t.Errorf("error %q missing stable 'apply: ' prefix the handler maps to 400", err.Error())
+	}
+}
+
+func TestApplyResource_EmptyBodyRejected(t *testing.T) {
+	args := applyArgs("x", "prod", false)
+	args.Body = nil
+	_, err := ApplyResource(context.Background(), stubProvider{}, args)
+	if err == nil || !strings.HasPrefix(err.Error(), "apply: ") {
+		t.Fatalf("expected 'apply: ' prefixed error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds extensive test coverage for the apply resource handler and the underlying `ApplyResource` function. The changes include 436 lines of handler tests covering create/update flows, error cases, audit emission, and query parameter handling, plus 301 lines of integration tests for the k8s apply pipeline. These tests validate the handler's HTTP contract, audit trail generation, and error classification (400 for validation errors, 409 for conflicts, 403 for RBAC denials, 404 for missing resources).

## Related issue / RFC

Relates to issue #51 (SPA "Apply YAML" flow) and #52 (audit trail for apply operations).

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (user-visible API, config shape, or Helm values)
- [ ] Docs only
- [x] Refactor / internal cleanup
- [x] Test or CI only

## Surfaces touched

- [x] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
- [x] Audit / RBAC
- [x] Documentation

## How was this tested?

Added comprehensive test suite:

**Handler tests** (`cmd/periscope/apply_handler_test.go`):
- `TestApplyHandler_Create_AuditSuccess`: Validates create flow emits correct audit row with resource ref
- `TestApplyHandler_Update_AuditSuccess`: Regression test for existing update path
- `TestApplyHandler_NamespaceNotFound_AuditFailure`: 404 errors classified as Failure, audit row still emitted
- `TestApplyHandler_Forbidden_AuditDenied`: RBAC denials classified as Denied (not Failure)
- `TestApplyHandler_DryRun_AuditWithFlag`: Dry-run emits audit row with dryRun flag
- `TestApplyHandler_Force_PassedThrough`: Force flag propagates to apply layer
- `TestApplyHandler_GroupCoreNormalized`: Core API group rewritten to empty string
- `TestApplyHandler_BadYAML_400`: Validation errors map to 400 status
- `TestApplyHandler_Conflict_409`: SSA conflicts return 409 with metav1.Status body
- `TestApplyHandler_ClusterNotFound_404`: Missing cluster short-circuits without audit emission

**Apply pipeline tests** (`internal/k8s/apply_test.go`):
- `TestApplyResource_CreatesNewObject`: SSA creates new resources
- `TestApplyResource_UpdatesExisting`: SSA updates existing resources
- `TestApplyResource_DryRunDoesNotPersist`: Dry-run returns object without persisting
- `TestApplyResource_NamespaceNotFoundPropagatesUnwrapped`: NotFound errors preserved
- `TestApplyResource_ConflictPropagatesUnwrapped`: Conflict errors preserved for handler
- `TestApplyResource_RejectsIdentityMismatch`: L2 validation catches name mismatches
- `TestApplyResource_EmptyBodyRejected`: Empty body rejected with stable error prefix

Tests use a fake dynamic client with a custom PATCH reactor that mirrors apiserver SSA semantics (create-or-update, dry-run isolation, error propagation).

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests added or updated where it makes sense.
- [x] Docs updated (`docs/api.md` clarified create/update transparency).
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.

https://claude.ai/code/session_01BT5qxa3vJNb9t5DXnjHbqy