### PR TITLE
chore(security): tighten release.yaml permissions + attest provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,14 @@ on:
     tags:
       - "v*"
 
+# Top-level permissions are read-only by default. The release job
+# below grants the explicit write scopes it needs (contents to
+# create the GitHub Release, packages to push to ghcr.io,
+# id-token for cosign keyless signing + GH Attestations,
+# attestations to upload SLSA provenance via attest-build-provenance).
+# This shape passes OpenSSF Scorecard's Token-Permissions check.
 permissions:
-  contents: write       # create the GitHub Release
-  packages: write       # push to ghcr.io
-  id-token: write       # cosign keyless signing via GH OIDC
+  contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -31,6 +35,11 @@ jobs:
   release:
     name: Build, sign, and publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create the GitHub Release
+      packages: write       # push to ghcr.io
+      id-token: write       # cosign keyless signing + GH Attestations
+      attestations: write   # actions/attest-build-provenance
     steps:
       - uses: actions/checkout@v6
         with:
@@ -102,6 +111,20 @@ jobs:
             cosign sign --yes "${tag}@${DIGEST}"
           done
 
+      # SLSA build provenance attestation. The
+      # actions/attest-build-provenance action signs the predicate
+      # via Sigstore's public Fulcio CA (using the same OIDC
+      # identity as cosign), pushes the attestation as an OCI
+      # referrer next to the image, AND publishes it as a GitHub
+      # Attestation. OpenSSF Scorecard's Signed-Releases check
+      # picks up GitHub Attestations on recent versions.
+      - name: Attest server image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
       # ── SBOM ───────────────────────────────────────────────────
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
@@ -167,6 +190,13 @@ jobs:
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope:${VERSION}@${DIGEST}"
 
+      - name: Attest server chart provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope
+          subject-digest: ${{ steps.helm_push.outputs.digest }}
+          push-to-registry: true
+
       # ── Agent image (#42) ─────────────────────────────────────
       #
       # Separate Dockerfile.agent build so the agent image stays
@@ -214,6 +244,13 @@ jobs:
             cosign sign --yes "${tag}@${DIGEST}"
           done
 
+      - name: Attest agent image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}-agent
+          subject-digest: ${{ steps.build_agent.outputs.digest }}
+          push-to-registry: true
+
       # ── Agent Helm chart ──────────────────────────────────────
       - name: Sync agent chart version to tag
         run: |
@@ -241,6 +278,13 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope-agent:${VERSION}@${DIGEST}"
+
+      - name: Attest agent chart provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope-agent
+          subject-digest: ${{ steps.helm_push_agent.outputs.digest }}
+          push-to-registry: true
 
       # ── Artifact Hub repository metadata ──────────────────────
       #


### PR DESCRIPTION
## Summary

Two OpenSSF Scorecard quick wins on the v1.0.0 baseline (5.5/10).

| Check | Before | Expected after |
|---|---|---|
| Token-Permissions | 0/10 | 10/10 (next Scorecard run) |
| Signed-Releases | 0/10 | 10/10 (after next release tag fires `release.yaml`) |

## Token-Permissions fix

Reduced top-level `permissions:` to `contents: read` and moved write scopes into the release job's per-job block. This is the Scorecard-recommended workflow shape — every job declares only what it actually needs.

## Signed-Releases fix

Four `actions/attest-build-provenance@v4` steps, one after each artifact's existing cosign sign step:
- Server image
- Server chart
- Agent image
- Agent chart

Each generates SLSA build provenance, signs via Sigstore Fulcio, pushes as OCI referrer, and publishes as a GitHub Attestation.

## Caveats

- Token-Permissions improves on the **next** Scorecard run (weekly cron Mondays 06:00 UTC, push-to-main, or manual workflow_dispatch).
- Signed-Releases improves only **after the next release tag fires** `release.yaml` — today's v1.0.0 release is unattested. v1.0.1 / v1.1 will be.

## Verification

- YAML parses cleanly (`yaml.safe_load`)
- Diff is targeted (single workflow file, +47 / -3)
- All four `subject-digest:` references point at existing `steps.<id>.outputs.digest` outputs that already capture the OCI digest at push time
- Comment block at top of `permissions:` explains the shape for future maintainers

## Next score expectation

Combined with branch-protection-rule tightening (UI clicks, no code), the score should climb from 5.5 → 7–7.5 by next release.
