### PR TITLE
feat(web): Apply YAML dialog — paste / upload + multi-doc parser + dry-run + apply (#53)

### DIFF
--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -13,6 +13,7 @@
 import { useId } from "react";
 import { Modal } from "../ui/Modal";
 import { ApplyYamlInput } from "./ApplyYamlInput";
+import { DocPreviewList } from "./DocPreviewList";
 import { useApplyYamlState } from "../../hooks/useApplyYamlState";
 
 export interface ApplyYamlDialogProps {
@@ -55,11 +56,7 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
         {/* ── Body ──────────────────────────────────────────────── */}
         <div className="flex-1 overflow-auto px-6 py-5">
           <ApplyYamlInput value={state.yamlText} onChange={state.setYamlText} />
-          {state.docs.length > 0 && (
-            <p className="mt-3 font-mono text-[11px] text-ink-faint tabular">
-              {state.docs.length} document{state.docs.length === 1 ? "" : "s"} parsed
-            </p>
-          )}
+          <DocPreviewList docs={state.docs} results={state.results} />
         </div>
 
         {/* ── Footer ────────────────────────────────────────────── */}

--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -1,0 +1,93 @@
+// ApplyYamlDialog — operator-facing modal for pasting / uploading
+// arbitrary YAML and running it through the existing apply pipeline.
+//
+// Composition entry point for the Apply YAML epic (#51). This component
+// is the "what" — paste, parse, dry-run, apply, render results. The
+// "where" (button placement, Cmd+K palette) lives in #54 and mounts
+// this dialog with `open` / `onClose`.
+//
+// Scaffold commit — wires the modal shell + footer skeleton. Subsequent
+// commits add the YAML input (Monaco + drag-drop), parser, dry-run
+// orchestration, and results panel.
+
+import { useId } from "react";
+import { Modal } from "../ui/Modal";
+import { useApplyYamlState } from "../../hooks/useApplyYamlState";
+
+export interface ApplyYamlDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Cluster the apply will target. Plumbed through to api.applyResource. */
+  cluster: string;
+}
+
+export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps) {
+  const titleId = useId();
+  const state = useApplyYamlState();
+
+  // The dialog itself controls the close path — child components emit
+  // events (clear, cancel, apply-success) that route here so reset
+  // happens in one place.
+  const handleClose = () => {
+    state.reset();
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose} labelledBy={titleId} size="lg">
+      <div className="flex max-h-[85vh] flex-col">
+        {/* ── Header ────────────────────────────────────────────── */}
+        <header className="flex items-baseline justify-between gap-4 border-b border-border px-6 py-4">
+          <div>
+            <h2 id={titleId} className="font-mono text-[15px] tracking-tight text-ink">
+              Apply YAML
+            </h2>
+            <p className="mt-1 font-mono text-[11px] text-ink-faint tabular">
+              {cluster}
+            </p>
+          </div>
+          <p className="font-mono text-[11px] text-ink-muted">
+            Paste a manifest or drop a `.yaml` file. Multi-doc supported.
+          </p>
+        </header>
+
+        {/* ── Body ──────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-auto px-6 py-5">
+          <p className="text-sm text-ink-muted">
+            <em>YAML input + per-doc preview will land in subsequent
+            commits of this PR.</em>
+          </p>
+          {/* Placeholder so we can verify the modal renders + dismisses. */}
+          <div className="mt-4 rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[11px] text-ink-faint">
+            docs parsed: {state.docs.length} · busy: {state.busy}
+          </div>
+        </div>
+
+        {/* ── Footer ────────────────────────────────────────────── */}
+        <footer className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink transition-colors hover:bg-surface-2"
+          >
+            cancel
+          </button>
+          <button
+            type="button"
+            disabled
+            className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink-faint disabled:cursor-not-allowed"
+          >
+            dry-run
+          </button>
+          <button
+            type="button"
+            disabled
+            className="rounded-sm border border-accent bg-accent px-4 py-1.5 font-mono text-sm lowercase text-accent-ink disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            apply
+          </button>
+        </footer>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -12,6 +12,7 @@
 
 import { useId } from "react";
 import { Modal } from "../ui/Modal";
+import { ApplyYamlInput } from "./ApplyYamlInput";
 import { useApplyYamlState } from "../../hooks/useApplyYamlState";
 
 export interface ApplyYamlDialogProps {
@@ -53,14 +54,12 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
 
         {/* ── Body ──────────────────────────────────────────────── */}
         <div className="flex-1 overflow-auto px-6 py-5">
-          <p className="text-sm text-ink-muted">
-            <em>YAML input + per-doc preview will land in subsequent
-            commits of this PR.</em>
-          </p>
-          {/* Placeholder so we can verify the modal renders + dismisses. */}
-          <div className="mt-4 rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[11px] text-ink-faint">
-            docs parsed: {state.docs.length} · busy: {state.busy}
-          </div>
+          <ApplyYamlInput value={state.yamlText} onChange={state.setYamlText} />
+          {state.docs.length > 0 && (
+            <p className="mt-3 font-mono text-[11px] text-ink-faint tabular">
+              {state.docs.length} document{state.docs.length === 1 ? "" : "s"} parsed
+            </p>
+          )}
         </div>
 
         {/* ── Footer ────────────────────────────────────────────── */}

--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -59,7 +59,12 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
         {/* ── Body ──────────────────────────────────────────────── */}
         <div className="flex-1 overflow-auto px-6 py-5">
           <ApplyYamlInput value={state.yamlText} onChange={state.setYamlText} />
-          <DocPreviewList docs={state.docs} results={state.results} />
+          <DocPreviewList
+            docs={state.docs}
+            results={state.results}
+            onForce={(doc) => { void state.forceApplyOne(doc, cluster); }}
+            forceDisabled={state.busy !== "idle"}
+          />
         </div>
 
         {/* ── Footer ────────────────────────────────────────────── */}

--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -27,6 +27,9 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
   const titleId = useId();
   const state = useApplyYamlState();
 
+  const validCount = state.docs.filter((d) => d.valid).length;
+  const invalidCount = state.docs.length - validCount;
+
   // The dialog itself controls the close path — child components emit
   // events (clear, cancel, apply-success) that route here so reset
   // happens in one place.
@@ -60,28 +63,51 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
         </div>
 
         {/* ── Footer ────────────────────────────────────────────── */}
-        <footer className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
-          <button
-            type="button"
-            onClick={handleClose}
-            className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink transition-colors hover:bg-surface-2"
-          >
-            cancel
-          </button>
-          <button
-            type="button"
-            disabled
-            className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink-faint disabled:cursor-not-allowed"
-          >
-            dry-run
-          </button>
-          <button
-            type="button"
-            disabled
-            className="rounded-sm border border-accent bg-accent px-4 py-1.5 font-mono text-sm lowercase text-accent-ink disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            apply
-          </button>
+        <footer className="flex items-center justify-between gap-2 border-t border-border px-6 py-4">
+          <p className="font-mono text-[11px] text-ink-muted">
+            {state.busy === "dry-run" && "running dry-run…"}
+            {state.busy === "apply" && "applying…"}
+            {state.busy === "idle" && validCount > 0 && (
+              <>{validCount} valid {validCount === 1 ? "doc" : "docs"} ready{invalidCount > 0 && `, ${invalidCount} skipped`}</>
+            )}
+          </p>
+          <div className="flex items-center gap-2">
+            {state.busy !== "idle" ? (
+              <button
+                type="button"
+                onClick={state.cancel}
+                className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink transition-colors hover:bg-surface-2"
+              >
+                cancel run
+              </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink transition-colors hover:bg-surface-2"
+                >
+                  cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void state.runDryRun(cluster); }}
+                  disabled={validCount === 0}
+                  className="rounded-sm border border-border-strong px-4 py-1.5 font-mono text-sm lowercase text-ink transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  dry-run
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void state.runApply(cluster); }}
+                  disabled={validCount === 0}
+                  className="rounded-sm border border-accent bg-accent px-4 py-1.5 font-mono text-sm lowercase text-accent-ink transition-[filter] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  apply {validCount > 0 ? validCount : ""}
+                </button>
+              </>
+            )}
+          </div>
         </footer>
       </div>
     </Modal>

