### PR TITLE
chore(security): add Scorecard + CodeQL + govulncheck + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot — auto-PRs for vulnerable / outdated dependencies across
+# the three ecosystems Periscope cares about. Weekly cadence keeps PR
+# noise low while still catching CVEs within a reasonable window.
+#
+# Grouping: minor + patch updates land in a single PR per ecosystem so
+# a typical week is one consolidated PR per ecosystem rather than a
+# fan-out of 30 single-package bumps. Major updates still fan out so
+# we can review breaking changes individually.
+
+version: 2
+
+updates:
+  # Go modules — the central server, agent, and shared internal packages.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    groups:
+      go-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # npm — the SPA + tooling under web/.
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Some bundled dev-deps (vitest plugins, eslint configs) churn
+    # weekly with cosmetic-only releases. Ignore patch-only bumps for
+    # those to keep the dashboard tidy.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+
+  # GitHub Actions — pinned to major versions across our workflows.
+  # Dependabot bumps the major when a new one ships so we don't lag.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,16 @@ jobs:
           cache: true
       - run: go test ./...
 
+      # govulncheck — Go vulnerability scanner. Only flags vulns
+      # actually present in the call graph (lower noise than
+      # generic dep scanners). Report-only: continue-on-error so
+      # findings show in the run UI but do not fail the build.
+      - name: Govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+        continue-on-error: true
+
   web:
     name: Web (lint, test, build)
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # security-and-quality picks up more issues than the default
@@ -58,9 +58,9 @@ jobs:
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+# CodeQL — GitHub's static analysis for security bugs.
+# Runs on push to main + PRs + weekly cron. Findings land in the
+# repo's Security tab; this is intentionally report-only and does NOT
+# fail PRs. We can tighten later once we've watched the signal-to-noise
+# ratio on a few release cycles.
+#
+# Languages:
+#   - go        — backend (cmd/ + internal/)
+#   - javascript — picks up TypeScript via the JS extractor (web/)
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1'   # weekly, Mondays 07:00 UTC (an hour after Scorecard)
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload results to the Security tab.
+      security-events: write
+      # Required to fetch internal dependencies during build.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-and-quality picks up more issues than the default
+          # security-extended; report-only mode means more signal isn't
+          # painful while we tune.
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,66 @@
+# OpenSSF Scorecard — automated assessment of OSS security practices.
+# Runs weekly + on every push to main. Results go to GitHub's Security
+# tab AND populate the public Scorecard badge endpoint at
+# https://api.securityscorecards.dev/projects/github.com/gnana997/periscope/
+#
+# Report-only: never fails the run. The score is the signal; we use it
+# to track posture over time and to surface a public badge enterprise
+# evaluators recognise.
+#
+# Pinning: matches the rest of the repo's workflows — major-version
+# pinning. Scorecard itself dings us on this (Pinned-Dependencies
+# check); we accept the lower score in exchange for not having to
+# manually rotate SHAs across every workflow. Easy to upgrade later.
+
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'   # weekly, Mondays 06:00 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required by ossf/scorecard-action for uploading results.
+      security-events: write
+      # Required for OIDC token used to publish results.
+      id-token: write
+      # Required to read repo content.
+      contents: read
+      # Required for branch-protection check.
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish the score to the public scorecard endpoint
+          # (https://api.securityscorecards.dev/) so the README badge
+          # has data to render.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 [![Artifact Hub agent](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/periscope-agent)](https://artifacthub.io/packages/search?repo=periscope-agent)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8.svg)](https://go.dev/)
 [![Node](https://img.shields.io/badge/Node-22-339933.svg)](https://nodejs.org/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gnana997/periscope/badge)](https://scorecard.dev/viewer/?uri=github.com/gnana997/periscope)
+[![CodeQL](https://github.com/gnana997/periscope/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/gnana997/periscope/actions/workflows/codeql.yml)
 
 **v1.0.0 launched.** Read the [launch announcement](https://github.com/gnana997/periscope/discussions/70) — origin story, what shipped, what's not in v1.0, and what's next.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,10 +28,6 @@ Periscope is in early development and maintained by a small team. We aim to:
 
 We'll keep you updated and credit you in the release notes if you'd like.
 
-## Supported versions
-
-Until the project tags a `v1.0.0` release, security fixes land on `main` only. There are no LTS branches. If you're running Periscope from a pinned commit, plan on rebasing onto current `main` to receive fixes.
-
 ## Scope
 
 Issues we consider in scope:
@@ -49,6 +45,44 @@ Issues that are typically **out of scope**:
 - Vulnerabilities in third-party services Periscope integrates with (Auth0, Okta, AWS) — please report those upstream.
 - Findings from automated scanners without a demonstrated impact.
 - Denial-of-service via resource exhaustion against a single user's session.
+
+## Supported versions
+
+| Version | Status |
+|---|---|
+| `v1.x` (latest minor on `main`) | **Active** — security and bug fixes |
+| `v1.0.x` | **Maintenance** — security fixes only, until `v1.2` ships |
+| `< v1.0` | Unsupported |
+
+Periscope follows [semantic versioning](https://semver.org/spec/v2.0.0.html)
+for the public HTTP API, OIDC / cluster-registry config shape, and Helm
+chart values. The audit-log schema is wire-stable per RFC 0003. Breaking
+changes land in a future major (`v2`).
+
+## Supply-chain verification
+
+Every release ships:
+
+- **Cosign keyless signatures** on the container image and Helm chart,
+  backed by Sigstore's public transparency log. Verify before deploying:
+
+  \`\`\`sh
+  cosign verify ghcr.io/gnana997/periscope:vX.Y.Z \
+    --certificate-identity-regexp "https://github.com/gnana997/periscope" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  \`\`\`
+
+  Same pattern verifies the Helm chart at
+  \`oci://ghcr.io/gnana997/charts/periscope\`.
+
+- **SPDX SBOM** attached to the image (downloadable via \`cosign download
+  sbom\` or the GitHub release page). Operators wanting to enumerate
+  Periscope's dependency graph for their own scanners get it directly
+  from the artifact rather than re-deriving from source.
+
+- **Distroless runtime, non-root, read-only filesystem, all capabilities
+  dropped, RuntimeDefault seccomp** (Helm chart defaults). The runtime
+  attack surface is the Go binary plus a CA bundle — nothing else.
 
 ## Disclosure policy
 


### PR DESCRIPTION
## Summary

Three new GitHub-native security workflows + Dependabot config + a
SECURITY.md / README refresh. Audit-prep batch 1 of 2.

## Surfaces touched

- [x] CI workflows
- [x] Documentation (SECURITY.md, README.md)

## How was this tested?

- All four YAML files parse cleanly via PyYAML
- New workflows do NOT block PRs (CodeQL + Govulncheck are report-only)
- Existing CI (Backend lint / test, Web, Helm lint, Build embedded binary) untouched in shape

## Notes

- Workflow actions pinned to major versions, matching existing repo style. Scorecard will report a Pinned-Dependencies ding; accepting that for consistency. Easy to upgrade later.
- CodeQL + Govulncheck both report-only — findings go to Security tab without failing PRs. Tighten later once signal/noise is understood.
- Dependabot config has no labels (repo doesn't have `dependencies` / `go` / `ci` labels yet — can be added separately via `gh label create`).

## Next in this batch

PR2 — `docs/security/rbac-posture.md` (the document the audit team will actually read; pre-empts CIS 5.1.1 / AWS Guardrails findings).
v1.1 issue: #84 (opt-in cluster-admin binding).
