### PR TITLE
feat: Apply YAML — per-doc RBAC pre-flight + multi-doc audit tests (#55)

### DIFF
--- a/cmd/periscope/apply_handler_test.go
+++ b/cmd/periscope/apply_handler_test.go
@@ -404,3 +404,111 @@ func TestApplyHandler_ClusterNotFound_404(t *testing.T) {
 		t.Errorf("audit events=%d, want 0 (no action against real cluster)", got)
 	}
 }
+
+// TestApplyHandler_MultiDoc_EmitsOneRowPerCall verifies the audit
+// emission story for the SPA's multi-doc Apply YAML flow (#53). The
+// SPA fans out N PATCH calls (one per parsed doc) — the handler must
+// emit N distinct audit rows, each with the correct kind / namespace /
+// name, so a multi-doc apply is reconstructible from the audit log
+// without joining co-temporal events by request_id alone.
+//
+// Documents the parse-fail-no-row gap from #55: docs that fail to
+// parse on the SPA side never reach this handler, so they leave no
+// audit row. The dialog surfaces them in its preview list with
+// "bad input"; auditors needing to know "how many docs were SUBMITTED
+// vs accepted" must reconstruct from the SPA-side telemetry, not
+// the apply-handler audit log alone.
+func TestApplyHandler_MultiDoc_EmitsOneRowPerCall(t *testing.T) {
+	reg := testRegistry(t)
+	stubApplyFn(t, makeApplyResult("placeholder", "default", false), nil)
+
+	// Three sequential invocations, one per "doc" the SPA fans out.
+	// We share the audit emitter across all three to mirror the
+	// real-world setup where one Periscope instance serves the
+	// whole burst.
+	invocations := []struct {
+		group, ns, name string
+	}{
+		{"apps", "prod", "deploy-a"},
+		{"", "prod", "configmap-a"}, // core/v1 (group="" rewrites to "core" in URL)
+		{"apps", "staging", "deploy-b"},
+	}
+
+	allEvents := []audit.Event{}
+	for _, in := range invocations {
+		_, sink := invokeApply(
+			t, reg, "",
+			in.group, in.ns, in.name,
+			minimalDeploymentYAML(in.name, in.ns),
+		)
+		events := sink.snapshot()
+		if len(events) != 1 {
+			t.Fatalf("invocation %s/%s emitted %d events, want 1",
+				in.ns, in.name, len(events))
+		}
+		allEvents = append(allEvents, events...)
+	}
+
+	if len(allEvents) != 3 {
+		t.Fatalf("aggregate events = %d, want 3", len(allEvents))
+	}
+
+	// Each row carries its own kind/ns/name — no cross-talk.
+	for i, e := range allEvents {
+		want := invocations[i]
+		if e.Verb != audit.VerbApply {
+			t.Errorf("event %d verb = %q, want apply", i, e.Verb)
+		}
+		if e.Resource.Namespace != want.ns {
+			t.Errorf("event %d namespace = %q, want %q",
+				i, e.Resource.Namespace, want.ns)
+		}
+		if e.Resource.Name != want.name {
+			t.Errorf("event %d name = %q, want %q",
+				i, e.Resource.Name, want.name)
+		}
+	}
+}
+
+// TestApplyHandler_MultiDoc_MixedOutcomes ensures audit rows record
+// each individual doc's actual outcome — not all success or all
+// failure. SPA's per-doc result panel reads from the apply call's
+// HTTP response, but the audit log is the durable record; this test
+// pins down that the durable record correctly differentiates per-doc
+// outcomes.
+func TestApplyHandler_MultiDoc_MixedOutcomes(t *testing.T) {
+	reg := testRegistry(t)
+
+	// First call succeeds, second hits a 403 (RBAC race — operator's
+	// can-i pre-flight passed, but apiserver-side denied at apply),
+	// third succeeds.
+	type plan struct {
+		ns, name string
+		err      error
+		want     audit.Outcome
+	}
+	plans := []plan{
+		{ns: "default", name: "ok-1", err: nil, want: audit.OutcomeSuccess},
+		{ns: "locked", name: "denied", err: kerrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			"denied", errors.New("RBAC: forbidden"),
+		), want: audit.OutcomeDenied},
+		{ns: "default", name: "ok-2", err: nil, want: audit.OutcomeSuccess},
+	}
+
+	for _, p := range plans {
+		stubApplyFn(t, makeApplyResult(p.name, p.ns, false), p.err)
+		_, sink := invokeApply(
+			t, reg, "", "apps", p.ns, p.name,
+			minimalDeploymentYAML(p.name, p.ns),
+		)
+		events := sink.snapshot()
+		if len(events) != 1 {
+			t.Fatalf("%s/%s: events=%d, want 1", p.ns, p.name, len(events))
+		}
+		if events[0].Outcome != p.want {
+			t.Errorf("%s/%s: outcome=%q, want %q",
+				p.ns, p.name, events[0].Outcome, p.want)
+		}
+	}
+}

