### PR TITLE
fix(ci): pin ossf/scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,10 +7,13 @@
 # to track posture over time and to surface a public badge enterprise
 # evaluators recognise.
 #
-# Pinning: matches the rest of the repo's workflows — major-version
-# pinning. Scorecard itself dings us on this (Pinned-Dependencies
-# check); we accept the lower score in exchange for not having to
-# manually rotate SHAs across every workflow. Easy to upgrade later.
+# Pinning: most actions in this repo use major-version pins
+# (@v3, @v6, etc.). ossf/scorecard-action does NOT publish a
+# rolling major tag — only point releases — so this workflow
+# pins to the latest point version. Bump on each scorecard-action
+# release. Scorecard itself dings us on Pinned-Dependencies for
+# the rest of the repo's actions; accepting that lower score
+# in exchange for not rotating SHAs across every workflow.
 
 name: OpenSSF Scorecard
 
@@ -44,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Fixes the failing Scorecard run from PR #85's post-merge push.

`ossf/scorecard-action` doesn't publish a rolling `@v2` tag — only point releases. The original pin returned "unable to find version v2" on the resolver. Pin to the latest stable, `v2.4.3`.

## Failing run

https://github.com/gnana997/periscope/actions/runs/25373843953

## Verification

- YAML parses cleanly
- Single-file diff (workflow + its inline comment)
- Once merged, the next push to main will fire Scorecard successfully and the README badge will populate
