### PR TITLE
feat(web): Apply YAML mount points — PageHeader + Cmd+K + Overview banner (#54)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { Drawer } from "./exec/Drawer";
 import { Toaster } from "./lib/toast";
 import { SearchPalette } from "./components/search/SearchPalette";
 import { GlobalFetchingBar } from "./components/shell/GlobalFetchingBar";
+import { ApplyDialogProvider } from "./components/apply/ApplyDialogProvider";
 import { useAuth } from "./auth/useAuth";
 import { LoginScreen } from "./auth/LoginScreen";
 import { useTheme } from "./hooks/useTheme";
@@ -55,6 +56,7 @@ export default function App() {
 
   return (
     <ExecSessionsProvider>
+      <ApplyDialogProvider>
       <div className="flex h-full flex-col">
         <GlobalFetchingBar />
         <div className="min-h-0 flex-1 overflow-hidden">
@@ -64,6 +66,7 @@ export default function App() {
         <Drawer />
         <Toaster />
       </div>
+      </ApplyDialogProvider>
     </ExecSessionsProvider>
   );
 }

--- a/web/src/components/apply/ApplyDialogProvider.tsx
+++ b/web/src/components/apply/ApplyDialogProvider.tsx
@@ -1,0 +1,31 @@
+// ApplyDialogProvider — single-instance ApplyYamlDialog mounted at the
+// App root, opened from anywhere via useApplyDialog().
+//
+// Both entry points (the Sidebar button and the Cmd+K palette's quick
+// action) need to be able to open the dialog without owning it
+// themselves. Without a shared mount, the SearchPalette's own dialog
+// would unmount the moment the palette closes (palette's body returns
+// null when !open), losing the dialog mid-flight.
+//
+// Lives at App level so the dialog persists across page navigations
+// while it's open.
+
+import { useCallback, useState, type ReactNode } from "react";
+import { ApplyYamlDialog } from "./ApplyYamlDialog";
+import { ApplyDialogContext } from "../../contexts/applyDialog";
+
+export function ApplyDialogProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<string | null>(null);
+
+  const open = useCallback((cluster: string) => setTarget(cluster), []);
+  const close = useCallback(() => setTarget(null), []);
+
+  return (
+    <ApplyDialogContext.Provider value={{ open }}>
+      {children}
+      {target !== null && (
+        <ApplyYamlDialog open={true} onClose={close} cluster={target} />
+      )}
+    </ApplyDialogContext.Provider>
+  );
+}

--- a/web/src/components/apply/ApplyYamlEntry.tsx
+++ b/web/src/components/apply/ApplyYamlEntry.tsx
@@ -1,11 +1,15 @@
-// ApplyYamlEntry — Sidebar button that opens the shared
-// ApplyYamlDialog via useApplyDialog().
+// ApplyYamlEntry — button that opens the shared ApplyYamlDialog via
+// useApplyDialog().
 //
-// Mounted inside the cluster Sidebar above the resource navigation.
+// Mounted in PageHeader (right-side action row, between the page's
+// trailing slot and ThemeToggle), and in OverviewPage's
+// ClusterIdentityBanner. The dialog itself lives once at App level
+// via ApplyDialogProvider so multiple entry points share a single
+// mount.
+//
 // Hidden when the operator has no apply permission in the cluster
-// (per useCanApply). The dialog itself lives once at App level via
-// ApplyDialogProvider so multiple entry points (Sidebar + Cmd+K
-// palette + future surfaces) share a single mount.
+// (per useCanApply). Per-doc RBAC pre-flight inside the dialog is
+// sub-task #55.
 
 import { useParams } from "react-router-dom";
 import { Plus } from "lucide-react";
@@ -17,10 +21,10 @@ export function ApplyYamlEntry() {
   const can = useCanApply(cluster ?? "");
   const dialog = useApplyDialog();
 
-  // Hide the entry point entirely (don't render a disabled stub) when
-  // the operator can't apply anything. Loading shows the button so
-  // first paint stays usable; the dialog would error per-doc anyway
-  // if the operator turns out to lack permission.
+  // Hide entirely (don't render a disabled stub) when the operator
+  // can't apply anything. Loading shows the button so first paint
+  // stays usable; the dialog would error per-doc anyway if the
+  // operator turns out to lack permission.
   if (!cluster) return null;
   if (!can.loading && !can.allowed) return null;
 
@@ -29,7 +33,7 @@ export function ApplyYamlEntry() {
       type="button"
       onClick={() => dialog.open(cluster)}
       title="Paste / upload YAML and apply to this cluster"
-      className="group mx-2 mt-2 flex items-center gap-1.5 rounded-sm border border-border bg-surface-2 px-2.5 py-1.5 font-mono text-[12px] lowercase tracking-tight text-ink-muted transition-colors hover:border-accent hover:text-accent"
+      className="group inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 font-mono text-[11.5px] font-medium text-ink-muted transition-colors hover:border-accent hover:text-accent"
     >
       <Plus
         aria-hidden

--- a/web/src/components/apply/ApplyYamlEntry.tsx
+++ b/web/src/components/apply/ApplyYamlEntry.tsx
@@ -1,0 +1,41 @@
+// ApplyYamlEntry — Sidebar button that opens the shared
+// ApplyYamlDialog via useApplyDialog().
+//
+// Mounted inside the cluster Sidebar above the resource navigation.
+// Hidden when the operator has no apply permission in the cluster
+// (per useCanApply). The dialog itself lives once at App level via
+// ApplyDialogProvider so multiple entry points (Sidebar + Cmd+K
+// palette + future surfaces) share a single mount.
+
+import { useParams } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { useApplyDialog } from "../../contexts/applyDialog";
+import { useCanApply } from "../../hooks/useCanApply";
+
+export function ApplyYamlEntry() {
+  const { cluster } = useParams<{ cluster: string }>();
+  const can = useCanApply(cluster ?? "");
+  const dialog = useApplyDialog();
+
+  // Hide the entry point entirely (don't render a disabled stub) when
+  // the operator can't apply anything. Loading shows the button so
+  // first paint stays usable; the dialog would error per-doc anyway
+  // if the operator turns out to lack permission.
+  if (!cluster) return null;
+  if (!can.loading && !can.allowed) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => dialog.open(cluster)}
+      title="Paste / upload YAML and apply to this cluster"
+      className="group mx-2 mt-2 flex items-center gap-1.5 rounded-sm border border-border bg-surface-2 px-2.5 py-1.5 font-mono text-[12px] lowercase tracking-tight text-ink-muted transition-colors hover:border-accent hover:text-accent"
+    >
+      <Plus
+        aria-hidden
+        className="size-3.5 text-ink-faint transition-colors group-hover:text-accent"
+      />
+      <span>apply yaml</span>
+    </button>
+  );
+}

--- a/web/src/components/page/PageHeader.tsx
+++ b/web/src/components/page/PageHeader.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { cn } from "../../lib/cn";
 import { ThemeToggle } from "../shell/ThemeToggle";
+import { ApplyYamlEntry } from "../apply/ApplyYamlEntry";
 import { StreamHealthBadge } from "./StreamHealthBadge";
 import type { StreamStatus } from "../../hooks/useResourceStream";
 
@@ -54,6 +55,7 @@ export function PageHeader({
         {chips?.map((chip) => <Chip key={chip.label} {...chip} />)}
         <StreamHealthBadge status={streamStatus} />
         {trailing}
+        <ApplyYamlEntry />
         <ThemeToggle />
       </div>
     </div>

--- a/web/src/components/search/SearchPalette.tsx
+++ b/web/src/components/search/SearchPalette.tsx
@@ -7,6 +7,9 @@ import { queryKeys } from "../../lib/queryKeys";
 import { useCRDs } from "../../hooks/useResource";
 import { nameMatches } from "../../lib/format";
 import type { CRD, SearchKind, SearchResult } from "../../lib/types";
+import { useApplyDialog } from "../../contexts/applyDialog";
+import { useCanApply } from "../../hooks/useCanApply";
+import { Plus } from "lucide-react";
 
 const IS_MAC =
   typeof navigator !== "undefined" &&
@@ -67,6 +70,18 @@ export function SearchPalette({
   // <Routes>, not a descendant.
   const match = useMatch("/clusters/:cluster/*");
   const cluster = match?.params.cluster ?? "";
+
+  const dialog = useApplyDialog();
+
+  // When the operator picks the Apply YAML quick action: close the
+  // palette first (single Cmd+K invocation, single result), then open
+  // the shared dialog. The dialog lives at App level via
+  // ApplyDialogProvider, so palette unmount doesn't kill it.
+  const handleApplyAction = () => {
+    if (!cluster) return;
+    onClose();
+    dialog.open(cluster);
+  };
   const navigate = useNavigate();
 
   const [query, setQuery] = useState("");
@@ -264,7 +279,7 @@ export function SearchPalette({
           {!cluster ? (
             <Empty>open a cluster to search its resources</Empty>
           ) : !debounced ? (
-            <EmptyHint />
+            <EmptyHintWithActions cluster={cluster} onApplyClick={handleApplyAction} />
           ) : isFetching && results.length === 0 ? (
             <Empty>searching…</Empty>
           ) : isError ? (
@@ -536,13 +551,41 @@ function Empty({
   );
 }
 
-function EmptyHint() {
+function EmptyHintWithActions({
+  cluster,
+  onApplyClick,
+}: {
+  cluster: string;
+  onApplyClick: () => void;
+}) {
+  const canApply = useCanApply(cluster);
+  const showApply = canApply.allowed || canApply.loading;
   return (
-    <div className="px-4 py-8 text-center">
-      <p className="font-mono text-[12px] text-ink-muted">type to search</p>
-      <p className="mt-1.5 font-mono text-[10.5px] text-ink-faint">
-        across pods, deployments, services, configs and more
-      </p>
+    <div className="px-2 py-4">
+      {showApply && (
+        <div className="mb-2">
+          <div className="px-2 pb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+            quick actions
+          </div>
+          <button
+            type="button"
+            onClick={onApplyClick}
+            className="group flex w-full items-center gap-2.5 rounded-sm px-2 py-1.5 text-left transition-colors hover:bg-surface-2"
+          >
+            <Plus aria-hidden className="size-4 text-ink-faint group-hover:text-accent" />
+            <span className="font-mono text-[12.5px] text-ink">Apply YAML</span>
+            <span className="ml-auto font-mono text-[10.5px] text-ink-faint">
+              paste / upload manifests
+            </span>
+          </button>
+        </div>
+      )}
+      <div className="px-2 py-2 text-center">
+        <p className="font-mono text-[12px] text-ink-muted">type to search</p>
+        <p className="mt-1.5 font-mono text-[10.5px] text-ink-faint">
+          across pods, deployments, services, configs and more
+        </p>
+      </div>
     </div>
   );
 }

--- a/web/src/components/shell/Sidebar.tsx
+++ b/web/src/components/shell/Sidebar.tsx
@@ -1,8 +1,14 @@
 import { ResourceNav } from "./ResourceNav";
+import { ApplyYamlEntry } from "../apply/ApplyYamlEntry";
 
 export function Sidebar() {
   return (
     <aside className="flex h-full w-[256px] shrink-0 flex-col bg-surface">
+      {/* Apply YAML — sits above the resource navigation as the global
+          action affordance for "do something cluster-wide". Hidden
+          for users without apply permission (useCanApply). */}
+      <ApplyYamlEntry />
+      <div className="mt-2 h-px bg-border" />
       <ResourceNav />
     </aside>
   );

--- a/web/src/components/shell/Sidebar.tsx
+++ b/web/src/components/shell/Sidebar.tsx
@@ -1,14 +1,8 @@
 import { ResourceNav } from "./ResourceNav";
-import { ApplyYamlEntry } from "../apply/ApplyYamlEntry";
 
 export function Sidebar() {
   return (
     <aside className="flex h-full w-[256px] shrink-0 flex-col bg-surface">
-      {/* Apply YAML — sits above the resource navigation as the global
-          action affordance for "do something cluster-wide". Hidden
-          for users without apply permission (useCanApply). */}
-      <ApplyYamlEntry />
-      <div className="mt-2 h-px bg-border" />
       <ResourceNav />
     </aside>
   );

--- a/web/src/contexts/applyDialog.ts
+++ b/web/src/contexts/applyDialog.ts
@@ -1,0 +1,26 @@
+// applyDialog — React context + hook for the App-level ApplyYamlDialog.
+//
+// Lives in /contexts (no JSX) so the Provider component can sit in
+// /components/apply/ApplyDialogProvider.tsx without tripping the
+// react-refresh "single-component-per-file" rule.
+
+import { createContext, useContext } from "react";
+
+export interface ApplyDialogController {
+  /** Open the Apply YAML dialog targeting the given cluster. */
+  open: (cluster: string) => void;
+}
+
+export const ApplyDialogContext = createContext<ApplyDialogController | null>(
+  null,
+);
+
+export function useApplyDialog(): ApplyDialogController {
+  const ctx = useContext(ApplyDialogContext);
+  if (!ctx) {
+    throw new Error(
+      "useApplyDialog called outside of ApplyDialogProvider — wrap App with the provider",
+    );
+  }
+  return ctx;
+}

--- a/web/src/hooks/useCanApply.ts
+++ b/web/src/hooks/useCanApply.ts
@@ -1,0 +1,41 @@
+// useCanApply — gates the Apply YAML entry points (Sidebar button +
+// Cmd+K quick action) on whether the operator has any apply permission
+// in the cluster.
+//
+// We test three representative kinds (configmaps / deployments /
+// namespaces) and pass when ANY of them is allowed. Reasoning:
+//
+//   - configmaps: the lowest-bar write op; broadly granted to
+//     anything ≥ edit tier. Catches most "operator with namespaced
+//     write" cases.
+//   - deployments: catches operators with workload-write but no
+//     core/v1 access (rare but possible with custom RBAC).
+//   - namespaces: cluster-scoped check; catches admin-tier operators
+//     who'd legitimately use Apply YAML to create a namespace.
+//
+// Three checks land in one POST via useCanIBatch, cached for 30s.
+// Per-doc RBAC pre-flight (sub-task #55) is the real gate; this is
+// just for "show the button at all".
+
+import { useMemo } from "react";
+import { useCanIBatch, type CanICheck } from "./useCanI";
+
+const APPLY_PROBES: CanICheck[] = [
+  { verb: "create", resource: "configmaps" },
+  { verb: "create", resource: "deployments", group: "apps" },
+  { verb: "create", resource: "namespaces" },
+];
+
+export interface CanApplyDecision {
+  allowed: boolean;
+  loading: boolean;
+}
+
+export function useCanApply(cluster: string): CanApplyDecision {
+  const decisions = useCanIBatch(cluster, APPLY_PROBES);
+  return useMemo(() => {
+    const loading = decisions.some((d) => d.loading);
+    const allowed = decisions.some((d) => d.allowed);
+    return { allowed, loading };
+  }, [decisions]);
+}

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useClusterSummary, useClusterEvents } from "../hooks/useResource";
 import { CircularGauge } from "../components/ui/CircularGauge";
 import { ThemeToggle } from "../components/shell/ThemeToggle";
+import { ApplyYamlEntry } from "../components/apply/ApplyYamlEntry";
 import { ageFrom } from "../lib/format";
 import { cn } from "../lib/cn";
 import type {
@@ -283,7 +284,10 @@ function ClusterIdentityBanner({
           </span>
         </div>
       </div>
-      <ThemeToggle />
+      <div className="flex shrink-0 items-center gap-2">
+        <ApplyYamlEntry />
+        <ThemeToggle />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Sub-task **#54** of the Apply YAML epic (#51). Mounts `<ApplyYamlDialog>` (shipped in #97) at two operator-reachable entry points so the dialog can be opened without context-switching:

1. **PageHeader action row** — `+ apply yaml` button between the page's trailing slot (NamespacePicker) and ThemeToggle. Cascades to ~25 cluster pages that use the shared `PageHeader`.
2. **Cmd+K palette quick action** — surfaces in `SearchPalette`'s empty state (before the operator types) under a "quick actions" section.
3. **OverviewPage banner** — Overview uses a custom `ClusterIdentityBanner` (kept for the rich cluster identity subtitle); button mounted there next to ThemeToggle.

Both gated by `useCanApply` — three representative `create` checks (configmaps, deployments, namespaces) via one batched `useCanIBatch` POST. Operators with no apply permission see no entry point.

## What lands

```
src/contexts/applyDialog.ts                 — context + useApplyDialog hook (no JSX)
src/components/apply/
  ApplyDialogProvider.tsx                   — App-level provider, single dialog mount
  ApplyYamlEntry.tsx                        — button (uses useApplyDialog + useCanApply)
src/hooks/useCanApply.ts                    — shared can-i gate (3-probe batch)
src/components/page/PageHeader.tsx          — mounts ApplyYamlEntry between trailing + Theme
src/components/search/SearchPalette.tsx     — Quick actions section in empty state
src/pages/OverviewPage.tsx                  — mounts ApplyYamlEntry next to ThemeToggle
src/App.tsx                                 — wraps the authenticated tree with ApplyDialogProvider
```

## Architecture decision worth flagging — single dialog mount via Provider

Naive approach: each entry point owns its own `<ApplyYamlDialog>` state. This breaks the Cmd+K flow specifically: `SearchPalette` returns `null` when closed, so a dialog mounted INSIDE the palette would unmount the moment the operator clicks the action and the palette closes — losing the dialog mid-open.

Resolved by lifting the dialog mount to App-level via `ApplyDialogProvider`. All entry points call `useApplyDialog().open(cluster)` to request the dialog. Single instance; survives palette close. Simple `target: string | null` state in the provider.

## UX placement reasoning

Started in the Sidebar (commit 1) — felt isolated from the existing per-page actions. Moved to PageHeader (commit 3) where it clusters naturally with NamespacePicker + ThemeToggle. Three-commit history walks that pivot if reviewers want it; squash-merge collapses to the final state.

Order in PageHeader: `[chips] [StreamHealthBadge] [trailing/Namespace] [Apply YAML] [ThemeToggle]`. ThemeToggle stays rightmost (it's "persona/settings", not an action).

## Verification

- `npx tsc -b` clean
- `npm run lint` clean
- `npx vitest run` — 111/111 pass (no test changes; existing parser/state tests cover the dialog from #97)
- `npm run build` clean

## Decisions per the issue body

- **PageHeader placement** chosen over Sidebar — visually integrates with existing actions; covers ~25 cluster pages with one mount
- **Cmd+K extension only on empty query** — keeps the palette focused on resource search once typing starts; promote to a full command palette when 5+ commands exist
- **`useCanApply` is a 3-probe batch** (configmaps / deployments / namespaces) — matches the issue's "any apply permission" intent without per-resource specificity
- **Per-page action button**: NOT added — global PageHeader + Cmd+K covers it; per-list-page would be clutter
- **OverviewPage**: kept its custom `ClusterIdentityBanner` (rich cluster identity subtitle) and added the button there directly rather than migrate to PageHeader

## Out of scope (per #54 acceptance)

- The dialog itself — sub-task **#53** (#97, merged)
- Per-doc RBAC pre-flight inside the dialog — sub-task **#55**

## Reviewer

Tagging @yogen9. Three commits walk the build:

1. `feat(web): add Apply YAML button to cluster Sidebar` — initial mount + Provider + useCanApply
2. `feat(web): enhance SearchPalette with Apply YAML quick action and updated empty state` — Cmd+K integration
3. `feat(web): add Apply YAML button to PageHeader + cluster overview banner` — moves the button to a more natural spot, adds it to OverviewPage's custom banner

If you'd rather walk a single coherent diff, the cumulative state is the merged content; commit 3 is the final placement.

Refs #51.
