### PR TITLE
chore(security): expand CODEOWNERS + add scorecard workflow_dispatch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,17 +10,45 @@
 # Default: the project maintainer owns everything.
 *                                       @gnana997
 
-# Security / auth / audit surfaces — listed explicitly so future
-# co-maintainers can be added with a one-line edit per surface,
-# without changing the catch-all above.
+# ── Security / auth / audit surfaces ──────────────────────────────
+# Listed explicitly so future co-maintainers can be added with a
+# one-line edit per surface, without changing the catch-all above.
+
 /internal/auth/                         @gnana997
 /internal/authz/                        @gnana997
 /internal/credentials/                  @gnana997
 /internal/audit/                        @gnana997
+/internal/secrets/                      @gnana997
+/internal/tunnel/                       @gnana997
+
+# Specific security-sensitive Go files — pod exec, secret reveal,
+# agent-tunnel exec proxy. Each has a separate audit verb attached
+# and gets the explicit ownership the directory catch-all already
+# implies.
 /internal/k8s/exec.go                   @gnana997
+/internal/k8s/secrets.go                @gnana997
+/internal/k8s/agent_exec_proxy.go       @gnana997
+
+# cmd/periscope handlers — split out so reviewers can see at a
+# glance which HTTP surfaces touch sensitive paths.
 /cmd/periscope/exec_handler.go          @gnana997
 /cmd/periscope/audit_handler.go         @gnana997
+/cmd/periscope/cani_handler.go          @gnana997
+/cmd/periscope/agent_handler.go         @gnana997
 
-# Helm chart + CI surfaces — operator-facing, deserve the same gate.
+# ── Documentation with security / compliance implications ─────────
+
+/SECURITY.md                            @gnana997
+/docs/rfcs/                             @gnana997
+/docs/security/                         @gnana997
+/docs/setup/cluster-rbac.md             @gnana997
+/docs/setup/audit.md                    @gnana997
+/docs/setup/auth0.md                    @gnana997
+/docs/setup/okta.md                     @gnana997
+/docs/setup/agent-onboarding.md         @gnana997
+/docs/setup/pod-exec.md                 @gnana997
+
+# ── Operator-facing surfaces (Helm charts, CI workflows) ──────────
+
 /deploy/                                @gnana997
 /.github/                               @gnana997

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,7 @@
 name: OpenSSF Scorecard
 
 on:
+  workflow_dispatch:        # manual trigger for debugging / on-demand re-evaluation
   branch_protection_rule:
   schedule:
     - cron: '0 6 * * 1'   # weekly, Mondays 06:00 UTC


### PR DESCRIPTION
## Summary

Two small chores bundled together so a single push-to-main triggers Scorecard with both improvements in place.

### CODEOWNERS update

Expands explicit ownership for surfaces added since v1.0.0 or missed previously:

- internal/ packages: secrets/, tunnel/
- Specific Go files: internal/k8s/secrets.go, internal/k8s/agent_exec_proxy.go
- cmd/periscope handlers: cani_handler.go, agent_handler.go
- Documentation with security implications: SECURITY.md, docs/rfcs/, docs/security/, several docs/setup/*.md

Catch-all (`*  @gnana997`) still applies. Reorganized into clearer section headers.

### Scorecard workflow_dispatch trigger

Adds the `workflow_dispatch` event so the OpenSSF Scorecard workflow can be fired manually from the Actions UI. Useful for:
- Re-evaluating after a release tag (tag pushes don't fire `push: main`)
- Debugging score regressions without no-op commits

No behavior change for existing triggers.

## Why bundled

After v1.0.1-rc1 published its SLSA build provenance attestations + cosign signatures, we want a fresh Scorecard run to confirm `Signed-Releases` moves from 0/10 → 10/10. Merging this PR triggers `push: main`, which fires Scorecard. If the score doesn't move, the new `workflow_dispatch` lets us iterate on a fix without re-pushing every time.

## Verification

- Two commits on the branch (CODEOWNERS update + workflow_dispatch addition)
- YAML parses for scorecard.yml
- All CODEOWNERS path globs verified against the file tree

## Expected post-merge effect

- Scorecard fires on push-to-main
- Token-Permissions stays 10/10 (already fixed by #91)
- Signed-Releases hopefully moves 0/10 → 10/10 (sees v1.0.1-rc1 + v1.0.1 attestations)
- Branch-Protection / Code-Review unchanged until you finish the ruleset UI work

If Signed-Releases doesn't move after this run, follow-up: add `.intoto.jsonl` files as GitHub Release assets too (some Scorecard versions look there specifically).