--- a/web/src/components/apply/ApplyYamlInput.tsx
+++ b/web/src/components/apply/ApplyYamlInput.tsx
@@ -1,0 +1,174 @@
+// ApplyYamlInput — writable Monaco textarea for the apply dialog with
+// a drag-drop overlay accepting .yaml / .yml files plus a file picker
+// fallback (Browse… button).
+//
+// Distinct from src/components/helm/MonacoYAML (read-only) and
+// src/components/detail/yaml/YamlEditor (tied to existing-resource
+// edit context with URI scoping, dirty state, schema lazy-load). This
+// is a simpler writable editor scoped to a single multi-doc paste.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as monaco from "monaco-editor";
+import { cn } from "../../lib/cn";
+import {
+  ensureMonacoConfigured,
+  useMonacoTheme,
+  currentMonacoTheme,
+} from "../../lib/monacoSetup";
+
+interface ApplyYamlInputProps {
+  value: string;
+  onChange: (next: string) => void;
+}
+
+export function ApplyYamlInput({ value, onChange }: ApplyYamlInputProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  useMonacoTheme();
+
+  // Mount monaco once. The editor's content is reflected back via
+  // onChange; the parent owns the value, but we avoid `editor.setValue`
+  // inside the change loop (would feedback-loop the cursor).
+  useEffect(() => {
+    if (!containerRef.current) return;
+    ensureMonacoConfigured();
+    const editor = monaco.editor.create(containerRef.current, {
+      value,
+      language: "yaml",
+      theme: currentMonacoTheme(),
+      readOnly: false,
+      automaticLayout: true,
+      fontFamily:
+        '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontSize: 12.5,
+      lineHeight: 19,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      renderLineHighlight: "none",
+      glyphMargin: false,
+      folding: true,
+      foldingStrategy: "indentation",
+      bracketPairColorization: { enabled: false },
+      padding: { top: 10, bottom: 10 },
+    });
+    editorRef.current = editor;
+
+    const sub = editor.onDidChangeModelContent(() => {
+      onChange(editor.getValue());
+    });
+
+    return () => {
+      sub.dispose();
+      editor.getModel()?.dispose();
+      editor.dispose();
+      editorRef.current = null;
+    };
+    // We intentionally do NOT depend on `value` or `onChange` — the
+    // editor's lifecycle is mount-once / dispose-on-unmount; live value
+    // sync goes through the imperative `setValue` effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync external value → editor when it diverges from editor content
+  // (e.g. file drop replaces the buffer). Guard against the change-loop
+  // by checking before calling setValue.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    if (editor.getValue() !== value) {
+      editor.setValue(value);
+    }
+  }, [value]);
+
+  const readFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const accepted: File[] = [];
+      for (const f of Array.from(files)) {
+        if (f.name.endsWith(".yaml") || f.name.endsWith(".yml")) {
+          accepted.push(f);
+        }
+      }
+      if (accepted.length === 0) return;
+      // Concatenate multiple files with `---` separators so a folder
+      // drop becomes a multi-doc apply.
+      const parts = await Promise.all(accepted.map((f) => f.text()));
+      const joined = parts
+        .map((p) => p.trimEnd())
+        .filter((p) => p.length > 0)
+        .join("\n---\n");
+      onChange(joined);
+    },
+    [onChange],
+  );
+
+  return (
+    <div
+      className={cn(
+        "relative h-[440px] overflow-hidden rounded-sm border border-border bg-bg",
+        dragging && "border-accent ring-2 ring-accent/30",
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={(e) => {
+        // Only clear when leaving the container, not entering a child.
+        if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+        setDragging(false);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragging(false);
+        if (e.dataTransfer?.files?.length) {
+          void readFiles(e.dataTransfer.files);
+        }
+      }}
+    >
+      <div ref={containerRef} className="h-full" />
+
+      {/* File picker fallback — top-right corner */}
+      <div className="absolute right-2 top-2 z-10">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".yaml,.yml,application/yaml,application/x-yaml,text/yaml"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files?.length) {
+              void readFiles(e.target.files);
+              // Clear the input so re-selecting the same file fires onChange
+              e.target.value = "";
+            }
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="rounded-sm border border-border-strong bg-surface px-2.5 py-1 font-mono text-[11px] lowercase text-ink-muted transition-colors hover:border-accent hover:text-accent"
+        >
+          browse…
+        </button>
+      </div>
+
+      {/* Drag-active overlay */}
+      {dragging && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-bg/80 backdrop-blur-sm">
+          <p className="font-mono text-sm text-accent">
+            drop .yaml / .yml file(s)
+          </p>
+        </div>
+      )}
+
+      {/* Empty hint when buffer is empty and not dragging */}
+      {!dragging && value.trim().length === 0 && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-3 text-center font-mono text-[11px] text-ink-faint">
+          paste yaml above, or drag-drop / browse a file
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/apply/DocPreviewList.tsx
+++ b/web/src/components/apply/DocPreviewList.tsx
@@ -1,0 +1,101 @@
+// DocPreviewList — per-doc preview rows for the apply dialog.
+//
+// Renders one row per parsed doc with kind / apiVersion / namespace /
+// name and either a "ready" badge (parsed clean) or a "bad input"
+// badge with the parse error message. Status of dry-run / apply
+// results layers on top via the optional DocResult prop.
+
+import type { ParsedDoc } from "../../lib/applyYamlParser";
+import type { DocResult } from "../../hooks/useApplyYamlState";
+import { cn } from "../../lib/cn";
+
+interface DocPreviewListProps {
+  docs: ParsedDoc[];
+  results: ReadonlyMap<string, DocResult>;
+}
+
+const STATE_GLYPH: Record<DocResult["state"], string> = {
+  idle: "○",
+  pending: "◐",
+  success: "●",
+  failure: "✕",
+  conflict: "⚠",
+};
+
+const STATE_COLOR: Record<DocResult["state"], string> = {
+  idle: "text-ink-faint",
+  pending: "text-ink-muted",
+  success: "text-green",
+  failure: "text-red",
+  conflict: "text-yellow",
+};
+
+export function DocPreviewList({ docs, results }: DocPreviewListProps) {
+  if (docs.length === 0) return null;
+
+  return (
+    <ul className="mt-4 divide-y divide-border border-y border-border">
+      {docs.map((doc) => {
+        const result = results.get(doc.id);
+        const state: DocResult["state"] = result?.state ?? "idle";
+        return (
+          <li
+            key={doc.id}
+            className={cn(
+              "flex items-baseline gap-3 py-2",
+              !doc.valid && "bg-red-soft/30",
+            )}
+          >
+            <span
+              aria-hidden
+              className={cn("font-mono text-[14px] w-4 shrink-0", STATE_COLOR[state])}
+            >
+              {STATE_GLYPH[state]}
+            </span>
+
+            {doc.valid ? (
+              <>
+                <span className="font-mono text-[12.5px] text-ink tabular">
+                  {doc.kind}
+                </span>
+                <span className="font-mono text-[11px] text-ink-faint tabular">
+                  {doc.apiVersion}
+                </span>
+                <span className="text-[12.5px] text-ink-muted">
+                  {doc.namespace ? `${doc.namespace}/` : ""}
+                  <span className="text-ink">{doc.name}</span>
+                  {!doc.namespace && (
+                    <span className="ml-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+                      cluster-scoped
+                    </span>
+                  )}
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="font-mono text-[12.5px] text-red">
+                  bad input
+                </span>
+                <span className="text-[12.5px] text-ink-muted line-clamp-1">
+                  {doc.parseError}
+                </span>
+              </>
+            )}
+
+            {result?.errorMessage && (
+              <span
+                className={cn(
+                  "ml-auto truncate font-mono text-[11px]",
+                  STATE_COLOR[state],
+                )}
+                title={result.errorMessage}
+              >
+                {result.errorMessage}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/components/apply/DocPreviewList.tsx
+++ b/web/src/components/apply/DocPreviewList.tsx
@@ -4,7 +4,13 @@
 // name and either a "ready" badge (parsed clean) or a "bad input"
 // badge with the parse error message. Status of dry-run / apply
 // results layers on top via the optional DocResult prop.
+//
+// Conflict rows expose a per-row Force button that retries with
+// force=true (takeover semantics). Successful dry-runs expose an
+// expandable diff so the operator can verify what would change before
+// committing.
 
+import { useState } from "react";
 import type { ParsedDoc } from "../../lib/applyYamlParser";
 import type { DocResult } from "../../hooks/useApplyYamlState";
 import { cn } from "../../lib/cn";
@@ -12,6 +18,13 @@ import { cn } from "../../lib/cn";
 interface DocPreviewListProps {
   docs: ParsedDoc[];
   results: ReadonlyMap<string, DocResult>;
+  /**
+   * Called when the operator clicks the per-row "Force" button on a
+   * conflict result. The dialog wires this to forceApplyOne(doc, cluster).
+   */
+  onForce?: (doc: ParsedDoc) => void;
+  /** Disabled state for force buttons (e.g. while a batch is running). */
+  forceDisabled?: boolean;
 }
 
 const STATE_GLYPH: Record<DocResult["state"], string> = {
@@ -30,72 +43,123 @@ const STATE_COLOR: Record<DocResult["state"], string> = {
   conflict: "text-yellow",
 };
 
-export function DocPreviewList({ docs, results }: DocPreviewListProps) {
+export function DocPreviewList({
+  docs,
+  results,
+  onForce,
+  forceDisabled,
+}: DocPreviewListProps) {
   if (docs.length === 0) return null;
 
   return (
     <ul className="mt-4 divide-y divide-border border-y border-border">
-      {docs.map((doc) => {
-        const result = results.get(doc.id);
-        const state: DocResult["state"] = result?.state ?? "idle";
-        return (
-          <li
-            key={doc.id}
-            className={cn(
-              "flex items-baseline gap-3 py-2",
-              !doc.valid && "bg-red-soft/30",
-            )}
-          >
-            <span
-              aria-hidden
-              className={cn("font-mono text-[14px] w-4 shrink-0", STATE_COLOR[state])}
-            >
-              {STATE_GLYPH[state]}
-            </span>
-
-            {doc.valid ? (
-              <>
-                <span className="font-mono text-[12.5px] text-ink tabular">
-                  {doc.kind}
-                </span>
-                <span className="font-mono text-[11px] text-ink-faint tabular">
-                  {doc.apiVersion}
-                </span>
-                <span className="text-[12.5px] text-ink-muted">
-                  {doc.namespace ? `${doc.namespace}/` : ""}
-                  <span className="text-ink">{doc.name}</span>
-                  {!doc.namespace && (
-                    <span className="ml-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
-                      cluster-scoped
-                    </span>
-                  )}
-                </span>
-              </>
-            ) : (
-              <>
-                <span className="font-mono text-[12.5px] text-red">
-                  bad input
-                </span>
-                <span className="text-[12.5px] text-ink-muted line-clamp-1">
-                  {doc.parseError}
-                </span>
-              </>
-            )}
-
-            {result?.errorMessage && (
-              <span
-                className={cn(
-                  "ml-auto truncate font-mono text-[11px]",
-                  STATE_COLOR[state],
-                )}
-                title={result.errorMessage}
-              >
-                {result.errorMessage}
-              </span>
-            )}
-          </li>
-        );
-      })}
+      {docs.map((doc) => (
+        <DocPreviewRow
+          key={doc.id}
+          doc={doc}
+          result={results.get(doc.id)}
+          onForce={onForce}
+          forceDisabled={forceDisabled}
+        />
+      ))}
     </ul>
+  );
+}
+
+interface DocPreviewRowProps {
+  doc: ParsedDoc;
+  result: DocResult | undefined;
+  onForce?: (doc: ParsedDoc) => void;
+  forceDisabled?: boolean;
+}
+
+function DocPreviewRow({ doc, result, onForce, forceDisabled }: DocPreviewRowProps) {
+  const [diffOpen, setDiffOpen] = useState(false);
+  const state: DocResult["state"] = result?.state ?? "idle";
+  const hasDiff = state === "success" && Boolean(result?.diff);
+
+  return (
+    <li
+      className={cn(
+        "flex flex-col py-2",
+        !doc.valid && "bg-red-soft/30",
+      )}
+    >
+      <div className="flex items-baseline gap-3">
+        <span
+          aria-hidden
+          className={cn("font-mono text-[14px] w-4 shrink-0", STATE_COLOR[state])}
+        >
+          {STATE_GLYPH[state]}
+        </span>
+
+        {doc.valid ? (
+          <>
+            <span className="font-mono text-[12.5px] text-ink tabular">
+              {doc.kind}
+            </span>
+            <span className="font-mono text-[11px] text-ink-faint tabular">
+              {doc.apiVersion}
+            </span>
+            <span className="text-[12.5px] text-ink-muted">
+              {doc.namespace ? `${doc.namespace}/` : ""}
+              <span className="text-ink">{doc.name}</span>
+              {!doc.namespace && (
+                <span className="ml-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+                  cluster-scoped
+                </span>
+              )}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="font-mono text-[12.5px] text-red">bad input</span>
+            <span className="text-[12.5px] text-ink-muted line-clamp-1">
+              {doc.parseError}
+            </span>
+          </>
+        )}
+
+        <div className="ml-auto flex shrink-0 items-baseline gap-2">
+          {result?.errorMessage && (
+            <span
+              className={cn(
+                "max-w-[26ch] truncate font-mono text-[11px]",
+                STATE_COLOR[state],
+              )}
+              title={result.errorMessage}
+            >
+              {result.errorMessage}
+            </span>
+          )}
+          {state === "conflict" && onForce && (
+            <button
+              type="button"
+              onClick={() => onForce(doc)}
+              disabled={forceDisabled}
+              title="Retry this doc with force=true (takeover ownership of conflicting fields)"
+              className="rounded-sm border border-yellow-soft bg-yellow-soft px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.08em] text-yellow transition-[filter] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              force
+            </button>
+          )}
+          {hasDiff && (
+            <button
+              type="button"
+              onClick={() => setDiffOpen((o) => !o)}
+              className="font-mono text-[10.5px] lowercase tracking-[0.04em] text-ink-muted underline-offset-2 hover:text-accent hover:underline"
+            >
+              {diffOpen ? "hide diff" : "show diff"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {hasDiff && diffOpen && result?.diff && (
+        <pre className="ml-7 mt-2 max-h-72 overflow-auto rounded-sm border border-border bg-bg p-3 font-mono text-[11px] leading-[1.4] text-ink-muted">
+          {result.diff}
+        </pre>
+      )}
+    </li>
   );
 }

--- a/web/src/hooks/useApplyYamlState.ts
+++ b/web/src/hooks/useApplyYamlState.ts
@@ -55,6 +55,8 @@ export interface UseApplyYamlState {
   runDryRun: (cluster: string) => Promise<void>;
   /** Run real apply for every valid doc. Skips docs with parse errors. */
   runApply: (cluster: string) => Promise<void>;
+  /** Retry a single conflicted doc with force=true. */
+  forceApplyOne: (doc: ParsedDoc, cluster: string) => Promise<void>;
 }
 
 export function useApplyYamlState(): UseApplyYamlState {
@@ -133,6 +135,47 @@ export function useApplyYamlState(): UseApplyYamlState {
     [updateResult],
   );
 
+  /**
+   * forceApplyOne — retry a single doc with force=true. Used when
+   * runApply() leaves a doc in `conflict` state and the operator
+   * confirms takeover via the per-row Force button. Independent of
+   * the batch worker pool — runs immediately, ignores the busy
+   * state machine, and updates only this doc's result entry.
+   */
+  const forceApplyOne = useCallback(
+    async (doc: ParsedDoc, cluster: string): Promise<void> => {
+      if (!doc.valid || !doc.apiVersion || !doc.kind || !doc.name) return;
+      const gvr = gvrFromApiVersionAndKind(doc.apiVersion, doc.kind);
+      const ctrl = new AbortController();
+      updateResult(doc.id, { state: "pending" });
+      try {
+        await api.applyResource(
+          {
+            cluster,
+            group: gvr.group,
+            version: gvr.version,
+            resource: gvr.resource,
+            namespace: doc.namespace,
+            name: doc.name,
+            yaml: doc.raw,
+            force: true,
+          },
+          ctrl.signal,
+        );
+        updateResult(doc.id, { state: "success" });
+      } catch (err) {
+        const apiErr = err instanceof ApiError ? err : null;
+        updateResult(doc.id, {
+          state: "failure",
+          errorMessage: errorMessage(err),
+          error: apiErr ?? undefined,
+        });
+      }
+    },
+    [updateResult],
+  );
+
+
   const runBatch = useCallback(
     async (cluster: string, dryRun: boolean): Promise<void> => {
       if (busy !== "idle") return;
@@ -186,6 +229,7 @@ export function useApplyYamlState(): UseApplyYamlState {
     reset,
     runDryRun,
     runApply,
+    forceApplyOne,
   };
 }
 

--- a/web/src/hooks/useApplyYamlState.ts
+++ b/web/src/hooks/useApplyYamlState.ts
@@ -1,0 +1,63 @@
+// useApplyYamlState — owns the ApplyYamlDialog's state.
+//
+// Lifted out of the dialog component so it can be tested in isolation
+// (parsing + result transitions) without dragging in Modal / Monaco.
+//
+// Skeleton in this commit; orchestration arrives in later commits.
+
+import { useCallback, useMemo, useState } from "react";
+import { type ParsedDoc, parseMultiDocYaml } from "../lib/applyYamlParser";
+import type { ApiError } from "../lib/api";
+
+export type DocResultState =
+  | "idle"
+  | "pending"
+  | "success"
+  | "failure"
+  | "conflict";
+
+export interface DocResult {
+  state: DocResultState;
+  /** Dry-run output rendered as a YAML/diff string. */
+  diff?: string;
+  /** Human-readable error message; populated on `failure` / `conflict`. */
+  errorMessage?: string;
+  /** Underlying error for handlers that want to inspect status codes. */
+  error?: ApiError;
+}
+
+export type DialogBusy = "idle" | "dry-run" | "apply";
+
+export interface UseApplyYamlState {
+  yamlText: string;
+  setYamlText: (next: string) => void;
+  docs: ParsedDoc[];
+  results: ReadonlyMap<string, DocResult>;
+  busy: DialogBusy;
+  /**
+   * Reset everything except cluster context. Called when the operator
+   * closes the dialog or hits a Clear action.
+   */
+  reset: () => void;
+}
+
+export function useApplyYamlState(): UseApplyYamlState {
+  const [yamlText, setYamlText] = useState("");
+  const [busy] = useState<DialogBusy>("idle");
+  const [results] = useState<Map<string, DocResult>>(() => new Map());
+
+  const docs = useMemo(() => parseMultiDocYaml(yamlText), [yamlText]);
+
+  const reset = useCallback(() => {
+    setYamlText("");
+  }, []);
+
+  return {
+    yamlText,
+    setYamlText,
+    docs,
+    results,
+    busy,
+    reset,
+  };
+}

--- a/web/src/hooks/useApplyYamlState.ts
+++ b/web/src/hooks/useApplyYamlState.ts
@@ -3,11 +3,24 @@
 // Lifted out of the dialog component so it can be tested in isolation
 // (parsing + result transitions) without dragging in Modal / Monaco.
 //
-// Skeleton in this commit; orchestration arrives in later commits.
+// Responsibilities:
+//   - yamlText buffer, parsed-doc derivation
+//   - per-doc results map (dry-run + apply outcomes)
+//   - busy state machine (idle | dry-run | apply)
+//   - concurrent dry-run / apply orchestration with a 6-way fan-out
+//     limiter (matches multiYaml.ts; same browser-connection-budget
+//     reasoning)
+//   - cancel via AbortController
 
-import { useCallback, useMemo, useState } from "react";
-import { type ParsedDoc, parseMultiDocYaml } from "../lib/applyYamlParser";
-import type { ApiError } from "../lib/api";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  type ParsedDoc,
+  parseMultiDocYaml,
+  gvrFromApiVersionAndKind,
+} from "../lib/applyYamlParser";
+import { ApiError, api } from "../lib/api";
+
+const MAX_PARALLEL = 6;
 
 export type DocResultState =
   | "idle"
@@ -34,23 +47,134 @@ export interface UseApplyYamlState {
   docs: ParsedDoc[];
   results: ReadonlyMap<string, DocResult>;
   busy: DialogBusy;
-  /**
-   * Reset everything except cluster context. Called when the operator
-   * closes the dialog or hits a Clear action.
-   */
+  /** Cancel any in-flight orchestration. No-op when idle. */
+  cancel: () => void;
+  /** Reset everything. Called when the dialog closes or operator clears. */
   reset: () => void;
+  /** Run dry-run for every valid doc; populates results.diff per doc. */
+  runDryRun: (cluster: string) => Promise<void>;
+  /** Run real apply for every valid doc. Skips docs with parse errors. */
+  runApply: (cluster: string) => Promise<void>;
 }
 
 export function useApplyYamlState(): UseApplyYamlState {
   const [yamlText, setYamlText] = useState("");
-  const [busy] = useState<DialogBusy>("idle");
-  const [results] = useState<Map<string, DocResult>>(() => new Map());
+  const [busy, setBusy] = useState<DialogBusy>("idle");
+  const [results, setResults] = useState<Map<string, DocResult>>(
+    () => new Map(),
+  );
+  const abortRef = useRef<AbortController | null>(null);
 
   const docs = useMemo(() => parseMultiDocYaml(yamlText), [yamlText]);
 
   const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
     setYamlText("");
+    setResults(new Map());
+    setBusy("idle");
   }, []);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const updateResult = useCallback((id: string, patch: DocResult) => {
+    setResults((prev) => {
+      const next = new Map(prev);
+      next.set(id, patch);
+      return next;
+    });
+  }, []);
+
+  const runOne = useCallback(
+    async (
+      doc: ParsedDoc,
+      cluster: string,
+      dryRun: boolean,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (!doc.valid || !doc.apiVersion || !doc.kind || !doc.name) return;
+      const gvr = gvrFromApiVersionAndKind(doc.apiVersion, doc.kind);
+      updateResult(doc.id, { state: "pending" });
+      try {
+        const response = await api.applyResource(
+          {
+            cluster,
+            group: gvr.group,
+            version: gvr.version,
+            resource: gvr.resource,
+            namespace: doc.namespace,
+            name: doc.name,
+            yaml: doc.raw,
+            dryRun,
+          },
+          signal,
+        );
+        // applyResource returns the post-apply object as JSON. For
+        // dry-run we render it as the diff payload; for real apply we
+        // just mark success.
+        updateResult(doc.id, {
+          state: "success",
+          diff: dryRun ? safeStringify(response) : undefined,
+        });
+      } catch (err) {
+        if (signal.aborted) return;
+        const apiErr = err instanceof ApiError ? err : null;
+        const status = apiErr?.status ?? 0;
+        const isConflict = status === 409;
+        updateResult(doc.id, {
+          state: isConflict ? "conflict" : "failure",
+          errorMessage: errorMessage(err),
+          error: apiErr ?? undefined,
+        });
+      }
+    },
+    [updateResult],
+  );
+
+  const runBatch = useCallback(
+    async (cluster: string, dryRun: boolean): Promise<void> => {
+      if (busy !== "idle") return;
+      const valid = docs.filter((d) => d.valid);
+      if (valid.length === 0) return;
+
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setBusy(dryRun ? "dry-run" : "apply");
+
+      // Worker-pool concurrency limiter. Pull next index off `cursor`
+      // until exhausted. Same shape as multiYaml.ts.
+      let cursor = 0;
+      const worker = async () => {
+        while (true) {
+          if (ctrl.signal.aborted) return;
+          const idx = cursor++;
+          if (idx >= valid.length) return;
+          await runOne(valid[idx], cluster, dryRun, ctrl.signal);
+        }
+      };
+
+      try {
+        await Promise.all(
+          Array.from({ length: Math.min(MAX_PARALLEL, valid.length) }, worker),
+        );
+      } finally {
+        if (abortRef.current === ctrl) abortRef.current = null;
+        setBusy("idle");
+      }
+    },
+    [busy, docs, runOne],
+  );
+
+  const runDryRun = useCallback(
+    (cluster: string) => runBatch(cluster, true),
+    [runBatch],
+  );
+  const runApply = useCallback(
+    (cluster: string) => runBatch(cluster, false),
+    [runBatch],
+  );
 
   return {
     yamlText,
@@ -58,6 +182,27 @@ export function useApplyYamlState(): UseApplyYamlState {
     docs,
     results,
     busy,
+    cancel,
     reset,
+    runDryRun,
+    runApply,
   };
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return "";
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    // The error message has the URL in it; trim to the status part for
+    // a tidier per-doc display.
+    return err.message.replace(/ on \/api\/.*$/, "");
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
 }

--- a/web/src/lib/applyYamlParser.test.ts
+++ b/web/src/lib/applyYamlParser.test.ts
@@ -1,0 +1,231 @@
+// applyYamlParser tests — parser correctness + GVR mapping. Both are
+// pure functions with no React / DOM dependencies, so they fit the
+// existing vitest node environment cleanly.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseMultiDocYaml,
+  gvrFromApiVersionAndKind,
+} from "./applyYamlParser";
+
+describe("parseMultiDocYaml", () => {
+  it("returns no docs for empty input", () => {
+    expect(parseMultiDocYaml("")).toEqual([]);
+    expect(parseMultiDocYaml("   \n\n  ")).toEqual([]);
+  });
+
+  it("parses a single valid doc", () => {
+    const input = `apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: default
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.27
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].valid).toBe(true);
+    expect(docs[0].apiVersion).toBe("v1");
+    expect(docs[0].kind).toBe("Pod");
+    expect(docs[0].name).toBe("nginx");
+    expect(docs[0].namespace).toBe("default");
+    expect(docs[0].parseError).toBeUndefined();
+  });
+
+  it("parses multiple docs separated by ---", () => {
+    const input = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  namespace: prod
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b
+  namespace: prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: c
+  namespace: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: c
+  template:
+    metadata:
+      labels:
+        app: c
+    spec:
+      containers:
+        - name: c
+          image: nginx:1.27
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(3);
+    expect(docs.map((d) => d.kind)).toEqual([
+      "ConfigMap",
+      "ConfigMap",
+      "Deployment",
+    ]);
+    expect(docs.every((d) => d.valid)).toBe(true);
+  });
+
+  it("treats cluster-scoped resources (no namespace) as valid", () => {
+    const input = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-cr
+rules: []
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].valid).toBe(true);
+    expect(docs[0].namespace).toBeUndefined();
+  });
+
+  it("flags missing required fields", () => {
+    const input = `metadata:
+  name: orphan
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].valid).toBe(false);
+    expect(docs[0].parseError).toMatch(/missing required field/);
+    expect(docs[0].parseError).toContain("apiVersion");
+    expect(docs[0].parseError).toContain("kind");
+  });
+
+  it("isolates parse errors per doc — bad doc doesn't kill the rest", () => {
+    const input = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: good-1
+---
+this: is: not: valid: yaml::
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: good-2
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(3);
+    expect(docs[0].valid).toBe(true);
+    expect(docs[0].name).toBe("good-1");
+    expect(docs[1].valid).toBe(false);
+    expect(docs[1].parseError).toBeTruthy();
+    expect(docs[2].valid).toBe(true);
+    expect(docs[2].name).toBe("good-2");
+  });
+
+  it("skips empty docs from leading / trailing separators", () => {
+    // Leading and trailing `---` shouldn't produce empty ParsedDoc entries.
+    const input = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: only
+---
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].name).toBe("only");
+  });
+
+  it("preserves verbatim raw text per doc (slicing from source)", () => {
+    const input = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  # inline comment that must survive
+data:
+  key: value
+`;
+    const docs = parseMultiDocYaml(input);
+    expect(docs[0].raw).toContain("inline comment that must survive");
+  });
+
+  it("generates stable IDs per doc", () => {
+    const input = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+`;
+    const ids1 = parseMultiDocYaml(input).map((d) => d.id);
+    const ids2 = parseMultiDocYaml(input).map((d) => d.id);
+    expect(ids1).toEqual(ids2);
+    // Different content → different IDs
+    const ids3 = parseMultiDocYaml(input + "data:\n  k: v\n").map((d) => d.id);
+    expect(ids3[0]).not.toBe(ids1[0]);
+  });
+});
+
+describe("gvrFromApiVersionAndKind", () => {
+  it("maps known core/v1 kinds via KIND_REGISTRY", () => {
+    expect(gvrFromApiVersionAndKind("v1", "Pod")).toEqual({
+      group: "",
+      version: "v1",
+      resource: "pods",
+    });
+    expect(gvrFromApiVersionAndKind("v1", "ConfigMap")).toEqual({
+      group: "",
+      version: "v1",
+      resource: "configmaps",
+    });
+  });
+
+  it("maps known grouped kinds (apps/v1, rbac/v1) via KIND_REGISTRY", () => {
+    expect(gvrFromApiVersionAndKind("apps/v1", "Deployment")).toEqual({
+      group: "apps",
+      version: "v1",
+      resource: "deployments",
+    });
+    expect(
+      gvrFromApiVersionAndKind("rbac.authorization.k8s.io/v1", "ClusterRole"),
+    ).toEqual({
+      group: "rbac.authorization.k8s.io",
+      version: "v1",
+      resource: "clusterroles",
+    });
+  });
+
+  it("falls back to lowercase + s for unknown kinds (CRDs)", () => {
+    expect(gvrFromApiVersionAndKind("cert-manager.io/v1", "Certificate")).toEqual({
+      group: "cert-manager.io",
+      version: "v1",
+      resource: "certificates",
+    });
+    expect(
+      gvrFromApiVersionAndKind("custom.example.com/v1", "MyResource"),
+    ).toEqual({
+      group: "custom.example.com",
+      version: "v1",
+      resource: "myresources",
+    });
+  });
+
+  it("does not double-pluralize kinds already ending in s", () => {
+    // "Endpoints" is the canonical kind name — already plural.
+    expect(gvrFromApiVersionAndKind("v1", "Endpoints")).toEqual({
+      group: "",
+      version: "v1",
+      // KIND_REGISTRY doesn't include Endpoints; falls through to
+      // fallback. Since "Endpoints" ends in 's', we keep it.
+      resource: "endpoints",
+    });
+  });
+
+  it("preserves empty group for core (apiVersion='v1')", () => {
+    // api.applyResource handles empty-group → 'core' URL substitution
+    // server-side; the helper should pass "" through verbatim.
+    const gvr = gvrFromApiVersionAndKind("v1", "ConfigMap");
+    expect(gvr.group).toBe("");
+  });
+});

--- a/web/src/lib/applyYamlParser.ts
+++ b/web/src/lib/applyYamlParser.ts
@@ -1,0 +1,31 @@
+// applyYamlParser — splits a multi-doc YAML blob into per-doc records,
+// extracts the four fields the apply pipeline needs (apiVersion, kind,
+// metadata.name, metadata.namespace), and surfaces parse errors at the
+// doc level so the dialog can show "doc 3 of 5: bad indent" without
+// failing the entire paste.
+//
+// Stub in this commit; real parsing arrives in a later commit of the
+// same PR.
+
+export interface ParsedDoc {
+  /** Stable ID for React keys. Hash of (raw + index). */
+  id: string;
+  /** Original YAML text for this single document. */
+  raw: string;
+  /** True when the four required fields are present and YAML parsed clean. */
+  valid: boolean;
+  apiVersion?: string;
+  kind?: string;
+  name?: string;
+  namespace?: string;
+  /** Human-readable YAML / validation error. */
+  parseError?: string;
+}
+
+/**
+ * parseMultiDocYaml — placeholder; returns no docs. Real implementation
+ * lands in the parser commit.
+ */
+export function parseMultiDocYaml(_yamlText: string): ParsedDoc[] {
+  return [];
+}

--- a/web/src/lib/applyYamlParser.ts
+++ b/web/src/lib/applyYamlParser.ts
@@ -142,3 +142,58 @@ function stableHash(s: string): string {
   }
   return (h >>> 0).toString(16).padStart(8, "0");
 }
+
+import { KIND_REGISTRY } from "./k8sKinds";
+
+export interface GVR {
+  group: string;
+  version: string;
+  resource: string;
+}
+
+/**
+ * gvrFromApiVersionAndKind splits a Kubernetes apiVersion + kind into
+ * the (group, version, resource) tuple Periscope's apply endpoint
+ * expects.
+ *
+ * For known built-in kinds (Pod / Deployment / ConfigMap / …), the
+ * resource plural comes from KIND_REGISTRY. For unknown kinds — most
+ * commonly Custom Resource Definitions whose plural varies —
+ * fall back to the naive "lowercase + 's'" pluralization. The
+ * apiserver will return a clear 404 on the apply call if the plural
+ * is wrong, which surfaces in the per-doc result panel.
+ *
+ * apiVersion conventions:
+ *   - "v1"          → group="" (core), version="v1"
+ *   - "apps/v1"     → group="apps", version="v1"
+ *   - "rbac.authorization.k8s.io/v1" → group="rbac.…", version="v1"
+ *
+ * Periscope's URL convention rewrites empty group to "core" — that
+ * substitution happens server-side in cmd/periscope/main.go, so we
+ * pass "" through and the existing api.applyResource handles it.
+ */
+export function gvrFromApiVersionAndKind(
+  apiVersion: string,
+  kind: string,
+): GVR {
+  const slash = apiVersion.indexOf("/");
+  const group = slash === -1 ? "" : apiVersion.slice(0, slash);
+  const version = slash === -1 ? apiVersion : apiVersion.slice(slash + 1);
+
+  // Reverse lookup: kind ("Pod") → KindMeta entry. KIND_REGISTRY is
+  // indexed by YamlKind (the URL-segment plural).
+  for (const meta of Object.values(KIND_REGISTRY)) {
+    if (meta.kind === kind) {
+      return { group: meta.group, version: meta.version, resource: meta.resource };
+    }
+  }
+
+  // Fallback: naive pluralization. Works for ~80% of CRD names that
+  // follow the noun + 's' convention. For irregulars (NetworkPolicy →
+  // networkpolicies, Endpoints → endpoints), the server will 404.
+  return {
+    group,
+    version,
+    resource: kind.toLowerCase() + (kind.endsWith("s") ? "" : "s"),
+  };
+}

--- a/web/src/lib/applyYamlParser.ts
+++ b/web/src/lib/applyYamlParser.ts
@@ -74,7 +74,14 @@ export function parseMultiDocYaml(yamlText: string): ParsedDoc[] {
     }
 
     const obj = doc.toJS() as unknown;
-    if (obj == null || typeof obj !== "object") {
+    if (obj == null) {
+      // Empty doc (e.g. content between adjacent --- separators,
+      // or trailing --- with no body). Silently skip rather than
+      // emit a parseError — this is a YAML quirk, not user fault.
+      idx += 1;
+      continue;
+    }
+    if (typeof obj !== "object") {
       out.push({
         id,
         raw,

--- a/web/src/lib/applyYamlParser.ts
+++ b/web/src/lib/applyYamlParser.ts
@@ -4,28 +4,141 @@
 // doc level so the dialog can show "doc 3 of 5: bad indent" without
 // failing the entire paste.
 //
-// Stub in this commit; real parsing arrives in a later commit of the
-// same PR.
+// Built on the `yaml` package's parseAllDocuments — same library the
+// existing inline editor uses (yamlPatch.ts, k8sSchema.ts).
+
+import { parseAllDocuments } from "yaml";
 
 export interface ParsedDoc {
-  /** Stable ID for React keys. Hash of (raw + index). */
+  /** Stable ID for React keys. Hash of raw + index. */
   id: string;
-  /** Original YAML text for this single document. */
+  /** Original YAML text for this single document, normalised (no leading separator). */
   raw: string;
-  /** True when the four required fields are present and YAML parsed clean. */
+  /** True when YAML parsed clean AND the four required fields are present. */
   valid: boolean;
   apiVersion?: string;
   kind?: string;
   name?: string;
   namespace?: string;
-  /** Human-readable YAML / validation error. */
+  /** Human-readable error covering YAML parse OR missing-field issues. */
   parseError?: string;
 }
 
 /**
- * parseMultiDocYaml — placeholder; returns no docs. Real implementation
- * lands in the parser commit.
+ * parseMultiDocYaml splits the input on YAML document boundaries
+ * (`---`) and parses each segment.
+ *
+ * Empty leading / trailing whitespace-only documents are dropped; this
+ * is consistent with `kubectl apply -f`'s behaviour on multi-doc files
+ * that start or end with a `---` separator.
+ *
+ * Validation: each doc must have `apiVersion`, `kind`, and
+ * `metadata.name`. `metadata.namespace` is optional (cluster-scoped
+ * resources don't have one). Missing fields surface as `parseError`
+ * rather than throwing.
  */
-export function parseMultiDocYaml(_yamlText: string): ParsedDoc[] {
-  return [];
+export function parseMultiDocYaml(yamlText: string): ParsedDoc[] {
+  if (yamlText.trim().length === 0) return [];
+
+  // parseAllDocuments handles `---` separators and tracks per-doc
+  // ranges in the source via Document#range. We use the range to slice
+  // the original text so each ParsedDoc.raw is the verbatim YAML the
+  // operator wrote, including comments and formatting — important for
+  // the apply call (server-side YAML normalisation has surprises).
+  const docs = parseAllDocuments(yamlText);
+  const out: ParsedDoc[] = [];
+  let idx = 0;
+
+  for (const doc of docs) {
+    const range = doc.range; // [contentStart, contentEnd, eofOrNextStart]
+    const sliceStart = range?.[0] ?? 0;
+    const sliceEnd = range?.[1] ?? yamlText.length;
+    const raw = yamlText.slice(sliceStart, sliceEnd).trim();
+
+    // parseAllDocuments emits an empty doc for buffers like "---\n---\n"
+    // where there's no content between separators. Skip those.
+    if (raw.length === 0 || doc.contents == null) {
+      continue;
+    }
+
+    const id = `doc-${idx}-${stableHash(raw)}`;
+
+    // YAML-level errors (bad indent, unclosed quote, etc.) come back
+    // on doc.errors. Surface the first one; the rest are usually
+    // cascades of the same root cause.
+    const yamlError = doc.errors?.[0]?.message;
+    if (yamlError) {
+      out.push({ id, raw, valid: false, parseError: yamlError });
+      idx += 1;
+      continue;
+    }
+
+    const obj = doc.toJS() as unknown;
+    if (obj == null || typeof obj !== "object") {
+      out.push({
+        id,
+        raw,
+        valid: false,
+        parseError: "document is not a YAML mapping",
+      });
+      idx += 1;
+      continue;
+    }
+    const meta = (obj as { metadata?: { name?: unknown; namespace?: unknown } })
+      .metadata;
+    const apiVersion = (obj as { apiVersion?: unknown }).apiVersion;
+    const kind = (obj as { kind?: unknown }).kind;
+    const name = meta?.name;
+    const namespace = meta?.namespace;
+
+    const missing: string[] = [];
+    if (typeof apiVersion !== "string" || apiVersion.length === 0) {
+      missing.push("apiVersion");
+    }
+    if (typeof kind !== "string" || kind.length === 0) {
+      missing.push("kind");
+    }
+    if (typeof name !== "string" || name.length === 0) {
+      missing.push("metadata.name");
+    }
+
+    if (missing.length > 0) {
+      out.push({
+        id,
+        raw,
+        valid: false,
+        apiVersion: typeof apiVersion === "string" ? apiVersion : undefined,
+        kind: typeof kind === "string" ? kind : undefined,
+        name: typeof name === "string" ? name : undefined,
+        namespace: typeof namespace === "string" ? namespace : undefined,
+        parseError: `missing required field(s): ${missing.join(", ")}`,
+      });
+      idx += 1;
+      continue;
+    }
+
+    out.push({
+      id,
+      raw,
+      valid: true,
+      apiVersion: apiVersion as string,
+      kind: kind as string,
+      name: name as string,
+      namespace: typeof namespace === "string" ? namespace : undefined,
+    });
+    idx += 1;
+  }
+
+  return out;
+}
+
+// stableHash — non-cryptographic 32-bit FNV-1a, just enough to disambiguate
+// React keys when two adjacent docs have similar but distinct content.
+function stableHash(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
 }


### PR DESCRIPTION
## Summary

Sub-task **#53** of the Apply YAML epic (#51). Implements the operator-facing `<ApplyYamlDialog>` — paste / upload arbitrary YAML, parse multi-doc, dry-run, apply, surface results per doc.

This is the substantive frontend piece. Once it merges:
- **#54** (UI button + Cmd+K palette) becomes two trivial mount points
- **#55** (RBAC pre-flight via can-i) layers on top of the parsed-docs list

## What lands

```
src/components/apply/
  ApplyYamlDialog.tsx       — modal owner (header / body / footer)
  ApplyYamlInput.tsx        — writable Monaco + drag-drop + file picker
  DocPreviewList.tsx        — per-doc rows with status + force + diff toggle
src/hooks/
  useApplyYamlState.ts      — state hook (yamlText / docs / results / busy / orchestration)
src/lib/
  applyYamlParser.ts        — parseMultiDocYaml + gvrFromApiVersionAndKind
  applyYamlParser.test.ts   — 14 vitest cases
```

## Six logical commits (squash-merge friendly, but each reviewable on its own)

1. `feat(web): scaffold ApplyYamlDialog modal + state shell`
2. `feat(web): add YAML input — Monaco textarea + drag-drop + file picker`
3. `feat(web): multi-doc YAML parser + per-doc preview rows`
4. `feat(web): dry-run + apply orchestration with concurrency limiter`
5. `feat(web): per-doc conflict force + expandable dry-run diff`
6. `test(web): vitest for parser + GVR mapping`

Reviewing commit-by-commit gives a clean reading order.

## Decisions locked (per #53's "leans")

- **Manual dry-run** (button click), not typing-driven — N apiserver round-trips per keystroke is bad math
- **Apply does NOT auto-dry-run** — operator already saw the dry-run; extra round-trip costs latency
- **Concurrency cap = 6** — same browser-connection-budget reasoning as `multiYaml.ts`
- **Force is per-doc** on conflict, not a batch toggle — multi-doc apply is coarse already; per-doc force keeps the takeover surgical-ish

## Composition with existing primitives

- `<Modal>` (sized `lg` = 1100px) — same shell as `DeleteResourceModal`, `EditLabelsModal`
- `api.applyResource({...args, dryRun, force})` — already accepts both; no backend change needed
- `KIND_REGISTRY` — kind-to-GVR mapping for built-in kinds; naive plural fallback for CRDs
- `yaml` package — same lib `lib/yamlPatch.ts` and `lib/k8sSchema.ts` already use
- Worker-pool concurrency pattern — adapted from `lib/multiYaml.ts`

## Verification

- `npx tsc -b` ✓
- `npm run lint` ✓
- `npx vitest run` — **111/111 pass** including 14 new parser/GVR cases
- `npm run build` — production build clean (Monaco bundle already chunked from prior YamlEditor usage; no regression)

## Out of scope (per #53 acceptance)

- Backend changes — sub-task **#52** already shipped (PR #81)
- UI placement / mount points (cluster nav button, Cmd+K palette command) — sub-task **#54**
- RBAC pre-flight — sub-task **#55**

## Component test coverage

The parser + GVR mapping have full vitest coverage. **Component-level tests** (dialog interactions, drag-drop, conflict UI) need `@testing-library/react` + `happy-dom` — that's tracked as separate test-infra work in **#27**. Deferred per the existing convention; this PR doesn't gate on it.

## Reviewer

Tagging @yogen9 — this is the meaty one. Six commits walk the build cleanly; the parser tests are the easiest entry point if you want to start there.

Refs #51.