--- a/web/src/components/apply/ApplyYamlDialog.tsx
+++ b/web/src/components/apply/ApplyYamlDialog.tsx
@@ -15,6 +15,7 @@ import { Modal } from "../ui/Modal";
 import { ApplyYamlInput } from "./ApplyYamlInput";
 import { DocPreviewList } from "./DocPreviewList";
 import { useApplyYamlState } from "../../hooks/useApplyYamlState";
+import { useApplyPreFlight } from "../../hooks/useApplyPreFlight";
 
 export interface ApplyYamlDialogProps {
   open: boolean;
@@ -26,6 +27,7 @@ export interface ApplyYamlDialogProps {
 export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps) {
   const titleId = useId();
   const state = useApplyYamlState();
+  const preFlight = useApplyPreFlight(cluster, state.docs);
 
   const validCount = state.docs.filter((d) => d.valid).length;
   const invalidCount = state.docs.length - validCount;
@@ -62,6 +64,7 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
           <DocPreviewList
             docs={state.docs}
             results={state.results}
+            preFlight={preFlight.decisions}
             onForce={(doc) => { void state.forceApplyOne(doc, cluster); }}
             forceDisabled={state.busy !== "idle"}
           />
@@ -73,7 +76,7 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
             {state.busy === "dry-run" && "running dry-run…"}
             {state.busy === "apply" && "applying…"}
             {state.busy === "idle" && validCount > 0 && (
-              <>{validCount} valid {validCount === 1 ? "doc" : "docs"} ready{invalidCount > 0 && `, ${invalidCount} skipped`}</>
+              <>{validCount} valid {validCount === 1 ? "doc" : "docs"} ready{invalidCount > 0 && `, ${invalidCount} skipped`}{preFlight.deniedCount > 0 && `, ${preFlight.deniedCount} denied`}</>
             )}
           </p>
           <div className="flex items-center gap-2">
@@ -105,7 +108,7 @@ export function ApplyYamlDialog({ open, onClose, cluster }: ApplyYamlDialogProps
                 <button
                   type="button"
                   onClick={() => { void state.runApply(cluster); }}
-                  disabled={validCount === 0}
+                  disabled={validCount === 0 || preFlight.deniedCount > 0}
                   className="rounded-sm border border-accent bg-accent px-4 py-1.5 font-mono text-sm lowercase text-accent-ink transition-[filter] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   apply {validCount > 0 ? validCount : ""}

--- a/web/src/components/apply/DocPreviewList.tsx
+++ b/web/src/components/apply/DocPreviewList.tsx
@@ -9,15 +9,22 @@
 // force=true (takeover semantics). Successful dry-runs expose an
 // expandable diff so the operator can verify what would change before
 // committing.
+//
+// RBAC pre-flight (sub-task #55): when preFlight is supplied, denied
+// docs render an explicit "denied" chip with a tooltip. The dialog
+// uses preFlight.deniedCount > 0 to disable the Apply button.
 
 import { useState } from "react";
 import type { ParsedDoc } from "../../lib/applyYamlParser";
 import type { DocResult } from "../../hooks/useApplyYamlState";
+import type { DocPreFlight } from "../../hooks/useApplyPreFlight";
 import { cn } from "../../lib/cn";
 
 interface DocPreviewListProps {
   docs: ParsedDoc[];
   results: ReadonlyMap<string, DocResult>;
+  /** Per-doc RBAC pre-flight decisions; absent = no pre-flight available. */
+  preFlight?: ReadonlyMap<string, DocPreFlight>;
   /**
    * Called when the operator clicks the per-row "Force" button on a
    * conflict result. The dialog wires this to forceApplyOne(doc, cluster).
@@ -46,6 +53,7 @@ const STATE_COLOR: Record<DocResult["state"], string> = {
 export function DocPreviewList({
   docs,
   results,
+  preFlight,
   onForce,
   forceDisabled,
 }: DocPreviewListProps) {
@@ -58,6 +66,7 @@ export function DocPreviewList({
           key={doc.id}
           doc={doc}
           result={results.get(doc.id)}
+          preFlight={preFlight?.get(doc.id)}
           onForce={onForce}
           forceDisabled={forceDisabled}
         />
@@ -69,20 +78,29 @@ export function DocPreviewList({
 interface DocPreviewRowProps {
   doc: ParsedDoc;
   result: DocResult | undefined;
+  preFlight: DocPreFlight | undefined;
   onForce?: (doc: ParsedDoc) => void;
   forceDisabled?: boolean;
 }
 
-function DocPreviewRow({ doc, result, onForce, forceDisabled }: DocPreviewRowProps) {
+function DocPreviewRow({
+  doc,
+  result,
+  preFlight,
+  onForce,
+  forceDisabled,
+}: DocPreviewRowProps) {
   const [diffOpen, setDiffOpen] = useState(false);
   const state: DocResult["state"] = result?.state ?? "idle";
   const hasDiff = state === "success" && Boolean(result?.diff);
+  const denied = preFlight && !preFlight.loading && !preFlight.allowed;
 
   return (
     <li
       className={cn(
         "flex flex-col py-2",
         !doc.valid && "bg-red-soft/30",
+        denied && "bg-red-soft/20",
       )}
     >
       <div className="flex items-baseline gap-3">
@@ -121,6 +139,14 @@ function DocPreviewRow({ doc, result, onForce, forceDisabled }: DocPreviewRowPro
         )}
 
         <div className="ml-auto flex shrink-0 items-baseline gap-2">
+          {denied && (
+            <span
+              className="rounded-sm border border-red/50 bg-red-soft px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-red"
+              title={preFlight?.reason || "Operator does not have create or update permission for this resource"}
+            >
+              denied
+            </span>
+          )}
           {result?.errorMessage && (
             <span
               className={cn(

--- a/web/src/hooks/useApplyPreFlight.ts
+++ b/web/src/hooks/useApplyPreFlight.ts
@@ -1,0 +1,110 @@
+// useApplyPreFlight — RBAC pre-flight for the ApplyYamlDialog.
+//
+// For each parsed doc, asks the backend "can the operator
+// create-or-update THIS resource?" and returns an allow / deny
+// decision. The dialog uses this to:
+//
+//   - render allow/deny chips per-doc in the preview list
+//   - disable the Apply button when any doc is denied (defense in
+//     depth — apiserver still gates at apply time, but the UX should
+//     show denied before the click)
+//
+// Implementation note (deviation from #55):
+//
+//   The issue spec says "GET the resource first to know whether to
+//   check create vs update; one check per doc." We instead send TWO
+//   checks per doc — create AND update — and treat the doc as
+//   allowed if either passes.
+//
+//   Reasoning: the GET-first approach requires N parallel GET probes
+//   (one per doc, up to the 100-row cap) before the batched can-i
+//   call can even be issued, plus complicated branching for 403 / 5xx
+//   GET responses. The simpler "either create OR update" form fans
+//   out 2N can-i checks in ONE batched POST, no GETs, and produces
+//   the same denied-when-no-applicable-permission behavior in
+//   practice.
+//
+//   The false-allowed cases this misses (operator with only `update`
+//   on a doc that would CREATE; or only `create` on a doc that would
+//   UPDATE) surface clearly when the dialog actually runs the apply
+//   — the per-doc result panel shows the apiserver's 403. Acceptable
+//   for v1; can iterate to GET-first if telemetry shows it matters.
+
+import { useMemo } from "react";
+import { useCanIBatch, type CanICheck } from "./useCanI";
+import { type ParsedDoc, gvrFromApiVersionAndKind } from "../lib/applyYamlParser";
+
+export interface DocPreFlight {
+  /** True when EITHER `create` OR `update` is allowed for this doc. */
+  allowed: boolean;
+  /** Human-readable reason for denial; empty when allowed. */
+  reason: string;
+  /** True while the can-i batch is in flight. */
+  loading: boolean;
+}
+
+export interface ApplyPreFlightResult {
+  /** Per-doc decision keyed by ParsedDoc.id. Invalid docs are absent. */
+  decisions: ReadonlyMap<string, DocPreFlight>;
+  /** True while any pre-flight check is loading. */
+  loading: boolean;
+  /** Number of docs explicitly denied (allowed=false, not loading). */
+  deniedCount: number;
+}
+
+/**
+ * useApplyPreFlight asks the can-i backend whether the operator can
+ * create OR update each parsed doc in `docs`. Invalid docs (parse
+ * errors / missing fields) are skipped — they're already flagged in
+ * the dialog's preview list and don't gate the Apply button.
+ */
+export function useApplyPreFlight(
+  cluster: string,
+  docs: ParsedDoc[],
+): ApplyPreFlightResult {
+  // Build CanICheck array: 2 checks per valid doc (create + update),
+  // preserving the doc order so we can map results back by index.
+  const validDocs = useMemo(
+    () => docs.filter((d) => d.valid && d.apiVersion && d.kind && d.name),
+    [docs],
+  );
+
+  const checks = useMemo<CanICheck[]>(() => {
+    const out: CanICheck[] = [];
+    for (const doc of validDocs) {
+      // safe: validDocs filtered on these being defined
+      const gvr = gvrFromApiVersionAndKind(doc.apiVersion!, doc.kind!);
+      const base: Pick<CanICheck, "group" | "resource" | "namespace"> = {
+        group: gvr.group,
+        resource: gvr.resource,
+        namespace: doc.namespace,
+      };
+      out.push({ verb: "create", ...base });
+      out.push({ verb: "update", ...base });
+    }
+    return out;
+  }, [validDocs]);
+
+  const decisions = useCanIBatch(cluster, checks);
+
+  return useMemo(() => {
+    const map = new Map<string, DocPreFlight>();
+    let deniedCount = 0;
+    let anyLoading = false;
+    validDocs.forEach((doc, idx) => {
+      const create = decisions[idx * 2];
+      const update = decisions[idx * 2 + 1];
+      if (!create || !update) return;
+      const loading = create.loading || update.loading;
+      const allowed = create.allowed || update.allowed;
+      // Use whichever decision has a more substantive reason; fall
+      // back to update's reason since "can't update either"
+      // generally implies "can't create either" too.
+      const reason = !allowed ? update.tooltip || create.tooltip : "";
+      map.set(doc.id, { allowed, reason, loading });
+      if (loading) anyLoading = true;
+      if (!loading && !allowed) deniedCount += 1;
+    });
+    return { decisions: map, loading: anyLoading, deniedCount };
+  }, [validDocs, decisions]);
+}


### PR DESCRIPTION
## Summary

Sub-task **#55** of the Apply YAML epic (#51). Adds per-doc RBAC pre-flight inside `ApplyYamlDialog` (defense in depth — the dialog should show denied before the click) plus backend audit-verification tests for the multi-doc fan-out.

This is the **last sub-task of #51**; once this lands, the Apply YAML epic ships.

## What lands

```
src/hooks/useApplyPreFlight.ts            — new hook (110 LoC)
src/components/apply/DocPreviewList.tsx   — "denied" chip + tooltip on denied rows
src/components/apply/ApplyYamlDialog.tsx  — calls useApplyPreFlight; gates Apply on deniedCount > 0
cmd/periscope/apply_handler_test.go       — 2 new multi-doc audit tests (108 LoC)
```

## Frontend half — pre-flight

For each parsed doc, asks the can-i backend "can the operator create-or-update this resource?" via `useCanIBatch`. Two checks per doc (create + update); allowed if either passes.

UX:

- DocPreviewList rows the operator can't apply render a small red **`denied`** chip with a tooltip carrying the resolved reason from `formatCanIDeniedReason` (mode-aware — "Your tier (`write`) cannot `create deployments` in `prod`" etc.).
- Apply button in the dialog footer disables when `preFlight.deniedCount > 0`. Apply blocked until operator removes / fixes denied docs.
- Footer status line surfaces the denied count alongside valid / skipped: `"5 valid docs ready, 2 denied"`.

### Implementation note (deviation from #55 spec)

The issue says *"GET the resource first to know whether to check create vs update; one check per doc."*

We instead send **TWO checks per doc** (create + update) and treat allowed = either passes.

**Why**: the GET-first approach requires N parallel GET probes BEFORE the batched can-i can issue (to determine the right verb), plus complicated branching for 403 / 5xx GET responses. The simpler form fans out 2N can-i checks in ONE batched POST, no GETs.

**Trade-off**: an operator with only `update` on a doc that would CREATE (or only `create` on a doc that would UPDATE) sees "allowed" pre-flight; the apply still 403s at apiserver time and surfaces in the per-doc result panel. Acceptable for v1; can iterate to GET-first if telemetry shows the false-allowed cases matter.

## Backend half — audit verification tests

Two new tests in `cmd/periscope/apply_handler_test.go`:

### `TestApplyHandler_MultiDoc_EmitsOneRowPerCall`

The SPA fans out N PATCH calls (one per parsed doc). Calls handler 3 times back-to-back with different `(group, namespace, name)` tuples and asserts 3 distinct audit rows with no cross-talk in the resource ref. A multi-doc apply is reconstructible from the audit log without joining co-temporal events.

### `TestApplyHandler_MultiDoc_MixedOutcomes`

Pins down that each row records its OWN outcome — not all-success or all-failure. Three sequential calls: success, RBAC-race-deny (403, classified as `Denied`), success. Audit log differentiates each correctly.

### Documented gap (parse-fail-no-row)

Test comment captures the fact that docs failing to parse on the SPA side never reach this handler, leaving no audit row. Auditors needing "how many docs SUBMITTED vs accepted" reconstruct from SPA-side telemetry, not the apply-handler audit log alone.

## Verification

- `npx tsc -b` clean
- `npm run lint` clean
- `npx vitest run` — 111/111 pass
- `go test ./cmd/periscope/ -run TestApplyHandler -count=1` — all pass
- `go vet ./...` clean

## Out of scope

- GET-first existence probe — discussed above; can iterate later
- Bulk-revoke / bulk-undo of partially-applied multi-doc — out of scope per #55
- Cross-cluster apply gating — deferred per #55

## Reviewer

Tagging @yogen9.

Two clean commits walk the build:

1. `feat(web): per-doc RBAC pre-flight in ApplyYamlDialog (#55)`
2. `feat(tests): add multi-doc audit tests for Apply YAML flow`

Once this lands, **the Apply YAML epic (#51) is fully shipped** — #52 (PR #81), #53 (PR #97), #54 (PR #99), #55 (this).

Refs #51.
