### PR TITLE
feat(audit): emit single bulk_download row per bulk YAML download (#82)

### DIFF
--- a/cmd/periscope/bulk_download_audit_handler_test.go
+++ b/cmd/periscope/bulk_download_audit_handler_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// Tests for bulkDownloadAuditHandler — the SPA-driven audit emission
+// that records "alice bulk-downloaded N {kind} from cluster X" as a
+// single structured row per download. See RFC 0003 §4 (`bulk_download`
+// verb) and the issue tracker (#82) for design rationale.
+//
+// fakeProvider is shared with cani_handler_test.go (same package).
+
+// recordSink captures audit events for assertion.
+type recordSink struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (r *recordSink) Record(_ context.Context, evt audit.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, evt)
+}
+
+func (r *recordSink) snapshot() []audit.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]audit.Event, len(r.events))
+	copy(cp, r.events)
+	return cp
+}
+
+// bulkDownloadRegistry writes a one-cluster YAML to a temp dir and
+// loads it. Mirrors how production boots; saves us from exposing a
+// programmatic Registry constructor for tests.
+func bulkDownloadRegistry(t *testing.T, clusterName string) *clusters.Registry {
+	t.Helper()
+	dir := t.TempDir()
+	yaml := "clusters:\n" +
+		"  - name: " + clusterName + "\n" +
+		"    backend: in-cluster\n"
+	path := filepath.Join(dir, "registry.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	reg, err := clusters.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	return reg
+}
+
+// invokeBulkDownload posts the body to the handler with a planted
+// session in the context and the {cluster} chi URL param wired in.
+func invokeBulkDownload(t *testing.T, reg *clusters.Registry, sink *recordSink, cluster string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	emitter := audit.New(sink)
+	h := bulkDownloadAuditHandler(reg, emitter)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/clusters/"+cluster+"/audit/bulk-download",
+		bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("cluster", cluster)
+	req = req.WithContext(credentials.WithSession(
+		context.WithValue(req.Context(), chi.RouteCtxKey, rctx),
+		credentials.Session{Subject: "alice@corp", Email: "alice@corp", Groups: []string{"eng"}},
+	))
+
+	rec := httptest.NewRecorder()
+	h(rec, req, fakeProvider{actor: "alice@corp"})
+	return rec
+}
+
+func TestBulkDownloadAudit_Success(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "prod-eu")
+	sink := &recordSink{}
+
+	body := mustJSONBulk(t, map[string]any{
+		"kind":          "configmaps",
+		"count":         42,
+		"ids":           []string{"default/cm-a", "default/cm-b", "default/cm-c"},
+		"outcome":       "success",
+		"failure_count": 0,
+	})
+	rec := invokeBulkDownload(t, reg, sink, "prod-eu", body)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rec.Code, rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	e := events[0]
+	if e.Verb != audit.VerbBulkDownload {
+		t.Errorf("verb = %q, want %q", e.Verb, audit.VerbBulkDownload)
+	}
+	if e.Outcome != audit.OutcomeSuccess {
+		t.Errorf("outcome = %q, want success", e.Outcome)
+	}
+	if e.Cluster != "prod-eu" {
+		t.Errorf("cluster = %q, want prod-eu", e.Cluster)
+	}
+	if e.Actor.Sub != "alice@corp" {
+		t.Errorf("actor.sub = %q, want alice@corp", e.Actor.Sub)
+	}
+	if e.Resource.Resource != "configmaps" || e.Resource.Namespace != "*" {
+		t.Errorf("resource = %+v, want {Resource:configmaps Namespace:*}", e.Resource)
+	}
+	if got := e.Extra["kind"]; got != "configmaps" {
+		t.Errorf("extra.kind = %v, want configmaps", got)
+	}
+	if got := e.Extra["count"]; got != 42 {
+		t.Errorf("extra.count = %v, want 42", got)
+	}
+	if got := e.Extra["failure_count"]; got != 0 {
+		t.Errorf("extra.failure_count = %v, want 0", got)
+	}
+}
+
+func TestBulkDownloadAudit_PartialIsSuccess(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{
+		"kind": "pods", "count": 10,
+		"ids":     []string{"ns/p1"},
+		"outcome": "success", "failure_count": 3,
+	})
+	if rec := invokeBulkDownload(t, reg, sink, "c1", body); rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	e := sink.snapshot()[0]
+	if e.Outcome != audit.OutcomeSuccess {
+		t.Errorf("partial should record as success, got %q", e.Outcome)
+	}
+	if got := e.Extra["failure_count"]; got != 3 {
+		t.Errorf("extra.failure_count = %v, want 3", got)
+	}
+}
+
+func TestBulkDownloadAudit_Failure(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{
+		"kind": "pods", "count": 5, "outcome": "failure", "failure_count": 5,
+	})
+	if rec := invokeBulkDownload(t, reg, sink, "c1", body); rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	e := sink.snapshot()[0]
+	if e.Outcome != audit.OutcomeFailure {
+		t.Errorf("outcome = %q, want failure", e.Outcome)
+	}
+}
+
+func TestBulkDownloadAudit_ClusterNotFound(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{"kind": "pods", "count": 1, "outcome": "success"})
+	rec := invokeBulkDownload(t, reg, sink, "nope", body)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := len(sink.snapshot()); got != 0 {
+		t.Errorf("emitted %d events on cluster-not-found, want 0", got)
+	}
+}
+
+func TestBulkDownloadAudit_MalformedBody(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	rec := invokeBulkDownload(t, reg, sink, "c1", []byte("not json"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := len(sink.snapshot()); got != 0 {
+		t.Errorf("emitted %d events on malformed body, want 0", got)
+	}
+}
+
+func TestBulkDownloadAudit_UnknownKind(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{"kind": "bogusresource", "count": 1, "outcome": "success"})
+	rec := invokeBulkDownload(t, reg, sink, "c1", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := len(sink.snapshot()); got != 0 {
+		t.Errorf("emitted %d events on unknown kind, want 0", got)
+	}
+}
+
+func TestBulkDownloadAudit_KnownKinds(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	for _, kind := range []string{"pods", "configmaps", "secrets", "customresources/certificates"} {
+		t.Run(kind, func(t *testing.T) {
+			sink := &recordSink{}
+			body := mustJSONBulk(t, map[string]any{
+				"kind": kind, "count": 1, "outcome": "success",
+			})
+			rec := invokeBulkDownload(t, reg, sink, "c1", body)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("kind=%q status = %d, want 204; body=%q", kind, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestBulkDownloadAudit_CountOverCap(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{
+		"kind": "pods", "count": bulkDownloadCap + 1, "outcome": "success",
+	})
+	rec := invokeBulkDownload(t, reg, sink, "c1", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestBulkDownloadAudit_CountZero(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	body := mustJSONBulk(t, map[string]any{"kind": "pods", "count": 0, "outcome": "success"})
+	rec := invokeBulkDownload(t, reg, sink, "c1", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for count=0", rec.Code)
+	}
+}
+
+func TestBulkDownloadAudit_IDsTruncatedServerSide(t *testing.T) {
+	reg := bulkDownloadRegistry(t, "c1")
+	sink := &recordSink{}
+	ids := make([]string, bulkDownloadIDCap+10)
+	for i := range ids {
+		ids[i] = "ns/r-" + strings.Repeat("x", 3)
+	}
+	body := mustJSONBulk(t, map[string]any{
+		"kind": "pods", "count": bulkDownloadIDCap + 10,
+		"ids": ids, "outcome": "success",
+	})
+	rec := invokeBulkDownload(t, reg, sink, "c1", body)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rec.Code, rec.Body.String())
+	}
+	e := sink.snapshot()[0]
+	gotIDs, ok := e.Extra["ids"].([]string)
+	if !ok {
+		t.Fatalf("extra.ids type = %T, want []string", e.Extra["ids"])
+	}
+	if len(gotIDs) != bulkDownloadIDCap {
+		t.Errorf("extra.ids len = %d, want %d (server-side truncate)", len(gotIDs), bulkDownloadIDCap)
+	}
+	if got := e.Extra["count"]; got != bulkDownloadIDCap+10 {
+		t.Errorf("extra.count = %v, want %d (count is the truth, ids are a sample)", got, bulkDownloadIDCap+10)
+	}
+}
+
+func mustJSONBulk(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -1011,6 +1011,17 @@ func main() {
 	router.Get("/api/clusters/{cluster}/secrets/{ns}/{name}/data/{key}",
 		credentials.Wrap(factory, secretRevealHandler(registry, auditEmitter)))
 
+	// --- Bulk download audit endpoint ---
+	//
+	// One row per bulk YAML download from the SPA. Records the
+	// operator's intent ("alice downloaded N {kind} from cluster X")
+	// so audit reviewers can answer that question without joining
+	// individual /yaml read events. Per-fetch RBAC is still
+	// enforced by the underlying yamlHandler routes; this endpoint
+	// only records the batch.
+	router.Post("/api/clusters/{cluster}/audit/bulk-download",
+		credentials.Wrap(factory, bulkDownloadAuditHandler(registry, auditEmitter)))
+
 	// --- Generic resource mutation endpoints (PR-D) ---
 	//
 	// One pair of routes covers every editable resource — Pod, Deployment,
@@ -1658,6 +1669,153 @@ func secretYamlHandler(reg *clusters.Registry, auditer *audit.Emitter) credentia
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(yaml))
 	}
+}
+
+// bulkDownloadCap mirrors the SPA's per-tab selection cap (see
+// useTableSelection.DEFAULT_CAP). Server enforces defensively so a
+// patched / forged client can't blow audit-row size out.
+const bulkDownloadCap = 100
+
+// bulkDownloadIDCap caps the slice of resource IDs that lands in
+// `Extra.ids`. The full count lives in `Extra.count` regardless; the
+// IDs are a forensic sample, not the source of truth.
+const bulkDownloadIDCap = 50
+
+// bulkDownloadAuditHandler records a single audit row per bulk YAML
+// download initiated from the SPA. The actual /yaml fetches go
+// through the existing per-kind handlers (each with its own RBAC and,
+// for secrets, its own audit row); this endpoint only records the
+// operator's batch intent so audit reviewers can answer "what did
+// alice bulk-download from prod last week?" with a single query.
+//
+// Outcome semantics:
+//   - "success" → at least one /yaml fetch succeeded (partials count as success;
+//     `Extra.failure_count` carries the partial-failure count)
+//   - "failure" → zero /yaml fetches succeeded (RBAC denies, network errors,
+//     etc.). The operator's intent is still audit-worthy.
+//
+// The endpoint is RBAC-open for any authenticated user — anyone who
+// can call /yaml can also call this. The audit gate doesn't need
+// extra authorization on top of the per-fetch RBAC.
+func bulkDownloadAuditHandler(reg *clusters.Registry, auditer *audit.Emitter) credentials.Handler {
+	type req struct {
+		Kind         string   `json:"kind"`
+		Count        int      `json:"count"`
+		IDs          []string `json:"ids"`
+		Outcome      string   `json:"outcome"` // "success" | "failure"
+		FailureCount int      `json:"failure_count"`
+	}
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		var body req
+		// 16 KiB is comfortably above the worst-case payload (50 IDs of
+		// reasonable length + a handful of small fields) and well under
+		// any sane request budget.
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<14)).Decode(&body); err != nil {
+			http.Error(w, "malformed body", http.StatusBadRequest)
+			return
+		}
+		if !isKnownBulkDownloadKind(body.Kind) {
+			http.Error(w, "unknown kind", http.StatusBadRequest)
+			return
+		}
+		if body.Count <= 0 || body.Count > bulkDownloadCap {
+			http.Error(w, "count out of range", http.StatusBadRequest)
+			return
+		}
+		if len(body.IDs) > bulkDownloadIDCap {
+			// Server-side truncate — never reject. The operator already
+			// did the download; we'd rather record a slightly-truncated
+			// row than no row at all.
+			body.IDs = body.IDs[:bulkDownloadIDCap]
+		}
+		if body.FailureCount < 0 {
+			body.FailureCount = 0
+		}
+		outcome := audit.OutcomeFailure
+		if body.Outcome == "success" {
+			outcome = audit.OutcomeSuccess
+		}
+		auditer.Record(r.Context(), audit.Event{
+			Actor:   actorFromContext(r.Context()),
+			Verb:    audit.VerbBulkDownload,
+			Outcome: outcome,
+			Cluster: c.Name,
+			Resource: audit.ResourceRef{
+				Resource:  body.Kind,
+				Namespace: "*", // bulk selections may span namespaces
+			},
+			Extra: map[string]any{
+				"kind":          body.Kind,
+				"count":         body.Count,
+				"ids":           body.IDs,
+				"failure_count": body.FailureCount,
+			},
+		})
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// bulkDownloadableKinds enumerates the URL plurals the SPA may
+// pass as `kind` for a bulk YAML download. Equivalent to the set
+// of /api/clusters/{c}/{plural}/.../yaml routes registered in
+// main(). Custom resources use the `customresources/<plural>`
+// prefix since their plural varies per CRD.
+var bulkDownloadableKinds = map[string]struct{}{
+	// namespaced (have /{ns}/{name}/yaml)
+	"configmaps":              {},
+	"cronjobs":                {},
+	"daemonsets":              {},
+	"deployments":             {},
+	"endpointslices":          {},
+	"horizontalpodautoscalers": {},
+	"ingresses":               {},
+	"jobs":                    {},
+	"limitranges":             {},
+	"networkpolicies":         {},
+	"poddisruptionbudgets":    {},
+	"pods":                    {},
+	"pvcs":                    {},
+	"replicasets":             {},
+	"resourcequotas":          {},
+	"rolebindings":            {},
+	"roles":                   {},
+	"secrets":                 {},
+	"serviceaccounts":         {},
+	"services":                {},
+	"statefulsets":            {},
+	// cluster-scoped (have /{name}/yaml)
+	"clusterrolebindings":     {},
+	"clusterroles":            {},
+	"ingressclasses":          {},
+	"namespaces":              {},
+	"priorityclasses":         {},
+	"pvs":                     {},
+	"runtimeclasses":          {},
+	"storageclasses":          {},
+}
+
+// isKnownBulkDownloadKind validates the SPA-supplied kind label.
+// The set lives one place (above) — single source of truth shared
+// with the audit log, so a typo on the SPA side rejects fast.
+// Custom resources are accepted via the `customresources/<plural>`
+// prefix; the plural after the slash isn't validated server-side
+// since the CRD catalog is dynamic.
+func isKnownBulkDownloadKind(kind string) bool {
+	if kind == "" {
+		return false
+	}
+	if _, ok := bulkDownloadableKinds[kind]; ok {
+		return true
+	}
+	if strings.HasPrefix(kind, "customresources/") {
+		return len(kind) > len("customresources/")
+	}
+	return false
 }
 
 // podLogsHandler streams a single pod's logs as Server-Sent Events.

--- a/docs/rfcs/0003-audit-log.md
+++ b/docs/rfcs/0003-audit-log.md
@@ -111,9 +111,18 @@ are not allowed — every emission site uses a `audit.Verb*` constant.
 | `delete` | `deleteResourceHandler` | `success` / `failure` / `denied` | — |
 | `trigger` | `triggerCronJobHandler` | `success` / `failure` / `denied` | on success: `jobName: string` |
 | `secret_reveal` | `secretRevealHandler` | `success` / `failure` / `denied` | `key: string`; on success also `size: int` (bytes of the decoded value) |
+| `bulk_download` | `bulkDownloadAuditHandler` (POST `/api/clusters/{c}/audit/bulk-download`, called by the SPA after a bulk YAML download resolves) | `success` (≥1 fetch succeeded) / `failure` (zero fetches succeeded) | `kind: string`, `count: int`, `ids: []string` (server-truncated to 50), `failure_count: int` |
 | `exec_open` | `execHandler` immediately after session admit | `success` only | `session_id`, `container`, `tty`, `command`, `k8s_identity`, `started_at` |
 | `exec_close` | `execHandler` once `execsess.Run` returns | `success` / `failure` | all `exec_open` fields plus `transport`, `ended_at`, `duration_ms`, `exit_code`, `bytes_stdin`, `bytes_stdout`, `err`. `Reason` carries the close disposition: `completed` / `idle_timeout` / `abort` / `server_error` |
 | `log_open` | _reserved_ | _reserved_ | _reserved_ |
+
+`bulk_download` is **SPA-emitted**, not server-derived. The endpoint
+doesn't gate access — anyone who can call /yaml can also POST
+/audit/bulk-download — because the auditable event is the operator's
+batch *intent*, recorded once. The per-fetch RBAC is enforced by the
+underlying yamlHandler routes. A failed audit POST is fire-and-forget
+client-side: the download already happened, the audit row is the
+thing we're willing to lose, not the user's work.
 
 `apply` is intentionally a single verb covering both create and update.
 Periscope's mutation surface is `PATCH application/apply-patch+yaml`

--- a/docs/setup/audit.md
+++ b/docs/setup/audit.md
@@ -1,6 +1,6 @@
 # Audit log
 
-Periscope records every privileged action — pod exec, secret reveal,
+Periscope records every privileged action — pod exec, secret reveal, bulk YAML download,
 resource apply / delete / scale / label edit, cronjob trigger — as a
 structured `audit.Event`. Events flow through an in-process Emitter to
 one or more sinks.

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -42,6 +42,7 @@ const (
 	VerbExecOpen     Verb = "exec_open"
 	VerbExecClose    Verb = "exec_close"
 	VerbSecretReveal Verb = "secret_reveal"
+	VerbBulkDownload Verb = "bulk_download"
 	// VerbLogOpen is reserved for pod/workload log stream opens. No
 	// emission site exists yet; declared so the taxonomy is visible
 	// and a follow-up PR can wire it without revisiting this file.

--- a/web/src/components/audit/AuditFilterStrip.tsx
+++ b/web/src/components/audit/AuditFilterStrip.tsx
@@ -17,6 +17,7 @@ const VERBS = [
   "exec_close",
   "secret_reveal",
   "log_open",
+  "bulk_download",
 ] as const;
 
 

--- a/web/src/components/table/BulkActionsToolbar.tsx
+++ b/web/src/components/table/BulkActionsToolbar.tsx
@@ -22,6 +22,7 @@ import {
   buildFilename,
   triggerYamlDownload,
 } from "../../lib/multiYaml";
+import { recordBulkDownload } from "../../lib/api";
 import type { TableSelection } from "../../hooks/useTableSelection";
 
 export interface BulkActionsToolbarProps<T> {
@@ -111,6 +112,24 @@ export function BulkActionsToolbar<T>({
           showToast("download canceled", "info");
           return;
         }
+        // Emit one structured audit row per download — fire-and-forget
+        // so a failed audit POST never blocks the operator. Both the
+        // success and the all-failed paths emit; both are auditable
+        // operator intent. See RFC 0003 §4 (`bulk_download` verb).
+        const auditOutcome = result.successCount === 0 ? "failure" : "success";
+        void recordBulkDownload(cluster, {
+          kind: kindLabel,
+          count: selectedRows.length,
+          ids: selectedRows.slice(0, 50).map((row) => rowKey(row)),
+          outcome: auditOutcome,
+          failure_count: result.failures.length,
+        }).catch(() => {
+          // Audit POST failed — log nothing visible. The download
+          // already completed. The audit gap is acceptable: missing
+          // audit row beats blocking the user on a transient API
+          // failure of the audit endpoint itself.
+        });
+
         if (result.successCount === 0) {
           showToast(
             `download failed — 0 of ${selectedRows.length} fetched`,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1002,4 +1002,52 @@ export async function mintAgentToken(cluster: string, signal?: AbortSignal): Pro
   return (await res.json()) as AgentTokenIssuance;
 }
 
+
+/**
+ * recordBulkDownload — emit one structured audit row for a bulk YAML
+ * download. The actual /yaml fetches are unchanged; this endpoint
+ * only records "alice bulk-downloaded N {kind} from cluster X" so
+ * audit reviewers can answer that question without joining
+ * individual /yaml read events. See RFC 0003 §4 (`bulk_download`
+ * verb) for the schema.
+ *
+ * Outcome semantics:
+ *   - "success" — at least one /yaml fetch succeeded (partials
+ *     count as success; pass `failure_count` for the partial count)
+ *   - "failure" — zero /yaml fetches succeeded. The operator's
+ *     intent is still audit-worthy.
+ *
+ * Caller should fire-and-forget — a failed audit POST must not
+ * block the user, the download has already been served.
+ */
+export interface BulkDownloadAuditBody {
+  kind: string;
+  count: number;
+  ids: string[];
+  outcome: "success" | "failure";
+  failure_count: number;
+}
+
+export async function recordBulkDownload(
+  cluster: string,
+  body: BulkDownloadAuditBody,
+): Promise<void> {
+  const res = await fetch(
+    `/api/clusters/${encodeURIComponent(cluster)}/audit/bulk-download`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new ApiError(
+      `${res.status} ${res.statusText} on /audit/bulk-download`,
+      res.status,
+      text,
+    );
+  }
+}
+
 export { ApiError };


### PR DESCRIPTION
## Summary

Closes #82.

PR #80 expanded the read fan-out (one click → up to 100 `/yaml` fetches) without an audit signal at the bulk level. Per-fetch reads still flow through their existing handlers, and Secret reads land structured `secret_reveal` rows via `secretYamlHandler`, but bulk downloads of non-secret kinds previously left zero structured trail tying the N reads back to a single operator action.

This PR adds a single SPA-emitted `bulk_download` audit verb that records the operator's batch intent as one row per download:

```
actor / cluster / verb=bulk_download / outcome=success|failure
Extra: { kind, count, ids (≤50, server-truncated), failure_count }
```

`success` when ≥1 fetch succeeded (partials count as success; `failure_count` carries the partial count). `failure` when zero succeeded. The operator's intent is auditable in both cases.

## Related issue

Closes #82.

## Type of change

- [x] New feature (non-breaking)

## Surfaces touched

- [x] HTTP API — new `POST /api/clusters/{c}/audit/bulk-download`
- [x] Audit / RBAC — new `bulk_download` verb in the closed taxonomy (RFC 0003 §4)
- [x] SPA / frontend — `BulkActionsToolbar` emits after `bulkFetchYaml` resolves
- [x] Documentation — RFC 0003 + `docs/setup/audit.md`

## How was this tested?

Backend:
- `go test ./cmd/periscope/...` — new `TestBulkDownloadAudit_*` suite covers success, partial-as-success, failure outcome, cluster-not-found, malformed body, unknown kind, all known kinds (incl. `customresources/<plural>` prefix), count-over-cap, count-zero, server-side ids truncation
- `go test ./...` — full suite green
- `go vet ./...` — clean

Frontend:
- `tsc -b` clean, `eslint .` clean
- Existing `multiYaml.test.ts` still passes (no behavior change in the bulk-fetch lib itself)

## Design notes

- **SPA-emitted, not server-derived.** The endpoint doesn't gate access — anyone who can call `/yaml` can also POST `/audit/bulk-download` — because the auditable event is the operator's batch *intent*, recorded once. Per-fetch RBAC is enforced by the underlying `yamlHandler` routes.
- **Fire-and-forget client-side.** A failed audit POST never blocks the operator: the download has already been served. Missing an audit row beats blocking the user on a transient audit-endpoint failure.
- **Server-side defensive caps.** `count` validated against `bulkDownloadCap` (100, mirrors SPA selection cap); `ids` server-truncated to `bulkDownloadIDCap` (50). The full `count` is always preserved as the source of truth; the IDs are a forensic sample.
- **Kind validation lives in one place.** New `bulkDownloadableKinds` map enumerates the URL plurals the SPA can bulk-download — equivalent to the set of `/yaml` routes mounted in `main()`. Custom resources accepted via the `customresources/<plural>` prefix.

## Checklist

- [x] CONTRIBUTING.md read
- [x] Tests added or updated where it makes sense
- [x] Docs updated (RFC 0003 §4 + `docs/setup/audit.md`)
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files
