### PR TITLE
Add EKS Upgrade Insights read-only endpoints (issue #103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Both signed (cosign keyless) and discoverable on [Artifact Hub](https://artifact
 - [Pod exec setup](docs/setup/pod-exec.md)
 - [NetworkPolicy](docs/setup/networkpolicy.md)
 - [Multi-cluster onboarding (agent)](docs/setup/agent-onboarding.md) — register a managed cluster via the periscope-agent tunnel
+- [EKS upgrade readiness](docs/setup/eks-upgrade-readiness.md) — Upgrade Insights + managed node group AMI drift
 
 **Architecture**
 - [Architecture overview](docs/architecture/README.md) — component map, source-tree guide, reading order for new contributors

--- a/cmd/periscope/eks_ami_catalog.go
+++ b/cmd/periscope/eks_ami_catalog.go
@@ -50,12 +50,19 @@ import (
 
 // LatestAMI is the result of a catalog lookup. ImageID is always
 // populated; ReleaseVersion is only available from the SSM source
-// (DescribeImages fallback leaves it empty and PublishedAt holds
-// the AMI's CreationDate so the SPA can still render a date).
+// (DescribeImages fallback leaves it empty).
 type LatestAMI struct {
 	ImageID        string
 	ReleaseVersion string
-	PublishedAt    *time.Time
+	// LatestSeenAt is a best-effort freshness timestamp from whichever
+	// source produced this entry. SSM path: the parameter's
+	// LastModifiedDate (when AWS published a new "recommended"
+	// pointer). EC2 path: the AMI's own CreationDate. They usually
+	// correlate but are not the same clock — treat the value as
+	// "approximately when this AMI became the latest" rather than
+	// a strict release date. The Source field below distinguishes
+	// the two for debugging.
+	LatestSeenAt *time.Time
 	// Source records which path produced the result so audit /
 	// debugging can tell SSM hits from EC2 fallback at a glance.
 	Source string // "ssm" | "ec2"
@@ -82,6 +89,15 @@ func (r *realAMICatalogClient) GetParameter(ctx context.Context, in *ssm.GetPara
 func (r *realAMICatalogClient) DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, opts ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
 	return r.ec2.DescribeImages(ctx, in, opts...)
 }
+
+// ec2FallbackOwners is the owner-id list passed to DescribeImages on
+// the EC2 fallback path. The "amazon" alias covers the newer AL2023
+// family; 602401143452 is the historical EKS-optimized AMI account
+// that still owns AL2 AMIs in some commercial partitions. Both have
+// to be listed because the alias does NOT include the EKS account.
+// Exported for the test seam — same package, package-level so the
+// test asserts the exact slice passed to the fake client.
+var ec2FallbackOwners = []string{"amazon", "602401143452"}
 
 // newAMICatalogClient is swapped by tests. Default builds the real
 // SSM + EC2 clients from the request's Provider.
@@ -225,7 +241,7 @@ func lookupSSM(ctx context.Context, client amiCatalogAPI, fam amiFamily, amiType
 	out := &LatestAMI{
 		ImageID:     *imageOut.Parameter.Value,
 		Source:      "ssm",
-		PublishedAt: imageOut.Parameter.LastModifiedDate,
+		LatestSeenAt: imageOut.Parameter.LastModifiedDate,
 	}
 
 	// release_version / image_version is best-effort. A missing
@@ -264,9 +280,14 @@ func ssmPaths(fam amiFamily, amiType ekstypes.AMITypes, k8sVersion string) (stri
 
 func lookupEC2(ctx context.Context, client amiCatalogAPI, fam amiFamily, k8sVersion string) (*LatestAMI, error) {
 	pattern := strings.ReplaceAll(fam.EC2NamePattern, "{v}", k8sVersion)
-	owner := "amazon"
+	// "amazon" is the alias for canonical Amazon AMIs (newer al2023
+	// family is published here); 602401143452 is the historical EKS-
+	// optimized AMI account (al2 lives there in older AWS partitions).
+	// Listing both keeps the fallback usable across every commercial
+	// region. GovCloud / China use different account IDs and are out
+	// of scope for v1 — see docs/setup/eks-upgrade-readiness.md.
 	out, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
-		Owners: []string{owner},
+		Owners: ec2FallbackOwners,
 		Filters: []ec2types.Filter{
 			{Name: aws.String("name"), Values: []string{pattern}},
 		},
@@ -290,7 +311,7 @@ func lookupEC2(ctx context.Context, client amiCatalogAPI, fam amiFamily, k8sVers
 		Source:  "ec2",
 	}
 	if t, err := time.Parse(time.RFC3339, strDeref(chosen.CreationDate)); err == nil {
-		res.PublishedAt = &t
+		res.LatestSeenAt = &t
 	}
 	// EKS-optimized AMI names embed the release version, e.g.
 	// "amazon-eks-node-1.30-v20240819". Extract the trailing token

--- a/cmd/periscope/eks_ami_catalog.go
+++ b/cmd/periscope/eks_ami_catalog.go
@@ -1,0 +1,457 @@
+package main
+
+// eks_ami_catalog.go — "what's the latest AMI for this nodegroup?"
+// lookup, used by the drift fields on the nodegroup detail
+// response.
+//
+// Two data sources, in order:
+//
+//   1. SSM public parameter (primary). AWS publishes recommended
+//      AMI IDs and release versions under
+//      /aws/service/eks/optimized-ami/<k8sVer>/<family>/recommended/{image_id,release_version}
+//      and an analogous Bottlerocket tree. One GetParameter call
+//      per (family, k8sVersion) gets us authoritative "latest".
+//
+//   2. ec2:DescribeImages (fallback). When SSM fails — denied,
+//      throttled, or the parameter doesn't exist for the family in
+//      this region — we filter EC2 by image name pattern and pick
+//      the most recent by CreationDate. Less precise (no release
+//      version) but always available.
+//
+// Out of scope for v1:
+//   - Windows AMIs. The SSM path is wholly different (no
+//     /recommended/release_version subkey) and Windows EKS is rare
+//     enough we'd rather punt than half-implement. Windows
+//     nodegroups get drift=uncomputed and the row shows "—".
+//   - CUSTOM AMIs. AWS doesn't publish a "latest" for these — the
+//     handler skips the catalog lookup entirely.
+//   - Pinned-version queries (issue #1843 on awslabs/amazon-eks-ami
+//     tracks AWS adding indexed-by-release-version SSM keys; not
+//     yet shipped).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// LatestAMI is the result of a catalog lookup. ImageID is always
+// populated; ReleaseVersion is only available from the SSM source
+// (DescribeImages fallback leaves it empty and PublishedAt holds
+// the AMI's CreationDate so the SPA can still render a date).
+type LatestAMI struct {
+	ImageID        string
+	ReleaseVersion string
+	PublishedAt    *time.Time
+	// Source records which path produced the result so audit /
+	// debugging can tell SSM hits from EC2 fallback at a glance.
+	Source string // "ssm" | "ec2"
+}
+
+// amiCatalogAPI is the SDK seam for testability.
+type amiCatalogAPI interface {
+	GetParameter(ctx context.Context, in *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, opts ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+}
+
+// realAMICatalogClient is a tiny wrapper over the two real SDK
+// clients so the production code can satisfy amiCatalogAPI through
+// a single struct.
+type realAMICatalogClient struct {
+	ssm *ssm.Client
+	ec2 *ec2.Client
+}
+
+func (r *realAMICatalogClient) GetParameter(ctx context.Context, in *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return r.ssm.GetParameter(ctx, in, opts...)
+}
+
+func (r *realAMICatalogClient) DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, opts ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+	return r.ec2.DescribeImages(ctx, in, opts...)
+}
+
+// newAMICatalogClient is swapped by tests. Default builds the real
+// SSM + EC2 clients from the request's Provider.
+var newAMICatalogClient = defaultNewAMICatalogClient
+
+func defaultNewAMICatalogClient(p credentials.Provider, c clusters.Cluster) amiCatalogAPI {
+	cfg := aws.Config{Region: c.Region, Credentials: p}
+	return &realAMICatalogClient{
+		ssm: ssm.NewFromConfig(cfg),
+		ec2: ec2.NewFromConfig(cfg),
+	}
+}
+
+// ── Family mapping ──────────────────────────────────────────────────
+
+// amiFamily captures the per-family bits the SSM path needs. The
+// Tree field is "eks" or "bottlerocket" because the two top-level
+// SSM trees have different child shapes (recommended vs latest,
+// release_version vs image_version).
+type amiFamily struct {
+	// Tree is "eks" or "bottlerocket". Drives the parameter prefix
+	// and the version-key choice.
+	Tree string
+	// Path is the family slug embedded in the SSM key. For the eks
+	// tree it sits under /optimized-ami/{k8sVer}/<Path>/recommended/;
+	// for bottlerocket it's "aws-k8s-{k8sVer}{Suffix}/<arch>".
+	Path string
+	// EC2NamePattern is the AMI name filter for the DescribeImages
+	// fallback. Concrete substitutions of {k8sVer} happen at lookup
+	// time. "" means we don't have a fallback for this family.
+	EC2NamePattern string
+}
+
+// familyForAMIType maps an EKS AmiType enum value to the catalog
+// family. Returns (zero, false) for AMIs we don't (yet) support
+// drift detection on — Windows + FIPS today. CUSTOM is callable but
+// the handler skips it before reaching this map.
+func familyForAMIType(t ekstypes.AMITypes) (amiFamily, bool) {
+	switch t {
+	// Amazon Linux 2 (legacy)
+	case ekstypes.AMITypesAl2X8664:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2", EC2NamePattern: "amazon-eks-node-{v}-*"}, true
+	case ekstypes.AMITypesAl2X8664Gpu:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2-gpu", EC2NamePattern: "amazon-eks-gpu-node-{v}-*"}, true
+	case ekstypes.AMITypesAl2Arm64:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2-arm64", EC2NamePattern: "amazon-eks-arm64-node-{v}-*"}, true
+	// Amazon Linux 2023
+	case ekstypes.AMITypesAl2023X8664Standard:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2023/x86_64/standard", EC2NamePattern: "amazon-eks-node-al2023-x86_64-standard-{v}-*"}, true
+	case ekstypes.AMITypesAl2023Arm64Standard:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2023/arm64/standard", EC2NamePattern: "amazon-eks-node-al2023-arm64-standard-{v}-*"}, true
+	case ekstypes.AMITypesAl2023X8664Neuron:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2023/x86_64/neuron", EC2NamePattern: "amazon-eks-node-al2023-x86_64-neuron-{v}-*"}, true
+	case ekstypes.AMITypesAl2023X8664Nvidia:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2023/x86_64/nvidia", EC2NamePattern: "amazon-eks-node-al2023-x86_64-nvidia-{v}-*"}, true
+	case ekstypes.AMITypesAl2023Arm64Nvidia:
+		return amiFamily{Tree: "eks", Path: "amazon-linux-2023/arm64/nvidia", EC2NamePattern: "amazon-eks-node-al2023-arm64-nvidia-{v}-*"}, true
+	// Bottlerocket — the "aws-k8s-{k8sVer}" path; flavor encoded as
+	// suffix on the k8s segment ("-nvidia" / "-fips").
+	case ekstypes.AMITypesBottlerocketX8664:
+		return amiFamily{Tree: "bottlerocket", Path: "x86_64", EC2NamePattern: "bottlerocket-aws-k8s-{v}-x86_64-*"}, true
+	case ekstypes.AMITypesBottlerocketArm64:
+		return amiFamily{Tree: "bottlerocket", Path: "arm64", EC2NamePattern: "bottlerocket-aws-k8s-{v}-aarch64-*"}, true
+	case ekstypes.AMITypesBottlerocketX8664Nvidia:
+		return amiFamily{Tree: "bottlerocket", Path: "x86_64", EC2NamePattern: "bottlerocket-aws-k8s-{v}-nvidia-x86_64-*"}, true
+	case ekstypes.AMITypesBottlerocketArm64Nvidia:
+		return amiFamily{Tree: "bottlerocket", Path: "arm64", EC2NamePattern: "bottlerocket-aws-k8s-{v}-nvidia-aarch64-*"}, true
+	// Everything else — Windows variants, FIPS, future families —
+	// gets drift=uncomputed in v1.
+	default:
+		return amiFamily{}, false
+	}
+}
+
+// bottlerocketFlavorSuffix returns the "-nvidia" / "-fips" suffix
+// for the bottlerocket SSM path's k8s-version segment. Pure
+// function so the test can pin the matrix.
+func bottlerocketFlavorSuffix(t ekstypes.AMITypes) string {
+	switch t {
+	case ekstypes.AMITypesBottlerocketX8664Nvidia, ekstypes.AMITypesBottlerocketArm64Nvidia:
+		return "-nvidia"
+	default:
+		return ""
+	}
+}
+
+// ── SSM-first lookup ─────────────────────────────────────────────────
+
+// LatestForNodegroup returns the latest AMI for a nodegroup's
+// (AmiType, k8sVersion) coordinates. Returns (nil, nil) when the
+// family isn't supported — callers should treat that as "drift not
+// computed" without erroring.
+func latestForNodegroup(ctx context.Context, client amiCatalogAPI, amiType ekstypes.AMITypes, k8sVersion string) (*LatestAMI, error) {
+	if k8sVersion == "" {
+		return nil, nil
+	}
+	fam, ok := familyForAMIType(amiType)
+	if !ok {
+		return nil, nil
+	}
+
+	// Try SSM first. If that fails (NotFound, AccessDenied, throttled),
+	// fall through to DescribeImages — both errors are logged so an
+	// operator can correlate "no drift on AL2 nodegroup" with "the
+	// pod's role lacks ssm:GetParameter".
+	out, ssmErr := lookupSSM(ctx, client, fam, amiType, k8sVersion)
+	if ssmErr == nil {
+		return out, nil
+	}
+	slog.Warn("eks ami catalog: ssm lookup failed; trying ec2 fallback",
+		"ami_type", string(amiType), "k8s", k8sVersion, "err", ssmErr)
+
+	if fam.EC2NamePattern == "" {
+		return nil, ssmErr
+	}
+	out, ec2Err := lookupEC2(ctx, client, fam, k8sVersion)
+	if ec2Err != nil {
+		return nil, fmt.Errorf("ssm: %w; ec2: %v", ssmErr, ec2Err)
+	}
+	return out, nil
+}
+
+// lookupSSM does two GetParameter calls (image_id + version) for
+// the family. Bottlerocket uses "image_version" instead of
+// "release_version"; the version-key shape is encoded in the
+// family's Tree.
+func lookupSSM(ctx context.Context, client amiCatalogAPI, fam amiFamily, amiType ekstypes.AMITypes, k8sVersion string) (*LatestAMI, error) {
+	imageIDPath, versionPath := ssmPaths(fam, amiType, k8sVersion)
+	if imageIDPath == "" {
+		return nil, errors.New("no ssm path for family")
+	}
+
+	imageOut, err := client.GetParameter(ctx, &ssm.GetParameterInput{Name: &imageIDPath})
+	if err != nil {
+		return nil, fmt.Errorf("ssm get %s: %w", imageIDPath, err)
+	}
+	if imageOut.Parameter == nil || imageOut.Parameter.Value == nil {
+		return nil, errors.New("ssm returned empty image_id parameter")
+	}
+
+	out := &LatestAMI{
+		ImageID:     *imageOut.Parameter.Value,
+		Source:      "ssm",
+		PublishedAt: imageOut.Parameter.LastModifiedDate,
+	}
+
+	// release_version / image_version is best-effort. A missing
+	// version key shouldn't fail the lookup — the image_id is
+	// already useful for the SPA's "latest is ami-…" display.
+	verOut, err := client.GetParameter(ctx, &ssm.GetParameterInput{Name: &versionPath})
+	if err != nil {
+		slog.Warn("eks ami catalog: version parameter unavailable",
+			"path", versionPath, "err", err)
+		return out, nil
+	}
+	if verOut.Parameter != nil && verOut.Parameter.Value != nil {
+		out.ReleaseVersion = *verOut.Parameter.Value
+	}
+	return out, nil
+}
+
+// ssmPaths builds the (image_id, version) SSM parameter paths for
+// the family. Pure function — exported via lowercase name for the
+// test, which exercises the matrix directly.
+func ssmPaths(fam amiFamily, amiType ekstypes.AMITypes, k8sVersion string) (string, string) {
+	switch fam.Tree {
+	case "eks":
+		base := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/recommended", k8sVersion, fam.Path)
+		return base + "/image_id", base + "/release_version"
+	case "bottlerocket":
+		// /aws/service/bottlerocket/aws-k8s-{k8s}{flavor}/{arch}/latest/{image_id|image_version}
+		flavor := bottlerocketFlavorSuffix(amiType)
+		base := fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s%s/%s/latest", k8sVersion, flavor, fam.Path)
+		return base + "/image_id", base + "/image_version"
+	}
+	return "", ""
+}
+
+// ── DescribeImages fallback ──────────────────────────────────────────
+
+func lookupEC2(ctx context.Context, client amiCatalogAPI, fam amiFamily, k8sVersion string) (*LatestAMI, error) {
+	pattern := strings.ReplaceAll(fam.EC2NamePattern, "{v}", k8sVersion)
+	owner := "amazon"
+	out, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Owners: []string{owner},
+		Filters: []ec2types.Filter{
+			{Name: aws.String("name"), Values: []string{pattern}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describe-images %s: %w", pattern, err)
+	}
+	if len(out.Images) == 0 {
+		return nil, fmt.Errorf("ec2 describe-images returned no images for %s", pattern)
+	}
+
+	// Pick the most recent by CreationDate. AWS returns RFC3339
+	// strings; lex-sort works because the format is fixed-width.
+	sort.SliceStable(out.Images, func(i, j int) bool {
+		return strDeref(out.Images[i].CreationDate) > strDeref(out.Images[j].CreationDate)
+	})
+	chosen := out.Images[0]
+
+	res := &LatestAMI{
+		ImageID: strDeref(chosen.ImageId),
+		Source:  "ec2",
+	}
+	if t, err := time.Parse(time.RFC3339, strDeref(chosen.CreationDate)); err == nil {
+		res.PublishedAt = &t
+	}
+	// EKS-optimized AMI names embed the release version, e.g.
+	// "amazon-eks-node-1.30-v20240819". Extract the trailing token
+	// when it looks like a version-y suffix; otherwise leave empty.
+	if name := strDeref(chosen.Name); name != "" {
+		if rv := releaseVersionFromAMIName(name); rv != "" {
+			res.ReleaseVersion = rv
+		}
+	}
+	return res, nil
+}
+
+// releaseVersionFromAMIName parses a release version out of an EKS-
+// optimized AMI name. Best-effort — returns "" if no recognizable
+// suffix is present. The format varies by family:
+//
+//   amazon-eks-node-1.30-v20240819                 → 1.30-v20240819
+//   amazon-eks-node-al2023-x86_64-standard-1.30-v20240819
+//                                                  → 1.30-v20240819
+//   bottlerocket-aws-k8s-1.30-x86_64-v1.20.5-…     → v1.20.5
+//
+// We split on "-" and look for a "vYYYYMMDD" or "vN.N.N" suffix.
+func releaseVersionFromAMIName(name string) string {
+	parts := strings.Split(name, "-")
+	for i := len(parts) - 1; i >= 0; i-- {
+		p := parts[i]
+		if len(p) > 1 && p[0] == 'v' && (isDigit(p[1])) {
+			// For EKS-optimized names the release version is the
+			// "1.30-v20240819" pair; include the previous segment if
+			// it parses as a k8s minor.
+			if i > 0 && looksLikeK8sMinor(parts[i-1]) {
+				return parts[i-1] + "-" + p
+			}
+			return p
+		}
+	}
+	return ""
+}
+
+func looksLikeK8sMinor(s string) bool {
+	// "1.30" / "1.30.0" — at least one dot, all numeric segments.
+	if !strings.Contains(s, ".") {
+		return false
+	}
+	for _, seg := range strings.Split(s, ".") {
+		if seg == "" {
+			return false
+		}
+		for _, r := range seg {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+// ── Drift computation ────────────────────────────────────────────────
+
+// driftResult is the slice the handler folds onto NodegroupSummary.
+type driftResult struct {
+	IsBehind             bool
+	DaysBehind           int
+	LatestReleaseVersion string
+	LatestImageID        string
+}
+
+// computeDrift compares the nodegroup's current ReleaseVersion to
+// the catalog's latest. Three outcomes:
+//
+//   - equal release_version: not behind. daysBehind=0.
+//   - different release_version with parseable date suffixes
+//     (-YYYYMMDD): daysBehind = days between dates.
+//   - different release_version, dates unparseable (Bottlerocket
+//     semver): isBehind=true, daysBehind=0. SPA shows "behind
+//     (days unknown)".
+func computeDrift(currentReleaseVersion string, latest *LatestAMI) driftResult {
+	if latest == nil {
+		return driftResult{}
+	}
+	out := driftResult{
+		LatestReleaseVersion: latest.ReleaseVersion,
+		LatestImageID:        latest.ImageID,
+	}
+	if currentReleaseVersion == "" || latest.ReleaseVersion == "" {
+		// Can't compare; assume not-behind so the SPA doesn't show a
+		// false alarm. Operators see "not tracked" via the
+		// driftComputed=false branch instead.
+		return out
+	}
+	if currentReleaseVersion == latest.ReleaseVersion {
+		return out // not behind
+	}
+	out.IsBehind = true
+	if d, ok := releaseVersionDateDiffDays(currentReleaseVersion, latest.ReleaseVersion); ok {
+		out.DaysBehind = d
+	}
+	return out
+}
+
+// releaseVersionDateDiffDays parses YYYYMMDD suffixes from two EKS
+// release versions and returns abs(latest - current) in whole days.
+// Returns false when either side doesn't have a parseable suffix
+// (Bottlerocket semver, custom names, …).
+func releaseVersionDateDiffDays(current, latest string) (int, bool) {
+	cd, ok := dateFromReleaseVersion(current)
+	if !ok {
+		return 0, false
+	}
+	ld, ok := dateFromReleaseVersion(latest)
+	if !ok {
+		return 0, false
+	}
+	hours := ld.Sub(cd).Hours()
+	if hours < 0 {
+		hours = -hours
+	}
+	return int(hours / 24), true
+}
+
+// dateFromReleaseVersion finds the rightmost 8-digit run preceded
+// by a non-digit and parses it as YYYYMMDD. Tolerates the various
+// EKS release-version shapes:
+//
+//   1.30.0-20240819             → 2024-08-19
+//   1.30-v20240819              → 2024-08-19
+//   v20240819                   → 2024-08-19
+func dateFromReleaseVersion(s string) (time.Time, bool) {
+	for i := len(s) - 8; i >= 0; i-- {
+		seg := s[i : i+8]
+		if !allDigits(seg) {
+			continue
+		}
+		if i > 0 && isDigit(s[i-1]) {
+			continue
+		}
+		if t, err := time.Parse("20060102", seg); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// strDeref is a tiny helper for SDK pointer fields. We don't want
+// to depend on the deref helper in eks_insights_handler.go because
+// the catalog is logically a separate concern; if we move it to a
+// subpackage later the helper goes with it.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cmd/periscope/eks_ami_catalog_cache.go
+++ b/cmd/periscope/eks_ami_catalog_cache.go
@@ -1,0 +1,114 @@
+package main
+
+// eks_ami_catalog_cache.go — TTL cache for "latest AMI" lookups.
+//
+// Different shape from the nodegroup cache: keys are
+// (amiType, k8sVersion) tuples (NOT cluster-scoped) because the
+// answer doesn't depend on which cluster asked. A fleet-wide view
+// of 50 clusters all running AL2023 1.30 nodegroups burns one SSM
+// call per (family, k8sVer) every 30 minutes, not 50.
+//
+// 30min TTL: the issue calls this number out and it's appropriate —
+// AWS publishes new AL2023 EKS-optimized AMIs roughly weekly, so
+// 30min is well inside any operator's "I want to know now" window
+// while still making the AWS API budget negligible.
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+const amiCatalogCacheMaxEntries = 256
+
+type amiCatalogCacheEntry struct {
+	value   *LatestAMI // nil = "lookup returned no answer" (negative cache)
+	err     error      // sticky error so a 30min misconfigured-IAM doesn't burn quota
+	expires time.Time
+}
+
+type amiCatalogCache struct {
+	ttl time.Duration
+	max int
+	mu  sync.Mutex
+	m   map[string]amiCatalogCacheEntry
+}
+
+func newAMICatalogCache(ttl time.Duration) *amiCatalogCache {
+	return &amiCatalogCache{
+		ttl: ttl,
+		max: amiCatalogCacheMaxEntries,
+		m:   make(map[string]amiCatalogCacheEntry),
+	}
+}
+
+// Get returns the cached lookup, if any. Three return shapes:
+//
+//   ok=false           : cache miss; caller does the AWS call
+//   ok=true, err==nil  : cached success — value points to the
+//                        catalog entry (nil if the family is
+//                        unsupported, see lookupSSM negative case)
+//   ok=true, err!=nil  : cached failure; do not retry
+func (c *amiCatalogCache) Get(amiType ekstypes.AMITypes, k8sVersion string) (*LatestAMI, error, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[amiCatalogKey(amiType, k8sVersion)]
+	if !ok {
+		return nil, nil, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.m, amiCatalogKey(amiType, k8sVersion))
+		return nil, nil, false
+	}
+	return e.value, e.err, true
+}
+
+func (c *amiCatalogCache) Put(amiType ekstypes.AMITypes, k8sVersion string, val *LatestAMI, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[amiCatalogKey(amiType, k8sVersion)] = amiCatalogCacheEntry{
+		value:   val,
+		err:     err,
+		expires: time.Now().Add(c.ttl),
+	}
+	if len(c.m) > c.max {
+		c.evictLocked()
+	}
+}
+
+func (c *amiCatalogCache) evictLocked() {
+	now := time.Now()
+	for k, e := range c.m {
+		if now.After(e.expires) {
+			delete(c.m, k)
+		}
+	}
+	if len(c.m) <= c.max {
+		return
+	}
+	type kv struct {
+		key string
+		exp time.Time
+	}
+	all := make([]kv, 0, len(c.m))
+	for k, e := range c.m {
+		all = append(all, kv{key: k, exp: e.expires})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].exp.Before(all[j].exp) })
+	target := c.max * 9 / 10
+	for i := 0; i < len(all)-target; i++ {
+		delete(c.m, all[i].key)
+	}
+}
+
+func (c *amiCatalogCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.m)
+}
+
+func amiCatalogKey(t ekstypes.AMITypes, k8sVersion string) string {
+	return string(t) + "|" + k8sVersion
+}

--- a/cmd/periscope/eks_ami_catalog_cache_test.go
+++ b/cmd/periscope/eks_ami_catalog_cache_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+func TestAMICatalogCache_PutGet(t *testing.T) {
+	c := newAMICatalogCache(time.Hour)
+	val := &LatestAMI{ImageID: "ami-1", Source: "ssm"}
+	c.Put(ekstypes.AMITypesAl2023X8664Standard, "1.30", val, nil)
+
+	got, err, hit := c.Get(ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	if !hit {
+		t.Fatalf("expected hit")
+	}
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != val {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestAMICatalogCache_StickyError(t *testing.T) {
+	c := newAMICatalogCache(time.Hour)
+	want := errors.New("AccessDenied")
+	c.Put(ekstypes.AMITypesAl2023X8664Standard, "1.30", nil, want)
+
+	got, err, hit := c.Get(ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	if !hit {
+		t.Fatalf("expected hit")
+	}
+	if !errors.Is(err, want) && err.Error() != want.Error() {
+		t.Errorf("err = %v", err)
+	}
+	if got != nil {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestAMICatalogCache_Expiry(t *testing.T) {
+	c := newAMICatalogCache(time.Millisecond)
+	c.Put(ekstypes.AMITypesAl2023X8664Standard, "1.30", &LatestAMI{}, nil)
+	time.Sleep(10 * time.Millisecond)
+	if _, _, hit := c.Get(ekstypes.AMITypesAl2023X8664Standard, "1.30"); hit {
+		t.Errorf("expected expired entry to miss")
+	}
+}
+
+func TestAMICatalogCache_KeyDistinguishesAMITypeAndK8s(t *testing.T) {
+	c := newAMICatalogCache(time.Hour)
+	c.Put(ekstypes.AMITypesAl2023X8664Standard, "1.30", &LatestAMI{ImageID: "a"}, nil)
+	c.Put(ekstypes.AMITypesAl2023Arm64Standard, "1.30", &LatestAMI{ImageID: "b"}, nil)
+	c.Put(ekstypes.AMITypesAl2023X8664Standard, "1.31", &LatestAMI{ImageID: "c"}, nil)
+
+	a, _, _ := c.Get(ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	b, _, _ := c.Get(ekstypes.AMITypesAl2023Arm64Standard, "1.30")
+	d, _, _ := c.Get(ekstypes.AMITypesAl2023X8664Standard, "1.31")
+
+	if a == nil || b == nil || d == nil {
+		t.Fatalf("a=%v b=%v d=%v", a, b, d)
+	}
+	if a.ImageID == b.ImageID || a.ImageID == d.ImageID {
+		t.Errorf("keys collided: a=%s b=%s d=%s", a.ImageID, b.ImageID, d.ImageID)
+	}
+}

--- a/cmd/periscope/eks_ami_catalog_test.go
+++ b/cmd/periscope/eks_ami_catalog_test.go
@@ -174,8 +174,8 @@ func TestLatestForNodegroup_FallsBackToEC2OnSSMFailure(t *testing.T) {
 			return nil, errors.New("AccessDenied: GetParameter")
 		},
 		ec2Fn: func(_ context.Context, in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
-			if len(in.Owners) != 1 || in.Owners[0] != "amazon" {
-				t.Errorf("expected owners=[amazon], got %v", in.Owners)
+			if len(in.Owners) != 2 || in.Owners[0] != "amazon" || in.Owners[1] != "602401143452" {
+				t.Errorf("expected owners=[amazon 602401143452], got %v", in.Owners)
 			}
 			id := imageID
 			cd := creation
@@ -207,8 +207,10 @@ func TestLookupEC2_PicksMostRecent(t *testing.T) {
 	nameB := "amazon-eks-node-1.30-v20240901"
 
 	fam, _ := familyForAMIType(ekstypes.AMITypesAl2X8664)
+	var capturedOwners []string
 	fake := &fakeAMICatalogClient{
-		ec2Fn: func(_ context.Context, _ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+		ec2Fn: func(_ context.Context, in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+			capturedOwners = in.Owners
 			// Return out-of-order to confirm the sort.
 			return &ec2.DescribeImagesOutput{Images: []ec2types.Image{
 				{ImageId: aws.String(idA), CreationDate: aws.String(older), Name: aws.String(nameA)},
@@ -222,6 +224,19 @@ func TestLookupEC2_PicksMostRecent(t *testing.T) {
 	}
 	if got.ImageID != idB {
 		t.Errorf("expected newer image, got %q", got.ImageID)
+	}
+	// LatestSeenAt is populated from the AMI's CreationDate on the EC2
+	// path; renaming PublishedAt → LatestSeenAt was a duplicate-code
+	// cleanup so the field's semantics are explicit.
+	if got.LatestSeenAt == nil || got.LatestSeenAt.Year() != 2024 {
+		t.Errorf("LatestSeenAt = %v, want 2024-09-01-ish", got.LatestSeenAt)
+	}
+	// Owners must include both the "amazon" alias (covers AL2023) and
+	// the historical EKS-optimized AMI account 602401143452 (covers
+	// AL2 in older partitions). Without the second owner the fallback
+	// silently returns zero results in those regions.
+	if len(capturedOwners) != 2 || capturedOwners[0] != "amazon" || capturedOwners[1] != "602401143452" {
+		t.Errorf("Owners = %v, want [amazon 602401143452]", capturedOwners)
 	}
 }
 

--- a/cmd/periscope/eks_ami_catalog_test.go
+++ b/cmd/periscope/eks_ami_catalog_test.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// fakeAMICatalogClient implements amiCatalogAPI. Per-test wiring of
+// SSM and EC2 fns so each test pins exactly the failure mode it
+// cares about.
+type fakeAMICatalogClient struct {
+	ssmFn func(ctx context.Context, in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+	ec2Fn func(ctx context.Context, in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
+}
+
+func (f *fakeAMICatalogClient) GetParameter(ctx context.Context, in *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	if f.ssmFn == nil {
+		return nil, errors.New("ssmFn not set")
+	}
+	return f.ssmFn(ctx, in)
+}
+
+func (f *fakeAMICatalogClient) DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, _ ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+	if f.ec2Fn == nil {
+		return nil, errors.New("ec2Fn not set")
+	}
+	return f.ec2Fn(ctx, in)
+}
+
+// ── SSM path mapping ─────────────────────────────────────────────────
+
+func TestSSMPaths(t *testing.T) {
+	cases := []struct {
+		name        string
+		amiType     ekstypes.AMITypes
+		k8sVersion  string
+		wantImageID string
+		wantVersion string
+	}{
+		{
+			name:        "AL2023_x86_64_STANDARD",
+			amiType:     ekstypes.AMITypesAl2023X8664Standard,
+			k8sVersion:  "1.30",
+			wantImageID: "/aws/service/eks/optimized-ami/1.30/amazon-linux-2023/x86_64/standard/recommended/image_id",
+			wantVersion: "/aws/service/eks/optimized-ami/1.30/amazon-linux-2023/x86_64/standard/recommended/release_version",
+		},
+		{
+			name:        "AL2_x86_64",
+			amiType:     ekstypes.AMITypesAl2X8664,
+			k8sVersion:  "1.29",
+			wantImageID: "/aws/service/eks/optimized-ami/1.29/amazon-linux-2/recommended/image_id",
+			wantVersion: "/aws/service/eks/optimized-ami/1.29/amazon-linux-2/recommended/release_version",
+		},
+		{
+			name:        "Bottlerocket_x86_64",
+			amiType:     ekstypes.AMITypesBottlerocketX8664,
+			k8sVersion:  "1.30",
+			wantImageID: "/aws/service/bottlerocket/aws-k8s-1.30/x86_64/latest/image_id",
+			wantVersion: "/aws/service/bottlerocket/aws-k8s-1.30/x86_64/latest/image_version",
+		},
+		{
+			name:        "Bottlerocket_arm64_nvidia",
+			amiType:     ekstypes.AMITypesBottlerocketArm64Nvidia,
+			k8sVersion:  "1.30",
+			wantImageID: "/aws/service/bottlerocket/aws-k8s-1.30-nvidia/arm64/latest/image_id",
+			wantVersion: "/aws/service/bottlerocket/aws-k8s-1.30-nvidia/arm64/latest/image_version",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fam, ok := familyForAMIType(tc.amiType)
+			if !ok {
+				t.Fatalf("expected family for %s", tc.amiType)
+			}
+			gotImage, gotVersion := ssmPaths(fam, tc.amiType, tc.k8sVersion)
+			if gotImage != tc.wantImageID {
+				t.Errorf("image_id path = %q, want %q", gotImage, tc.wantImageID)
+			}
+			if gotVersion != tc.wantVersion {
+				t.Errorf("version path = %q, want %q", gotVersion, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestFamilyForAMIType_UnsupportedReturnsFalse(t *testing.T) {
+	if _, ok := familyForAMIType(ekstypes.AMITypesWindowsCore2022X8664); ok {
+		t.Errorf("Windows AMIs should be unsupported in v1")
+	}
+	if _, ok := familyForAMIType(ekstypes.AMITypesCustom); ok {
+		t.Errorf("CUSTOM AMI should not have a family entry (handler skips earlier)")
+	}
+}
+
+// ── SSM lookup happy path ────────────────────────────────────────────
+
+func TestLatestForNodegroup_SSMPathPopulatesAll(t *testing.T) {
+	imageID := "ami-0abc"
+	releaseVersion := "1.30.0-20240901"
+	mod := time.Date(2024, 9, 1, 0, 0, 0, 0, time.UTC)
+	calls := 0
+	fake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			calls++
+			val := imageID
+			if in.Name != nil && (lastTokenIs(*in.Name, "release_version") || lastTokenIs(*in.Name, "image_version")) {
+				val = releaseVersion
+			}
+			return &ssm.GetParameterOutput{
+				Parameter: &ssmtypes.Parameter{
+					Name:             in.Name,
+					Value:            &val,
+					LastModifiedDate: &mod,
+				},
+			}, nil
+		},
+	}
+
+	got, err := latestForNodegroup(context.Background(), fake, ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil LatestAMI")
+	}
+	if got.ImageID != imageID || got.ReleaseVersion != releaseVersion || got.Source != "ssm" {
+		t.Errorf("got = %+v", got)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 SSM calls (image_id + version), got %d", calls)
+	}
+}
+
+// release_version key missing should NOT fail the lookup — the
+// image_id alone is useful, and the SPA degrades gracefully.
+func TestLatestForNodegroup_VersionMissingDoesNotFail(t *testing.T) {
+	imageID := "ami-0abc"
+	fake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			if in.Name != nil && lastTokenIs(*in.Name, "release_version") {
+				return nil, errors.New("ParameterNotFound")
+			}
+			return &ssm.GetParameterOutput{
+				Parameter: &ssmtypes.Parameter{Value: &imageID},
+			}, nil
+		},
+	}
+	got, err := latestForNodegroup(context.Background(), fake, ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got == nil || got.ImageID != imageID || got.ReleaseVersion != "" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+// ── DescribeImages fallback ──────────────────────────────────────────
+
+func TestLatestForNodegroup_FallsBackToEC2OnSSMFailure(t *testing.T) {
+	creation := "2024-09-01T00:00:00.000Z"
+	imageID := "ami-fallback"
+	imageName := "amazon-eks-node-al2023-x86_64-standard-1.30-v20240901"
+	fake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, errors.New("AccessDenied: GetParameter")
+		},
+		ec2Fn: func(_ context.Context, in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+			if len(in.Owners) != 1 || in.Owners[0] != "amazon" {
+				t.Errorf("expected owners=[amazon], got %v", in.Owners)
+			}
+			id := imageID
+			cd := creation
+			n := imageName
+			return &ec2.DescribeImagesOutput{Images: []ec2types.Image{
+				{ImageId: &id, CreationDate: &cd, Name: &n},
+			}}, nil
+		},
+	}
+
+	got, err := latestForNodegroup(context.Background(), fake, ekstypes.AMITypesAl2023X8664Standard, "1.30")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got == nil || got.ImageID != imageID || got.Source != "ec2" {
+		t.Errorf("got = %+v", got)
+	}
+	if got.ReleaseVersion != "1.30-v20240901" {
+		t.Errorf("expected release version parsed from name; got %q", got.ReleaseVersion)
+	}
+}
+
+// EC2 fallback picks the most recent CreationDate.
+func TestLookupEC2_PicksMostRecent(t *testing.T) {
+	older := "2024-08-01T00:00:00.000Z"
+	newer := "2024-09-01T00:00:00.000Z"
+	idA, idB := "ami-old", "ami-new"
+	nameA := "amazon-eks-node-1.30-v20240801"
+	nameB := "amazon-eks-node-1.30-v20240901"
+
+	fam, _ := familyForAMIType(ekstypes.AMITypesAl2X8664)
+	fake := &fakeAMICatalogClient{
+		ec2Fn: func(_ context.Context, _ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+			// Return out-of-order to confirm the sort.
+			return &ec2.DescribeImagesOutput{Images: []ec2types.Image{
+				{ImageId: aws.String(idA), CreationDate: aws.String(older), Name: aws.String(nameA)},
+				{ImageId: aws.String(idB), CreationDate: aws.String(newer), Name: aws.String(nameB)},
+			}}, nil
+		},
+	}
+	got, err := lookupEC2(context.Background(), fake, fam, "1.30")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got.ImageID != idB {
+		t.Errorf("expected newer image, got %q", got.ImageID)
+	}
+}
+
+// Family with no EC2 pattern means an SSM failure surfaces directly.
+func TestLatestForNodegroup_UnsupportedFamilyReturnsNil(t *testing.T) {
+	got, err := latestForNodegroup(context.Background(), nil, ekstypes.AMITypesWindowsCore2022X8664, "1.30")
+	if err != nil {
+		t.Errorf("err = %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for unsupported family, got %+v", got)
+	}
+}
+
+// ── Drift computation ────────────────────────────────────────────────
+
+func TestComputeDrift_EqualReleaseNotBehind(t *testing.T) {
+	r := computeDrift("1.30.0-20240901", &LatestAMI{ReleaseVersion: "1.30.0-20240901"})
+	if r.IsBehind || r.DaysBehind != 0 {
+		t.Errorf("got = %+v", r)
+	}
+}
+
+func TestComputeDrift_DifferentDateSurfacesDays(t *testing.T) {
+	r := computeDrift("1.30.0-20240819", &LatestAMI{ReleaseVersion: "1.30.0-20240901"})
+	if !r.IsBehind {
+		t.Errorf("expected IsBehind=true")
+	}
+	if r.DaysBehind != 13 {
+		t.Errorf("DaysBehind = %d, want 13", r.DaysBehind)
+	}
+}
+
+func TestComputeDrift_BottlerocketSemverNoDays(t *testing.T) {
+	// Bottlerocket image_version is semver — the date diff isn't
+	// computable, so daysBehind stays 0 but IsBehind is true.
+	r := computeDrift("1.20.4", &LatestAMI{ReleaseVersion: "1.20.5"})
+	if !r.IsBehind {
+		t.Errorf("expected IsBehind=true")
+	}
+	if r.DaysBehind != 0 {
+		t.Errorf("DaysBehind = %d, want 0", r.DaysBehind)
+	}
+}
+
+func TestComputeDrift_NilLatestReturnsZero(t *testing.T) {
+	r := computeDrift("1.30.0-20240819", nil)
+	if r.IsBehind || r.DaysBehind != 0 || r.LatestReleaseVersion != "" {
+		t.Errorf("got = %+v", r)
+	}
+}
+
+func TestComputeDrift_EmptyCurrentBailsOut(t *testing.T) {
+	r := computeDrift("", &LatestAMI{ReleaseVersion: "1.30.0-20240901"})
+	if r.IsBehind {
+		t.Errorf("empty current shouldn't trigger IsBehind")
+	}
+	if r.LatestReleaseVersion != "1.30.0-20240901" {
+		t.Errorf("LatestReleaseVersion = %q", r.LatestReleaseVersion)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+func lastTokenIs(path, want string) bool {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[i+1:] == want
+		}
+	}
+	return path == want
+}
+
+func TestReleaseVersionFromAMIName(t *testing.T) {
+	cases := map[string]string{
+		"amazon-eks-node-1.30-v20240819":                          "1.30-v20240819",
+		"amazon-eks-node-al2023-x86_64-standard-1.30-v20240901":   "1.30-v20240901",
+		"bottlerocket-aws-k8s-1.30-x86_64-v1.20.5-1234abcd":       "v1.20.5",
+		"some-random-name-without-version":                        "",
+	}
+	for name, want := range cases {
+		if got := releaseVersionFromAMIName(name); got != want {
+			t.Errorf("%s → %q, want %q", name, got, want)
+		}
+	}
+}

--- a/cmd/periscope/eks_insights_cache.go
+++ b/cmd/periscope/eks_insights_cache.go
@@ -1,0 +1,164 @@
+package main
+
+// eks_insights_cache.go — bounded TTL cache for the
+// /eks/upgrade-insights endpoints.
+//
+// Two important divergences from helmListCache (the closest
+// existing analogue):
+//
+//   1. Cluster-keyed only, NOT actor-keyed. EKS Upgrade Insights
+//      come from AWS at the cluster boundary; they are not
+//      RBAC-filtered against the requesting user the way the helm
+//      release list is. Per-actor keying would inflate cache
+//      cardinality (1 entry per (user, cluster) pair instead of
+//      per cluster) for no benefit, and would prevent shared cache
+//      hits across users looking at the same cluster — which is
+//      the common case for upgrade reviews.
+//
+//   2. Long TTL (1h). AWS itself only refreshes insights once per
+//      day, so polling more aggressively just burns money on AWS
+//      API calls without changing what the operator sees. The TTL
+//      can still be busted by a process restart (the cache lives in
+//      memory only).
+//
+// One cache shared across the list and detail endpoints. The list
+// entry is keyed "list" and the detail entries are keyed by
+// insightId — both within a per-cluster namespace.
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// eksInsightsCacheMaxEntries caps the cache. With a few dozen
+// insights per cluster × a list entry × ~50 clusters in a fleet,
+// 256 entries is generous; the sweep keeps memory bounded under
+// pathological registries too.
+const eksInsightsCacheMaxEntries = 256
+
+// eksInsightsCacheValue is the discriminated union the cache holds.
+// Exactly one of List or Detail is non-nil for any given entry; the
+// other is the zero value. Using pointers avoids copying the larger
+// detail blob on Get.
+type eksInsightsCacheValue struct {
+	List   *UpgradeInsightsListResponse
+	Detail *UpgradeInsightDetail
+}
+
+type eksInsightsCache struct {
+	ttl time.Duration
+	max int
+	mu  sync.Mutex
+	m   map[string]eksInsightsCacheEntry
+}
+
+type eksInsightsCacheEntry struct {
+	value   eksInsightsCacheValue
+	expires time.Time
+}
+
+func newEKSInsightsCache(ttl time.Duration) *eksInsightsCache {
+	return &eksInsightsCache{
+		ttl: ttl,
+		max: eksInsightsCacheMaxEntries,
+		m:   make(map[string]eksInsightsCacheEntry),
+	}
+}
+
+// GetList returns the cached list response for cluster, if any.
+// The returned pointer points into the cache; callers must treat
+// the value as read-only.
+func (c *eksInsightsCache) GetList(cluster string) (*UpgradeInsightsListResponse, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[listKey(cluster)]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.m, listKey(cluster))
+		return nil, false
+	}
+	return e.value.List, e.value.List != nil
+}
+
+// PutList stores the list response under (cluster, "list").
+func (c *eksInsightsCache) PutList(cluster string, val UpgradeInsightsListResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[listKey(cluster)] = eksInsightsCacheEntry{
+		value:   eksInsightsCacheValue{List: &val},
+		expires: time.Now().Add(c.ttl),
+	}
+	if len(c.m) > c.max {
+		c.evictLocked()
+	}
+}
+
+// GetDetail returns the cached detail blob for (cluster, insightId).
+func (c *eksInsightsCache) GetDetail(cluster, insightID string) (*UpgradeInsightDetail, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[detailKey(cluster, insightID)]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.m, detailKey(cluster, insightID))
+		return nil, false
+	}
+	return e.value.Detail, e.value.Detail != nil
+}
+
+// PutDetail stores the detail blob under (cluster, insightId).
+func (c *eksInsightsCache) PutDetail(cluster, insightID string, val UpgradeInsightDetail) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[detailKey(cluster, insightID)] = eksInsightsCacheEntry{
+		value:   eksInsightsCacheValue{Detail: &val},
+		expires: time.Now().Add(c.ttl),
+	}
+	if len(c.m) > c.max {
+		c.evictLocked()
+	}
+}
+
+// evictLocked is called with c.mu held when the map is over cap.
+// Sweeps expired entries first; if still over cap, trims the
+// oldest-expiry entries down to 90% of cap. Mirrors helmListCache so
+// behavior under memory pressure is consistent across handlers.
+func (c *eksInsightsCache) evictLocked() {
+	now := time.Now()
+	for k, e := range c.m {
+		if now.After(e.expires) {
+			delete(c.m, k)
+		}
+	}
+	if len(c.m) <= c.max {
+		return
+	}
+	type kv struct {
+		key string
+		exp time.Time
+	}
+	all := make([]kv, 0, len(c.m))
+	for k, e := range c.m {
+		all = append(all, kv{key: k, exp: e.expires})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].exp.Before(all[j].exp) })
+	target := c.max * 9 / 10
+	for i := 0; i < len(all)-target; i++ {
+		delete(c.m, all[i].key)
+	}
+}
+
+// Len reports the current entry count. Test-only.
+func (c *eksInsightsCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.m)
+}
+
+func listKey(cluster string) string         { return cluster + "|list" }
+func detailKey(cluster, id string) string   { return cluster + "|d|" + id }

--- a/cmd/periscope/eks_insights_cache_test.go
+++ b/cmd/periscope/eks_insights_cache_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEKSInsightsCache_ListPutGet(t *testing.T) {
+	c := newEKSInsightsCache(time.Hour)
+	val := UpgradeInsightsListResponse{
+		Insights: []UpgradeInsightSummary{{ID: "abc", Status: "PASSING"}},
+		Counts:   UpgradeInsightCounts{Passing: 1},
+	}
+	c.PutList("prod", val)
+
+	got, ok := c.GetList("prod")
+	if !ok {
+		t.Fatalf("expected hit")
+	}
+	if len(got.Insights) != 1 || got.Insights[0].ID != "abc" {
+		t.Fatalf("got = %+v, want one insight with ID abc", got)
+	}
+	if _, ok := c.GetList("staging"); ok {
+		t.Fatalf("staging should miss — different cluster key")
+	}
+}
+
+func TestEKSInsightsCache_DetailPutGet(t *testing.T) {
+	c := newEKSInsightsCache(time.Hour)
+	val := UpgradeInsightDetail{
+		UpgradeInsightSummary: UpgradeInsightSummary{ID: "i-1", Status: "ERROR"},
+		Resources: []UpgradeInsightResourceRef{
+			{KubernetesResourceURI: "/api/v1/pods/x"},
+		},
+	}
+	c.PutDetail("prod", "i-1", val)
+
+	got, ok := c.GetDetail("prod", "i-1")
+	if !ok {
+		t.Fatalf("expected hit")
+	}
+	if got.ID != "i-1" || len(got.Resources) != 1 {
+		t.Fatalf("got = %+v", got)
+	}
+	if _, ok := c.GetDetail("prod", "i-2"); ok {
+		t.Fatalf("different insightId should miss")
+	}
+	if _, ok := c.GetDetail("other", "i-1"); ok {
+		t.Fatalf("different cluster should miss")
+	}
+}
+
+func TestEKSInsightsCache_Expiry(t *testing.T) {
+	c := newEKSInsightsCache(time.Millisecond)
+	c.PutList("prod", UpgradeInsightsListResponse{})
+	time.Sleep(10 * time.Millisecond)
+	if _, ok := c.GetList("prod"); ok {
+		t.Fatalf("expected expired entry to miss")
+	}
+}
+
+func TestEKSInsightsCache_Eviction(t *testing.T) {
+	// Force the cap below the natural ceiling so we can exercise the
+	// eviction path deterministically. 4 entries → cap 3 → after the
+	// 4th Put we should be at len 3 (90% of cap, rounded down to int).
+	c := newEKSInsightsCache(time.Hour)
+	c.max = 3
+
+	c.PutList("a", UpgradeInsightsListResponse{})
+	c.PutList("b", UpgradeInsightsListResponse{})
+	c.PutList("c", UpgradeInsightsListResponse{})
+	c.PutList("d", UpgradeInsightsListResponse{})
+
+	if got := c.Len(); got > 3 {
+		t.Fatalf("cache exceeded cap: len = %d, want <= 3", got)
+	}
+}

--- a/cmd/periscope/eks_insights_handler.go
+++ b/cmd/periscope/eks_insights_handler.go
@@ -1,0 +1,498 @@
+package main
+
+// eks_insights_handler.go — read-only EKS Upgrade Insights endpoints.
+//
+//   GET /api/clusters/{cluster}/eks/upgrade-insights
+//   GET /api/clusters/{cluster}/eks/upgrade-insights/{insightId}
+//
+// Both wrap AWS EKS SDK calls (ListInsights and DescribeInsight)
+// scoped to the UPGRADE_READINESS category. The unique-to-Periscope
+// move is that each affected resource on the detail blob is decorated
+// with an `editorPath` field — a deep link into the SPA's existing
+// per-kind list page with the YAML tab pre-selected. AWS Console
+// can't do that; kubectl can't do that. "From scan to fix in one
+// click" is the differentiator.
+//
+// Both endpoints are EKS-only by design. For non-EKS clusters the
+// surface returns 422 + a stable `E_BACKEND_NOT_EKS` code so the SPA
+// can render a clear empty state ("upgrade insights are an EKS
+// feature; this cluster's backend is `agent`") instead of a generic
+// red banner. 404 would be wrong — the cluster exists, the surface
+// just doesn't apply.
+//
+// Audit: every read emits a VerbEKSInsightsRead row regardless of
+// outcome (success / failure). Compliance reviewers asked for a
+// record that an operator checked upgrade readiness before a
+// version bump, so the read itself has to be auditable. The verb
+// is documented in internal/audit/event.go as the first read verb;
+// this handler is the only emission site today.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// eksInsightsListMaxResults caps the AWS-side page size. The
+// UPGRADE_READINESS category produces a small fixed set of insights
+// per cluster (~30) so a single page covers every real cluster.
+// We do not paginate; if AWS ever returns a NextToken the handler
+// returns what it has and logs a warning — the alternative
+// (silently fetching every page) makes the cache TTL story
+// confusing because partial results would be the new normal.
+const eksInsightsListMaxResults = 100
+
+// errBackendNotEKSCode is the stable string the SPA matches on to
+// render the non-EKS empty state. Treat as part of the public API
+// once shipped — renaming requires a coordinated SPA release.
+const errBackendNotEKSCode = "E_BACKEND_NOT_EKS"
+
+// eksInsightsAPI is the subset of the EKS SDK this handler depends
+// on. Defining a narrow interface keeps the test seam tiny — the
+// real client (eks.NewFromConfig(...)) satisfies it implicitly.
+type eksInsightsAPI interface {
+	ListInsights(ctx context.Context, in *eks.ListInsightsInput, opts ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
+	DescribeInsight(ctx context.Context, in *eks.DescribeInsightInput, opts ...func(*eks.Options)) (*eks.DescribeInsightOutput, error)
+}
+
+// newEKSInsightsClient is swapped by tests for a fake. The default
+// builds a real eks.Client from the request's Provider — same
+// shape used in internal/k8s/client.go's buildEKSRestConfig.
+var newEKSInsightsClient = defaultNewEKSInsightsClient
+
+func defaultNewEKSInsightsClient(p credentials.Provider, c clusters.Cluster) eksInsightsAPI {
+	return eks.NewFromConfig(aws.Config{
+		Region:      c.Region,
+		Credentials: p,
+	})
+}
+
+// ── Wire types ───────────────────────────────────────────────────────
+
+// UpgradeInsightCounts is the bucket header the SPA renders on the
+// overview card and the tab. Keeping it server-computed means the
+// summary stays consistent across browsers / refreshes / the card
+// vs. the tab. AWS does not return a precomputed count.
+type UpgradeInsightCounts struct {
+	Passing int `json:"passing"`
+	Warning int `json:"warning"`
+	Error   int `json:"error"`
+	Unknown int `json:"unknown"`
+}
+
+// UpgradeInsightSummary is one row in the list response — and the
+// embedded base of UpgradeInsightDetail so the detail endpoint
+// returns a strict superset of fields. Pointer-typed timestamps so
+// "AWS didn't tell us" stays distinguishable from the zero time.
+type UpgradeInsightSummary struct {
+	ID                 string     `json:"id"`
+	Name               string     `json:"name"`
+	Category           string     `json:"category"`
+	KubernetesVersion  string     `json:"kubernetesVersion,omitempty"`
+	Status             string     `json:"status"`
+	StatusReason       string     `json:"statusReason,omitempty"`
+	LastRefreshTime    *time.Time `json:"lastRefreshTime,omitempty"`
+	LastTransitionTime *time.Time `json:"lastTransitionTime,omitempty"`
+	Description        string     `json:"description,omitempty"`
+}
+
+// UpgradeInsightsListResponse is the GET /upgrade-insights payload.
+type UpgradeInsightsListResponse struct {
+	Insights []UpgradeInsightSummary `json:"insights"`
+	Counts   UpgradeInsightCounts    `json:"counts"`
+	// TargetKubernetesVersion is the version most insights point at,
+	// surfaced on the card. Picked as the modal value across the
+	// list; ties broken in favor of the highest version. Empty when
+	// no insight reports a version (which would be a degenerate AWS
+	// response but is permitted by the schema).
+	TargetKubernetesVersion string `json:"targetKubernetesVersion,omitempty"`
+}
+
+// UpgradeInsightResourceRef is one affected K8s object. The raw
+// `kubernetesResourceUri` is preserved verbatim so the SPA can show
+// it as a tooltip even when we couldn't parse it; the parsed pieces
+// and `editorPath` are populated only on a clean parse.
+type UpgradeInsightResourceRef struct {
+	KubernetesResourceURI string `json:"kubernetesResourceUri"`
+	ARN                   string `json:"arn,omitempty"`
+	Group                 string `json:"group,omitempty"`
+	Version               string `json:"version,omitempty"`
+	Resource              string `json:"resource,omitempty"`
+	Namespace             string `json:"namespace,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	EditorPath            string `json:"editorPath,omitempty"`
+	Status                string `json:"status,omitempty"`
+	StatusReason          string `json:"statusReason,omitempty"`
+}
+
+// DeprecationDetail mirrors the AWS shape, with timestamps repointed
+// from *time.Time so JSON encoding emits ISO-8601 instead of the
+// SDK's pointer indirection.
+type DeprecationDetail struct {
+	Usage                          string                  `json:"usage,omitempty"`
+	ReplacedWith                   string                  `json:"replacedWith,omitempty"`
+	StopServingVersion             string                  `json:"stopServingVersion,omitempty"`
+	StartServingReplacementVersion string                  `json:"startServingReplacementVersion,omitempty"`
+	ClientStats                    []DeprecationClientStat `json:"clientStats,omitempty"`
+}
+
+// DeprecationClientStat is per-user-agent traffic the apiserver saw
+// against a deprecated API. Useful for "this controller is the one
+// still calling v1beta1 PSP" debugging.
+type DeprecationClientStat struct {
+	UserAgent                  string     `json:"userAgent,omitempty"`
+	NumberOfRequestsLast30Days int32      `json:"numberOfRequestsLast30Days,omitempty"`
+	LastRequestTime            *time.Time `json:"lastRequestTime,omitempty"`
+}
+
+// UpgradeInsightDetail is the GET /upgrade-insights/{id} payload.
+// Embeds the summary so a client that already has a row from the
+// list endpoint can detect whether to re-render based on summary
+// fields without diff-ing every detail field.
+type UpgradeInsightDetail struct {
+	UpgradeInsightSummary
+	Recommendation     string                      `json:"recommendation,omitempty"`
+	AdditionalInfo     map[string]string           `json:"additionalInfo,omitempty"`
+	Resources          []UpgradeInsightResourceRef `json:"resources"`
+	DeprecationDetails []DeprecationDetail         `json:"deprecationDetails,omitempty"`
+}
+
+// apiError is the structured error envelope used for the non-EKS
+// branch. Mirrors the http.Error pattern other handlers use but
+// adds a stable `code` so the SPA can branch on E_BACKEND_NOT_EKS
+// without parsing free-form English.
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeAPIErrorJSON(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(apiError{Code: code, Message: msg})
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────
+
+// eksInsightsListHandler returns the cluster's UPGRADE_READINESS
+// insights with precomputed bucket counts. Cache-first; cache miss
+// invokes ListInsights with the category filter.
+func eksInsightsListHandler(reg *clusters.Registry, cache *eksInsightsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		if !isEKSBackend(c) {
+			// No audit row here — the backend mismatch is a SPA-side
+			// branch, not a privileged action that needs a forensic
+			// record. The SPA only hits this endpoint speculatively
+			// for non-EKS clusters when the operator clicks the tab.
+			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
+				errBackendNotEKSCode,
+				"upgrade insights are only available for EKS-backed clusters")
+			return
+		}
+
+		if cached, ok := cache.GetList(c.Name); ok {
+			writeJSON(w, http.StatusOK, *cached)
+			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "cache_hit", "")
+			return
+		}
+
+		client := newEKSInsightsClient(p, c)
+		eksName := c.EKSName()
+		out, err := client.ListInsights(r.Context(), &eks.ListInsightsInput{
+			ClusterName: &eksName,
+			Filter: &ekstypes.InsightsFilter{
+				Categories: []ekstypes.Category{ekstypes.CategoryUpgradeReadiness},
+			},
+			MaxResults: int32Ptr(eksInsightsListMaxResults),
+		})
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.Warn("eks insights list failed", "cluster", c.Name, "err", err)
+			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "list", err.Error())
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"failed to list upgrade insights: "+err.Error())
+			return
+		}
+		if out.NextToken != nil && *out.NextToken != "" {
+			// Truncation case. The UPGRADE_READINESS list is small
+			// enough that we don't expect this in practice; log so
+			// it's visible if AWS ever changes the cardinality.
+			slog.Warn("eks insights list truncated; not paginating",
+				"cluster", c.Name, "page_size", eksInsightsListMaxResults)
+		}
+
+		resp := buildListResponse(out.Insights)
+		cache.PutList(c.Name, resp)
+		writeJSON(w, http.StatusOK, resp)
+		emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "list", "")
+	}
+}
+
+// eksInsightsGetHandler returns the per-insight detail blob with
+// per-resource editor links. Same cache backing as the list
+// endpoint but keyed by insightId.
+func eksInsightsGetHandler(reg *clusters.Registry, cache *eksInsightsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		if !isEKSBackend(c) {
+			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
+				errBackendNotEKSCode,
+				"upgrade insights are only available for EKS-backed clusters")
+			return
+		}
+		insightID := chi.URLParam(r, "insightId")
+		if insightID == "" {
+			http.Error(w, "missing insightId", http.StatusBadRequest)
+			return
+		}
+
+		if cached, ok := cache.GetDetail(c.Name, insightID); ok {
+			writeJSON(w, http.StatusOK, *cached)
+			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "detail:cache_hit", "")
+			return
+		}
+
+		client := newEKSInsightsClient(p, c)
+		eksName := c.EKSName()
+		out, err := client.DescribeInsight(r.Context(), &eks.DescribeInsightInput{
+			ClusterName: &eksName,
+			Id:          &insightID,
+		})
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.Warn("eks insights describe failed",
+				"cluster", c.Name, "insight_id", insightID, "err", err)
+			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "detail", err.Error())
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"failed to describe insight: "+err.Error())
+			return
+		}
+		if out.Insight == nil {
+			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "detail", "empty response")
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"DescribeInsight returned empty response")
+			return
+		}
+
+		detail := buildDetailResponse(c.Name, out.Insight)
+		cache.PutDetail(c.Name, insightID, detail)
+		writeJSON(w, http.StatusOK, detail)
+		emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "detail", "")
+	}
+}
+
+// ── SDK → wire mapping ───────────────────────────────────────────────
+
+func buildListResponse(in []ekstypes.InsightSummary) UpgradeInsightsListResponse {
+	out := UpgradeInsightsListResponse{
+		Insights: make([]UpgradeInsightSummary, 0, len(in)),
+	}
+	versionVotes := map[string]int{}
+	for i := range in {
+		s := mapInsightSummary(&in[i])
+		out.Insights = append(out.Insights, s)
+		switch s.Status {
+		case "PASSING":
+			out.Counts.Passing++
+		case "WARNING":
+			out.Counts.Warning++
+		case "ERROR":
+			out.Counts.Error++
+		default:
+			out.Counts.Unknown++
+		}
+		if s.KubernetesVersion != "" {
+			versionVotes[s.KubernetesVersion]++
+		}
+	}
+	out.TargetKubernetesVersion = pickModalVersion(versionVotes)
+	return out
+}
+
+func buildDetailResponse(cluster string, in *ekstypes.Insight) UpgradeInsightDetail {
+	out := UpgradeInsightDetail{
+		UpgradeInsightSummary: mapInsightSummaryFull(in),
+		Recommendation:        deref(in.Recommendation),
+		AdditionalInfo:        in.AdditionalInfo,
+		Resources:             make([]UpgradeInsightResourceRef, 0, len(in.Resources)),
+	}
+	for i := range in.Resources {
+		out.Resources = append(out.Resources, mapResource(cluster, &in.Resources[i]))
+	}
+	if in.CategorySpecificSummary != nil {
+		for i := range in.CategorySpecificSummary.DeprecationDetails {
+			out.DeprecationDetails = append(out.DeprecationDetails,
+				mapDeprecationDetail(&in.CategorySpecificSummary.DeprecationDetails[i]))
+		}
+	}
+	return out
+}
+
+// mapInsightSummary maps the SDK InsightSummary (used by the list
+// endpoint) to the wire summary. mapInsightSummaryFull does the
+// equivalent for the detail-shaped Insight; we share field
+// extraction via a small helper rather than reflecting because the
+// two SDK structs are not interface-compatible.
+func mapInsightSummary(in *ekstypes.InsightSummary) UpgradeInsightSummary {
+	return UpgradeInsightSummary{
+		ID:                 deref(in.Id),
+		Name:               deref(in.Name),
+		Category:           string(in.Category),
+		KubernetesVersion:  deref(in.KubernetesVersion),
+		Status:             insightStatus(in.InsightStatus),
+		StatusReason:       insightStatusReason(in.InsightStatus),
+		LastRefreshTime:    in.LastRefreshTime,
+		LastTransitionTime: in.LastTransitionTime,
+		Description:        deref(in.Description),
+	}
+}
+
+func mapInsightSummaryFull(in *ekstypes.Insight) UpgradeInsightSummary {
+	return UpgradeInsightSummary{
+		ID:                 deref(in.Id),
+		Name:               deref(in.Name),
+		Category:           string(in.Category),
+		KubernetesVersion:  deref(in.KubernetesVersion),
+		Status:             insightStatus(in.InsightStatus),
+		StatusReason:       insightStatusReason(in.InsightStatus),
+		LastRefreshTime:    in.LastRefreshTime,
+		LastTransitionTime: in.LastTransitionTime,
+		Description:        deref(in.Description),
+	}
+}
+
+func mapResource(cluster string, in *ekstypes.InsightResourceDetail) UpgradeInsightResourceRef {
+	uri := deref(in.KubernetesResourceUri)
+	out := UpgradeInsightResourceRef{
+		KubernetesResourceURI: uri,
+		ARN:                   deref(in.Arn),
+		Status:                insightStatus(in.InsightStatus),
+		StatusReason:          insightStatusReason(in.InsightStatus),
+	}
+	if parsed, ok := parseKubernetesResourceURI(cluster, uri); ok {
+		out.Group = parsed.Group
+		out.Version = parsed.Version
+		out.Resource = parsed.Plural
+		out.Namespace = parsed.Namespace
+		out.Name = parsed.Name
+		out.EditorPath = parsed.EditorPath
+	}
+	return out
+}
+
+func mapDeprecationDetail(in *ekstypes.DeprecationDetail) DeprecationDetail {
+	out := DeprecationDetail{
+		Usage:                          deref(in.Usage),
+		ReplacedWith:                   deref(in.ReplacedWith),
+		StopServingVersion:             deref(in.StopServingVersion),
+		StartServingReplacementVersion: deref(in.StartServingReplacementVersion),
+	}
+	for i := range in.ClientStats {
+		cs := &in.ClientStats[i]
+		out.ClientStats = append(out.ClientStats, DeprecationClientStat{
+			UserAgent:                  deref(cs.UserAgent),
+			NumberOfRequestsLast30Days: cs.NumberOfRequestsLast30Days,
+			LastRequestTime:            cs.LastRequestTime,
+		})
+	}
+	return out
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+func isEKSBackend(c clusters.Cluster) bool {
+	// Empty backend defaults to EKS — same convention as
+	// internal/k8s/client.go's buildRestConfig switch.
+	return c.Backend == clusters.BackendEKS || c.Backend == ""
+}
+
+func insightStatus(s *ekstypes.InsightStatus) string {
+	if s == nil {
+		return "UNKNOWN"
+	}
+	return string(s.Status)
+}
+
+func insightStatusReason(s *ekstypes.InsightStatus) string {
+	if s == nil || s.Reason == nil {
+		return ""
+	}
+	return *s.Reason
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+// pickModalVersion returns the version with the highest count.
+// Ties broken by lexicographic order of the version string, which
+// for "1.30" / "1.31" / "1.32" coincides with semantic order. Empty
+// when the input is empty.
+func pickModalVersion(votes map[string]int) string {
+	var best string
+	var bestCount int
+	for v, c := range votes {
+		if c > bestCount || (c == bestCount && v > best) {
+			best = v
+			bestCount = c
+		}
+	}
+	return best
+}
+
+// emitInsightsRead is the single audit-emission helper this handler
+// uses. Centralizing the call shape means a future change to the
+// row's Extra payload (request_id is already auto-snapped by the
+// emitter) lands in one place.
+func emitInsightsRead(ctx context.Context, emitter *audit.Emitter, p credentials.Provider, c clusters.Cluster, outcome audit.Outcome, op, reason string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Record(ctx, audit.Event{
+		Actor:   actorFromProvider(ctx, p),
+		Verb:    audit.VerbEKSInsightsRead,
+		Outcome: outcome,
+		Cluster: c.Name,
+		Reason:  reason,
+		Extra: map[string]any{
+			"op": op,
+		},
+	})
+}
+
+// actorFromProvider snapshots the actor from the request context's
+// session. Mirrors the existing actorFromContext helper but is named
+// here to make the dependency on ctx explicit at the callsite.
+func actorFromProvider(ctx context.Context, _ credentials.Provider) audit.Actor {
+	return actorFromContext(ctx)
+}

--- a/cmd/periscope/eks_insights_handler.go
+++ b/cmd/periscope/eks_insights_handler.go
@@ -209,7 +209,7 @@ func eksInsightsListHandler(reg *clusters.Registry, cache *eksInsightsCache, emi
 
 		if cached, ok := cache.GetList(c.Name); ok {
 			writeJSON(w, http.StatusOK, *cached)
-			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "cache_hit", "")
+			emitInsightsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "cache_hit", "")
 			return
 		}
 
@@ -227,8 +227,9 @@ func eksInsightsListHandler(reg *clusters.Registry, cache *eksInsightsCache, emi
 				return
 			}
 			slog.Warn("eks insights list failed", "cluster", c.Name, "err", err)
-			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "list", err.Error())
-			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+			emitInsightsRead(r.Context(), emitter, c, audit.OutcomeFailure, "list", err.Error())
+			status, code := awsErrorToStatus(err)
+			writeAPIErrorJSON(w, status, code,
 				"failed to list upgrade insights: "+err.Error())
 			return
 		}
@@ -243,7 +244,7 @@ func eksInsightsListHandler(reg *clusters.Registry, cache *eksInsightsCache, emi
 		resp := buildListResponse(out.Insights)
 		cache.PutList(c.Name, resp)
 		writeJSON(w, http.StatusOK, resp)
-		emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "list", "")
+		emitInsightsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "list", "")
 	}
 }
 
@@ -271,7 +272,7 @@ func eksInsightsGetHandler(reg *clusters.Registry, cache *eksInsightsCache, emit
 
 		if cached, ok := cache.GetDetail(c.Name, insightID); ok {
 			writeJSON(w, http.StatusOK, *cached)
-			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "detail:cache_hit", "")
+			emitInsightsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "detail:cache_hit", "")
 			return
 		}
 
@@ -287,13 +288,14 @@ func eksInsightsGetHandler(reg *clusters.Registry, cache *eksInsightsCache, emit
 			}
 			slog.Warn("eks insights describe failed",
 				"cluster", c.Name, "insight_id", insightID, "err", err)
-			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "detail", err.Error())
-			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+			emitInsightsRead(r.Context(), emitter, c, audit.OutcomeFailure, "detail", err.Error())
+			status, code := awsErrorToStatus(err)
+			writeAPIErrorJSON(w, status, code,
 				"failed to describe insight: "+err.Error())
 			return
 		}
 		if out.Insight == nil {
-			emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeFailure, "detail", "empty response")
+			emitInsightsRead(r.Context(), emitter, c, audit.OutcomeFailure, "detail", "empty response")
 			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
 				"DescribeInsight returned empty response")
 			return
@@ -302,7 +304,7 @@ func eksInsightsGetHandler(reg *clusters.Registry, cache *eksInsightsCache, emit
 		detail := buildDetailResponse(c.Name, out.Insight)
 		cache.PutDetail(c.Name, insightID, detail)
 		writeJSON(w, http.StatusOK, detail)
-		emitInsightsRead(r.Context(), emitter, p, c, audit.OutcomeSuccess, "detail", "")
+		emitInsightsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "detail", "")
 	}
 }
 
@@ -353,37 +355,43 @@ func buildDetailResponse(cluster string, in *ekstypes.Insight) UpgradeInsightDet
 	return out
 }
 
-// mapInsightSummary maps the SDK InsightSummary (used by the list
-// endpoint) to the wire summary. mapInsightSummaryFull does the
-// equivalent for the detail-shaped Insight; we share field
-// extraction via a small helper rather than reflecting because the
-// two SDK structs are not interface-compatible.
-func mapInsightSummary(in *ekstypes.InsightSummary) UpgradeInsightSummary {
+// summaryFromInsightFields builds the wire summary from already-
+// dereffed scalars. Shared between the list ([]InsightSummary) and
+// detail (Insight) SDK shapes — neither has a usable interface
+// surface, so we pass the fields explicitly instead of reflecting.
+// One source of truth for the wire shape; if a field is added to
+// UpgradeInsightSummary, only this body needs to change.
+func summaryFromInsightFields(
+	id, name, k8sVer, description string,
+	category ekstypes.Category,
+	status *ekstypes.InsightStatus,
+	refresh, transition *time.Time,
+) UpgradeInsightSummary {
 	return UpgradeInsightSummary{
-		ID:                 deref(in.Id),
-		Name:               deref(in.Name),
-		Category:           string(in.Category),
-		KubernetesVersion:  deref(in.KubernetesVersion),
-		Status:             insightStatus(in.InsightStatus),
-		StatusReason:       insightStatusReason(in.InsightStatus),
-		LastRefreshTime:    in.LastRefreshTime,
-		LastTransitionTime: in.LastTransitionTime,
-		Description:        deref(in.Description),
+		ID:                 id,
+		Name:               name,
+		Category:           string(category),
+		KubernetesVersion:  k8sVer,
+		Status:             insightStatus(status),
+		StatusReason:       insightStatusReason(status),
+		LastRefreshTime:    refresh,
+		LastTransitionTime: transition,
+		Description:        description,
 	}
 }
 
+func mapInsightSummary(in *ekstypes.InsightSummary) UpgradeInsightSummary {
+	return summaryFromInsightFields(
+		deref(in.Id), deref(in.Name), deref(in.KubernetesVersion), deref(in.Description),
+		in.Category, in.InsightStatus, in.LastRefreshTime, in.LastTransitionTime,
+	)
+}
+
 func mapInsightSummaryFull(in *ekstypes.Insight) UpgradeInsightSummary {
-	return UpgradeInsightSummary{
-		ID:                 deref(in.Id),
-		Name:               deref(in.Name),
-		Category:           string(in.Category),
-		KubernetesVersion:  deref(in.KubernetesVersion),
-		Status:             insightStatus(in.InsightStatus),
-		StatusReason:       insightStatusReason(in.InsightStatus),
-		LastRefreshTime:    in.LastRefreshTime,
-		LastTransitionTime: in.LastTransitionTime,
-		Description:        deref(in.Description),
-	}
+	return summaryFromInsightFields(
+		deref(in.Id), deref(in.Name), deref(in.KubernetesVersion), deref(in.Description),
+		in.Category, in.InsightStatus, in.LastRefreshTime, in.LastTransitionTime,
+	)
 }
 
 func mapResource(cluster string, in *ekstypes.InsightResourceDetail) UpgradeInsightResourceRef {
@@ -455,8 +463,10 @@ func deref(s *string) string {
 func int32Ptr(v int32) *int32 { return &v }
 
 // pickModalVersion returns the version with the highest count.
-// Ties broken by lexicographic order of the version string, which
-// for "1.30" / "1.31" / "1.32" coincides with semantic order. Empty
+// Ties broken by lexicographic order of the version string. EKS
+// minor versions are 1.27+ in 2026 and AWS does not roll back minors,
+// so lex order matches numeric order in practice — this would NOT
+// be safe for "1.9" vs "1.10" if EKS ever regressed there. Empty
 // when the input is empty.
 func pickModalVersion(votes map[string]int) string {
 	var best string
@@ -473,13 +483,14 @@ func pickModalVersion(votes map[string]int) string {
 // emitInsightsRead is the single audit-emission helper this handler
 // uses. Centralizing the call shape means a future change to the
 // row's Extra payload (request_id is already auto-snapped by the
-// emitter) lands in one place.
-func emitInsightsRead(ctx context.Context, emitter *audit.Emitter, p credentials.Provider, c clusters.Cluster, outcome audit.Outcome, op, reason string) {
+// emitter) lands in one place. Mirrors emitNodegroupsRead — both
+// pull the actor from the request context via actorFromContext.
+func emitInsightsRead(ctx context.Context, emitter *audit.Emitter, c clusters.Cluster, outcome audit.Outcome, op, reason string) {
 	if emitter == nil {
 		return
 	}
 	emitter.Record(ctx, audit.Event{
-		Actor:   actorFromProvider(ctx, p),
+		Actor:   actorFromContext(ctx),
 		Verb:    audit.VerbEKSInsightsRead,
 		Outcome: outcome,
 		Cluster: c.Name,
@@ -488,11 +499,4 @@ func emitInsightsRead(ctx context.Context, emitter *audit.Emitter, p credentials
 			"op": op,
 		},
 	})
-}
-
-// actorFromProvider snapshots the actor from the request context's
-// session. Mirrors the existing actorFromContext helper but is named
-// here to make the dependency on ctx explicit at the callsite.
-func actorFromProvider(ctx context.Context, _ credentials.Provider) audit.Actor {
-	return actorFromContext(ctx)
 }

--- a/cmd/periscope/eks_insights_handler_test.go
+++ b/cmd/periscope/eks_insights_handler_test.go
@@ -1,0 +1,516 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// fakeEKSInsightsClient implements eksInsightsAPI. Both ListInsights
+// and DescribeInsight are pluggable per-test; the default returns
+// errors so a test that forgot to wire one fails loudly.
+type fakeEKSInsightsClient struct {
+	mu        sync.Mutex
+	listCalls int
+	descCalls int
+	listFn    func(ctx context.Context, in *eks.ListInsightsInput) (*eks.ListInsightsOutput, error)
+	descFn    func(ctx context.Context, in *eks.DescribeInsightInput) (*eks.DescribeInsightOutput, error)
+}
+
+func (f *fakeEKSInsightsClient) ListInsights(ctx context.Context, in *eks.ListInsightsInput, _ ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+	f.mu.Lock()
+	f.listCalls++
+	f.mu.Unlock()
+	if f.listFn == nil {
+		return nil, errors.New("listFn not set")
+	}
+	return f.listFn(ctx, in)
+}
+
+func (f *fakeEKSInsightsClient) DescribeInsight(ctx context.Context, in *eks.DescribeInsightInput, _ ...func(*eks.Options)) (*eks.DescribeInsightOutput, error) {
+	f.mu.Lock()
+	f.descCalls++
+	f.mu.Unlock()
+	if f.descFn == nil {
+		return nil, errors.New("descFn not set")
+	}
+	return f.descFn(ctx, in)
+}
+
+// withFakeEKSClient swaps the package-level client constructor for
+// the duration of the test, returning a cleanup that restores the
+// original. Mirrors how cani_handler_test.go stubs SAR/SSRR fns.
+func withFakeEKSClient(t *testing.T, fake *fakeEKSInsightsClient) {
+	t.Helper()
+	orig := newEKSInsightsClient
+	newEKSInsightsClient = func(_ credentials.Provider, _ clusters.Cluster) eksInsightsAPI {
+		return fake
+	}
+	t.Cleanup(func() { newEKSInsightsClient = orig })
+}
+
+// eksRegistry writes a one-cluster YAML with the given backend and
+// (for EKS) a matching ARN/region. Mirrors bulkDownloadRegistry.
+func eksRegistry(t *testing.T, name, backend string) *clusters.Registry {
+	t.Helper()
+	dir := t.TempDir()
+	var yaml string
+	switch backend {
+	case clusters.BackendEKS:
+		yaml = "clusters:\n" +
+			"  - name: " + name + "\n" +
+			"    backend: eks\n" +
+			"    arn: arn:aws:eks:eu-west-1:111111111111:cluster/" + name + "\n" +
+			"    region: eu-west-1\n"
+	case clusters.BackendInCluster:
+		yaml = "clusters:\n" +
+			"  - name: " + name + "\n" +
+			"    backend: in-cluster\n"
+	case clusters.BackendAgent:
+		yaml = "clusters:\n" +
+			"  - name: " + name + "\n" +
+			"    backend: agent\n"
+	default:
+		t.Fatalf("eksRegistry: unhandled backend %q", backend)
+	}
+	path := filepath.Join(dir, "registry.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	reg, err := clusters.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	return reg
+}
+
+// invokeInsights drives a list or detail request with a planted
+// session and returns the recorder + the recording sink.
+func invokeInsights(t *testing.T, reg *clusters.Registry, cache *eksInsightsCache, sink *recordingSink, method, url string, params map[string]string, isDetail bool) *httptest.ResponseRecorder {
+	t.Helper()
+	emitter := audit.New(sink)
+	var h credentials.Handler
+	if isDetail {
+		h = eksInsightsGetHandler(reg, cache, emitter)
+	} else {
+		h = eksInsightsListHandler(reg, cache, emitter)
+	}
+	req := httptest.NewRequest(method, url, http.NoBody)
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	req = req.WithContext(credentials.WithSession(
+		context.WithValue(req.Context(), chi.RouteCtxKey, rctx),
+		credentials.Session{Subject: "alice@corp", Email: "alice@corp", Groups: []string{"eng"}},
+	))
+	rec := httptest.NewRecorder()
+	h(rec, req, fakeProvider{actor: "alice@corp"})
+	return rec
+}
+
+// ── List endpoint ────────────────────────────────────────────────────
+
+func TestEKSInsightsList_HappyPath(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+
+	now := time.Now().UTC()
+	fake := &fakeEKSInsightsClient{
+		listFn: func(_ context.Context, in *eks.ListInsightsInput) (*eks.ListInsightsOutput, error) {
+			// Confirm the handler filters the AWS-side query for us.
+			if in.Filter == nil || len(in.Filter.Categories) != 1 || in.Filter.Categories[0] != ekstypes.CategoryUpgradeReadiness {
+				t.Errorf("expected UPGRADE_READINESS filter, got %+v", in.Filter)
+			}
+			if in.ClusterName == nil || *in.ClusterName != "prod-eu-west-1" {
+				t.Errorf("expected cluster name from ARN; got %v", in.ClusterName)
+			}
+			return &eks.ListInsightsOutput{
+				Insights: []ekstypes.InsightSummary{
+					mkSummary("i-1", "Cluster health", "1.32", ekstypes.InsightStatusValuePassing, &now),
+					mkSummary("i-2", "Deprecated APIs", "1.32", ekstypes.InsightStatusValueError, &now),
+					mkSummary("i-3", "Add-on compat", "1.32", ekstypes.InsightStatusValueWarning, &now),
+					mkSummary("i-4", "IAM", "1.32", ekstypes.InsightStatusValuePassing, &now),
+				},
+			}, nil
+		},
+	}
+	withFakeEKSClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got UpgradeInsightsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Insights) != 4 {
+		t.Fatalf("Insights = %d, want 4", len(got.Insights))
+	}
+	wantCounts := UpgradeInsightCounts{Passing: 2, Warning: 1, Error: 1}
+	if got.Counts != wantCounts {
+		t.Errorf("Counts = %+v, want %+v", got.Counts, wantCounts)
+	}
+	if got.TargetKubernetesVersion != "1.32" {
+		t.Errorf("TargetKubernetesVersion = %q, want 1.32", got.TargetKubernetesVersion)
+	}
+
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit events = %d, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Verb != audit.VerbEKSInsightsRead {
+		t.Errorf("Verb = %q, want eks_insights_read", ev.Verb)
+	}
+	if ev.Outcome != audit.OutcomeSuccess {
+		t.Errorf("Outcome = %q, want success", ev.Outcome)
+	}
+	if ev.Cluster != "prod-eu-west-1" {
+		t.Errorf("Cluster = %q", ev.Cluster)
+	}
+	if op, _ := ev.Extra["op"].(string); op != "list" {
+		t.Errorf("Extra[op] = %q, want list", op)
+	}
+}
+
+func TestEKSInsightsList_NonEKSReturns422(t *testing.T) {
+	reg := eksRegistry(t, "kind-local", clusters.BackendInCluster)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/kind-local/eks/upgrade-insights",
+		map[string]string{"cluster": "kind-local"}, false)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body = %s", rec.Code, rec.Body.String())
+	}
+	var body apiError
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Code != errBackendNotEKSCode {
+		t.Errorf("code = %q, want %q", body.Code, errBackendNotEKSCode)
+	}
+	// No audit row for the non-EKS branch — it's a SPA-side feature
+	// gate, not a privileged action.
+	if events := sink.snapshot(); len(events) != 0 {
+		t.Errorf("expected zero audit rows, got %d", len(events))
+	}
+}
+
+func TestEKSInsightsList_AgentBackendReturns422(t *testing.T) {
+	reg := eksRegistry(t, "edge-1", clusters.BackendAgent)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/edge-1/eks/upgrade-insights",
+		map[string]string{"cluster": "edge-1"}, false)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}
+
+func TestEKSInsightsList_ClusterNotFound(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/missing/eks/upgrade-insights",
+		map[string]string{"cluster": "missing"}, false)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestEKSInsightsList_AWSErrorEmitsFailureAudit(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSInsightsClient{
+		listFn: func(_ context.Context, _ *eks.ListInsightsInput) (*eks.ListInsightsOutput, error) {
+			return nil, errors.New("AccessDenied: ListInsights")
+		},
+	}
+	withFakeEKSClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body = %s", rec.Code, rec.Body.String())
+	}
+
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit events = %d, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Outcome != audit.OutcomeFailure {
+		t.Errorf("Outcome = %q, want failure", ev.Outcome)
+	}
+	if ev.Reason == "" {
+		t.Errorf("expected non-empty Reason")
+	}
+}
+
+func TestEKSInsightsList_CacheHitSkipsAWS(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSInsightsClient{
+		listFn: func(_ context.Context, _ *eks.ListInsightsInput) (*eks.ListInsightsOutput, error) {
+			return &eks.ListInsightsOutput{
+				Insights: []ekstypes.InsightSummary{
+					mkSummary("i-1", "ok", "1.32", ekstypes.InsightStatusValuePassing, nil),
+				},
+			}, nil
+		},
+	}
+	withFakeEKSClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+
+	// First call populates the cache.
+	rec1 := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call status = %d", rec1.Code)
+	}
+
+	// Second call must hit the cache.
+	rec2 := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second call status = %d", rec2.Code)
+	}
+
+	if fake.listCalls != 1 {
+		t.Errorf("ListInsights calls = %d, want 1 (second call should be cache hit)", fake.listCalls)
+	}
+
+	// Both calls audit. The second should record op=cache_hit so a
+	// reviewer can distinguish AWS-side vs cache-served reads.
+	events := sink.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("audit events = %d, want 2", len(events))
+	}
+	if op, _ := events[0].Extra["op"].(string); op != "list" {
+		t.Errorf("first event op = %q, want list", op)
+	}
+	if op, _ := events[1].Extra["op"].(string); op != "cache_hit" {
+		t.Errorf("second event op = %q, want cache_hit", op)
+	}
+}
+
+// ── Detail endpoint ──────────────────────────────────────────────────
+
+func TestEKSInsightsGet_HappyPathWithEditorPaths(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSInsightsClient{
+		descFn: func(_ context.Context, in *eks.DescribeInsightInput) (*eks.DescribeInsightOutput, error) {
+			if in.Id == nil || *in.Id != "i-1" {
+				t.Errorf("expected insight id i-1, got %v", in.Id)
+			}
+			id := "i-1"
+			name := "Deprecated APIs"
+			version := "1.32"
+			desc := "Resources using removed APIs"
+			rec := "Migrate before 1.32 upgrade"
+			uri := "/apis/policy/v1beta1/namespaces/kube-system/poddisruptionbudgets/coredns"
+			usage := "/apis/policy/v1beta1/poddisruptionbudgets"
+			replaced := "/apis/policy/v1/poddisruptionbudgets"
+			stop := "1.25"
+			return &eks.DescribeInsightOutput{
+				Insight: &ekstypes.Insight{
+					Id:                 &id,
+					Name:               &name,
+					Category:           ekstypes.CategoryUpgradeReadiness,
+					KubernetesVersion:  &version,
+					Description:        &desc,
+					Recommendation:     &rec,
+					LastRefreshTime:    &now,
+					LastTransitionTime: &now,
+					InsightStatus: &ekstypes.InsightStatus{
+						Status: ekstypes.InsightStatusValueError,
+					},
+					Resources: []ekstypes.InsightResourceDetail{
+						{KubernetesResourceUri: &uri},
+					},
+					CategorySpecificSummary: &ekstypes.InsightCategorySpecificSummary{
+						DeprecationDetails: []ekstypes.DeprecationDetail{
+							{
+								Usage:              &usage,
+								ReplacedWith:       &replaced,
+								StopServingVersion: &stop,
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	withFakeEKSClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights/i-1",
+		map[string]string{"cluster": "prod-eu-west-1", "insightId": "i-1"}, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got UpgradeInsightDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != "i-1" || got.Status != "ERROR" {
+		t.Errorf("got = %+v", got.UpgradeInsightSummary)
+	}
+	if len(got.Resources) != 1 {
+		t.Fatalf("Resources = %d, want 1", len(got.Resources))
+	}
+	r := got.Resources[0]
+	if r.EditorPath != "/clusters/prod-eu-west-1/poddisruptionbudgets?sel=coredns&selNs=kube-system&tab=yaml" {
+		t.Errorf("EditorPath = %q", r.EditorPath)
+	}
+	if r.Group != "policy" || r.Version != "v1beta1" || r.Resource != "poddisruptionbudgets" {
+		t.Errorf("parsed parts wrong: %+v", r)
+	}
+	if len(got.DeprecationDetails) != 1 || got.DeprecationDetails[0].StopServingVersion != "1.25" {
+		t.Errorf("DeprecationDetails = %+v", got.DeprecationDetails)
+	}
+}
+
+func TestEKSInsightsGet_NoAffectedResources(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSInsightsClient{
+		descFn: func(_ context.Context, _ *eks.DescribeInsightInput) (*eks.DescribeInsightOutput, error) {
+			id := "i-x"
+			name := "All clear"
+			return &eks.DescribeInsightOutput{Insight: &ekstypes.Insight{
+				Id:   &id,
+				Name: &name,
+				InsightStatus: &ekstypes.InsightStatus{
+					Status: ekstypes.InsightStatusValuePassing,
+				},
+			}}, nil
+		},
+	}
+	withFakeEKSClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights/i-x",
+		map[string]string{"cluster": "prod-eu-west-1", "insightId": "i-x"}, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	// Resources must be `[]` not `null` so the SPA can iterate
+	// without a nil guard. Spot-check the JSON shape.
+	if !containsExact(rec.Body.String(), `"resources":[]`) {
+		t.Errorf("expected resources:[] in body, got: %s", rec.Body.String())
+	}
+}
+
+func TestEKSInsightsGet_EmptyInsightResponseFails(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSInsightsClient{
+		descFn: func(_ context.Context, _ *eks.DescribeInsightInput) (*eks.DescribeInsightOutput, error) {
+			return &eks.DescribeInsightOutput{Insight: nil}, nil
+		},
+	}
+	withFakeEKSClient(t, fake)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights/i-1",
+		map[string]string{"cluster": "prod-eu-west-1", "insightId": "i-1"}, true)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
+		t.Errorf("expected one failure event; got %+v", events)
+	}
+}
+
+func TestEKSInsightsGet_MissingInsightId(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/prod-eu-west-1/eks/upgrade-insights/",
+		map[string]string{"cluster": "prod-eu-west-1"}, true)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEKSInsightsGet_NonEKSReturns422(t *testing.T) {
+	reg := eksRegistry(t, "kind-local", clusters.BackendInCluster)
+	sink := &recordingSink{}
+	cache := newEKSInsightsCache(time.Hour)
+	rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+		"/api/clusters/kind-local/eks/upgrade-insights/i-1",
+		map[string]string{"cluster": "kind-local", "insightId": "i-1"}, true)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+func mkSummary(id, name, version string, status ekstypes.InsightStatusValue, ts *time.Time) ekstypes.InsightSummary {
+	idCopy := id
+	nameCopy := name
+	verCopy := version
+	return ekstypes.InsightSummary{
+		Id:                 &idCopy,
+		Name:               &nameCopy,
+		Category:           ekstypes.CategoryUpgradeReadiness,
+		KubernetesVersion:  &verCopy,
+		LastRefreshTime:    ts,
+		LastTransitionTime: ts,
+		InsightStatus:      &ekstypes.InsightStatus{Status: status},
+	}
+}
+
+func containsExact(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/cmd/periscope/eks_insights_handler_test.go
+++ b/cmd/periscope/eks_insights_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -275,6 +276,70 @@ func TestEKSInsightsList_AWSErrorEmitsFailureAudit(t *testing.T) {
 		t.Errorf("expected non-empty Reason")
 	}
 }
+
+// TestEKSInsightsList_ClassifiesAWSErrors covers the awsErrorToStatus
+// fold-in: each smithy-typed exception lands on the right HTTP status
+// + stable error code so the SPA can branch on them. A non-smithy
+// error keeps the legacy 502/E_AWS_API behavior.
+func TestEKSInsightsList_ClassifiesAWSErrors(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "AccessDenied → 403/E_AWS_FORBIDDEN",
+			err:        &ekstypes.AccessDeniedException{Message: strPtr("denied")},
+			wantStatus: http.StatusForbidden,
+			wantCode:   "E_AWS_FORBIDDEN",
+		},
+		{
+			name:       "ResourceNotFound → 404/E_AWS_NOT_FOUND",
+			err:        &ekstypes.ResourceNotFoundException{Message: strPtr("missing")},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "E_AWS_NOT_FOUND",
+		},
+		{
+			name:       "Throttling → 429/E_AWS_THROTTLED",
+			err:        &ekstypes.ThrottlingException{Message: strPtr("slow down")},
+			wantStatus: http.StatusTooManyRequests,
+			wantCode:   "E_AWS_THROTTLED",
+		},
+		{
+			name:       "unknown error → 502/E_AWS_API (legacy default preserved)",
+			err:        errors.New("opaque transport blip"),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   "E_AWS_API",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+			fake := &fakeEKSInsightsClient{
+				listFn: func(_ context.Context, _ *eks.ListInsightsInput) (*eks.ListInsightsOutput, error) {
+					return nil, tc.err
+				},
+			}
+			withFakeEKSClient(t, fake)
+
+			rec := invokeInsights(t, reg, newEKSInsightsCache(time.Hour),
+				&recordingSink{}, http.MethodGet,
+				"/api/clusters/prod-eu-west-1/eks/upgrade-insights",
+				map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s",
+					rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantCode) {
+				t.Errorf("body missing %q: %s", tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
 
 func TestEKSInsightsList_CacheHitSkipsAWS(t *testing.T) {
 	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)

--- a/cmd/periscope/eks_insights_uri.go
+++ b/cmd/periscope/eks_insights_uri.go
@@ -1,0 +1,207 @@
+package main
+
+// eks_insights_uri.go — pure parser that turns the
+// `kubernetesResourceUri` string returned by the EKS DescribeInsight
+// API into a deep link to Periscope's per-resource YAML editor.
+//
+// EKS returns a standard Kubernetes REST path:
+//
+//   /api/v1[/namespaces/{ns}]/{plural}/{name}             (core group)
+//   /apis/{group}/{version}[/namespaces/{ns}]/{plural}/{name}
+//
+// The SPA does not have a dedicated detail/editor route per kind.
+// Each list page (PodsPage, DeploymentsPage, …) reads `selNs` and
+// `sel` from the query string and opens the YAML tab when
+// `tab=yaml`. So the deep link this parser builds is always:
+//
+//   /clusters/{c}/{spaPlural}?selNs={ns}&sel={name}&tab=yaml
+//
+// where `spaPlural` matches the SPA route segment. For built-in
+// kinds the segment is the K8s plural with three aliases
+// (persistentvolumeclaims→pvcs, persistentvolumes→pvs,
+// customresourcedefinitions→crds). Anything else falls through to
+// the customresources route which takes the GVR verbatim.
+//
+// Critically, no cluster discovery is required. The mapping is a
+// pure function of the URI string — which is what makes this safe
+// to compute server-side and serve from a cluster-keyed cache that
+// no longer has access to a live apiserver.
+//
+// One caveat documented in docs/setup/eks-upgrade-readiness.md
+// (PR-2): when EKS flags a deprecated apiVersion (e.g.
+// policy/v1beta1 PDB), the built-in route opens the resource at the
+// SPA's current served version — actually the right UX, since the
+// editor shows live state. For CRDs at no-longer-served versions
+// the editor will surface a load error from the apiserver. We do
+// not try to be clever about this in v1.
+
+import (
+	"net/url"
+	"strings"
+)
+
+// builtinSPAPlurals maps a Kubernetes plural to the SPA's route
+// segment for the kinds that have a dedicated list page in
+// web/src/routes.tsx. Anything not in this map falls through to the
+// `/customresources/{group}/{version}/{plural}` route which accepts
+// any GVR.
+//
+// Keep this map in sync with web/src/routes.tsx. The SPA test
+// `eksInsights.test.tsx` covers the link shape end-to-end so a
+// missing entry here surfaces as a router 404 in the test, not a
+// silent regression.
+var builtinSPAPlurals = map[string]string{
+	"pods":                              "pods",
+	"deployments":                       "deployments",
+	"statefulsets":                      "statefulsets",
+	"daemonsets":                        "daemonsets",
+	"jobs":                              "jobs",
+	"cronjobs":                          "cronjobs",
+	"services":                          "services",
+	"ingresses":                         "ingresses",
+	"configmaps":                        "configmaps",
+	"secrets":                           "secrets",
+	"nodes":                             "nodes",
+	"namespaces":                        "namespaces",
+	"events":                            "events",
+	"persistentvolumeclaims":            "pvcs",
+	"persistentvolumes":                 "pvs",
+	"storageclasses":                    "storageclasses",
+	"roles":                             "roles",
+	"clusterroles":                      "clusterroles",
+	"rolebindings":                      "rolebindings",
+	"clusterrolebindings":               "clusterrolebindings",
+	"serviceaccounts":                   "serviceaccounts",
+	"horizontalpodautoscalers":          "horizontalpodautoscalers",
+	"poddisruptionbudgets":              "poddisruptionbudgets",
+	"replicasets":                       "replicasets",
+	"networkpolicies":                   "networkpolicies",
+	"endpointslices":                    "endpointslices",
+	"ingressclasses":                    "ingressclasses",
+	"resourcequotas":                    "resourcequotas",
+	"limitranges":                       "limitranges",
+	"priorityclasses":                   "priorityclasses",
+	"runtimeclasses":                    "runtimeclasses",
+	"customresourcedefinitions":         "crds",
+}
+
+// parsedResourceURI is the structured form of a kubernetesResourceUri.
+// EditorPath is empty when the URI shape is unrecognized; in that case
+// the SPA renders the raw URI as a non-clickable monospace string.
+type parsedResourceURI struct {
+	Group     string
+	Version   string
+	Plural    string
+	Namespace string
+	Name      string
+	// EditorPath is the cluster-rooted path the SPA navigates to so
+	// the relevant list page selects the resource and opens its YAML
+	// tab. Empty when the URI couldn't be parsed cleanly.
+	EditorPath string
+}
+
+// parseKubernetesResourceURI decomposes the URI EKS returns and
+// builds the SPA editor deep link. Cluster is the registry name —
+// this is the {cluster} segment in the SPA route, NOT the EKS ARN.
+//
+// Returns (zero, false) when the URI is empty or doesn't match a
+// recognized shape. Callers should still surface the raw URI in
+// that case so the operator can chase it manually.
+func parseKubernetesResourceURI(cluster, uri string) (parsedResourceURI, bool) {
+	if uri == "" {
+		return parsedResourceURI{}, false
+	}
+	// Strip a leading slash so strings.Split has a stable shape.
+	trimmed := strings.TrimPrefix(uri, "/")
+	parts := strings.Split(trimmed, "/")
+
+	var group, version string
+	var rest []string
+
+	switch parts[0] {
+	case "api":
+		// /api/v1[/namespaces/{ns}]/{plural}/{name}
+		if len(parts) < 2 {
+			return parsedResourceURI{}, false
+		}
+		group = ""
+		version = parts[1]
+		rest = parts[2:]
+	case "apis":
+		// /apis/{group}/{version}[/namespaces/{ns}]/{plural}/{name}
+		if len(parts) < 3 {
+			return parsedResourceURI{}, false
+		}
+		group = parts[1]
+		version = parts[2]
+		rest = parts[3:]
+	default:
+		return parsedResourceURI{}, false
+	}
+
+	var ns, plural, name string
+	switch {
+	case len(rest) >= 4 && rest[0] == "namespaces":
+		// namespaced: namespaces/{ns}/{plural}/{name}
+		ns = rest[1]
+		plural = rest[2]
+		name = rest[3]
+	case len(rest) >= 2 && rest[0] != "namespaces":
+		// cluster-scoped: {plural}/{name}
+		plural = rest[0]
+		name = rest[1]
+	default:
+		return parsedResourceURI{}, false
+	}
+
+	if plural == "" || name == "" {
+		return parsedResourceURI{}, false
+	}
+	if cluster == "" {
+		return parsedResourceURI{}, false
+	}
+
+	out := parsedResourceURI{
+		Group:     group,
+		Version:   version,
+		Plural:    plural,
+		Namespace: ns,
+		Name:      name,
+	}
+	out.EditorPath = buildEditorPath(cluster, group, version, plural, ns, name)
+	return out, true
+}
+
+// buildEditorPath constructs the SPA path with selection query
+// params. Built-in kinds use their dedicated route; everything else
+// falls through to /customresources/{group}/{version}/{plural}.
+//
+// The Path itself is built with url.URL so the cluster name and
+// resource name are escaped if they contain shell-special chars —
+// EKS shouldn't return funky names in practice, but the cluster
+// segment came from our registry which a misbehaving operator
+// could in principle stuff with weird characters.
+func buildEditorPath(cluster, group, version, plural, ns, name string) string {
+	q := url.Values{}
+	q.Set("selNs", ns)
+	q.Set("sel", name)
+	q.Set("tab", "yaml")
+
+	var path string
+	if spa, ok := builtinSPAPlurals[plural]; ok {
+		path = "/clusters/" + url.PathEscape(cluster) + "/" + spa
+	} else {
+		// Custom Resources need group + version in the path. The core
+		// group is empty in REST URIs but the customresources route
+		// requires a non-empty group segment. Treating an empty group
+		// as unmappable here is safe — every core-group kind is in
+		// the built-in map already, so this branch only fires for
+		// genuine CRDs.
+		if group == "" || version == "" {
+			return ""
+		}
+		path = "/clusters/" + url.PathEscape(cluster) + "/customresources/" +
+			url.PathEscape(group) + "/" + url.PathEscape(version) + "/" + url.PathEscape(plural)
+	}
+	return path + "?" + q.Encode()
+}

--- a/cmd/periscope/eks_insights_uri_test.go
+++ b/cmd/periscope/eks_insights_uri_test.go
@@ -1,0 +1,204 @@
+package main
+
+import "testing"
+
+// TestParseKubernetesResourceURI exercises every shape EKS can
+// realistically return: namespaced/cluster-scoped × core/named-group
+// × built-in-plural/CRD-plural, plus malformed inputs. The
+// editor-link mapping is the riskiest piece of PR-1 (see issue #103
+// thread) so the coverage here is deliberately exhaustive.
+func TestParseKubernetesResourceURI(t *testing.T) {
+	const cluster = "prod-eu-west-1"
+
+	cases := []struct {
+		name        string
+		uri         string
+		wantOK      bool
+		wantGroup   string
+		wantVersion string
+		wantPlural  string
+		wantNs      string
+		wantName    string
+		wantPath    string
+	}{
+		{
+			name:        "core_namespaced_pod",
+			uri:         "/api/v1/namespaces/default/pods/nginx",
+			wantOK:      true,
+			wantGroup:   "",
+			wantVersion: "v1",
+			wantPlural:  "pods",
+			wantNs:      "default",
+			wantName:    "nginx",
+			wantPath:    "/clusters/prod-eu-west-1/pods?sel=nginx&selNs=default&tab=yaml",
+		},
+		{
+			name:        "core_clusterscoped_node",
+			uri:         "/api/v1/nodes/ip-10-0-0-1",
+			wantOK:      true,
+			wantGroup:   "",
+			wantVersion: "v1",
+			wantPlural:  "nodes",
+			wantNs:      "",
+			wantName:    "ip-10-0-0-1",
+			wantPath:    "/clusters/prod-eu-west-1/nodes?sel=ip-10-0-0-1&selNs=&tab=yaml",
+		},
+		{
+			name:        "named_group_namespaced_pdb_v1beta1",
+			uri:         "/apis/policy/v1beta1/namespaces/kube-system/poddisruptionbudgets/coredns",
+			wantOK:      true,
+			wantGroup:   "policy",
+			wantVersion: "v1beta1",
+			wantPlural:  "poddisruptionbudgets",
+			wantNs:      "kube-system",
+			wantName:    "coredns",
+			wantPath:    "/clusters/prod-eu-west-1/poddisruptionbudgets?sel=coredns&selNs=kube-system&tab=yaml",
+		},
+		{
+			name:        "named_group_clusterscoped_clusterrole",
+			uri:         "/apis/rbac.authorization.k8s.io/v1/clusterroles/edit",
+			wantOK:      true,
+			wantGroup:   "rbac.authorization.k8s.io",
+			wantVersion: "v1",
+			wantPlural:  "clusterroles",
+			wantNs:      "",
+			wantName:    "edit",
+			wantPath:    "/clusters/prod-eu-west-1/clusterroles?sel=edit&selNs=&tab=yaml",
+		},
+		{
+			name:        "alias_persistentvolumeclaims",
+			uri:         "/api/v1/namespaces/data/persistentvolumeclaims/postgres",
+			wantOK:      true,
+			wantGroup:   "",
+			wantVersion: "v1",
+			wantPlural:  "persistentvolumeclaims",
+			wantNs:      "data",
+			wantName:    "postgres",
+			wantPath:    "/clusters/prod-eu-west-1/pvcs?sel=postgres&selNs=data&tab=yaml",
+		},
+		{
+			name:        "alias_persistentvolumes",
+			uri:         "/api/v1/persistentvolumes/pv-001",
+			wantOK:      true,
+			wantGroup:   "",
+			wantVersion: "v1",
+			wantPlural:  "persistentvolumes",
+			wantNs:      "",
+			wantName:    "pv-001",
+			wantPath:    "/clusters/prod-eu-west-1/pvs?sel=pv-001&selNs=&tab=yaml",
+		},
+		{
+			name:        "alias_customresourcedefinitions",
+			uri:         "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/widgets.example.com",
+			wantOK:      true,
+			wantGroup:   "apiextensions.k8s.io",
+			wantVersion: "v1",
+			wantPlural:  "customresourcedefinitions",
+			wantNs:      "",
+			wantName:    "widgets.example.com",
+			wantPath:    "/clusters/prod-eu-west-1/crds?sel=widgets.example.com&selNs=&tab=yaml",
+		},
+		{
+			name:        "crd_namespaced_falls_through",
+			uri:         "/apis/example.com/v1alpha1/namespaces/team-a/widgets/blue",
+			wantOK:      true,
+			wantGroup:   "example.com",
+			wantVersion: "v1alpha1",
+			wantPlural:  "widgets",
+			wantNs:      "team-a",
+			wantName:    "blue",
+			wantPath:    "/clusters/prod-eu-west-1/customresources/example.com/v1alpha1/widgets?sel=blue&selNs=team-a&tab=yaml",
+		},
+		{
+			name:        "crd_clusterscoped_falls_through",
+			uri:         "/apis/cert-manager.io/v1/clusterissuers/letsencrypt",
+			wantOK:      true,
+			wantGroup:   "cert-manager.io",
+			wantVersion: "v1",
+			wantPlural:  "clusterissuers",
+			wantNs:      "",
+			wantName:    "letsencrypt",
+			wantPath:    "/clusters/prod-eu-west-1/customresources/cert-manager.io/v1/clusterissuers?sel=letsencrypt&selNs=&tab=yaml",
+		},
+		{
+			name:        "removed_api_psp_v1beta1",
+			uri:         "/apis/policy/v1beta1/podsecuritypolicies/restricted",
+			wantOK:      true,
+			wantGroup:   "policy",
+			wantVersion: "v1beta1",
+			wantPlural:  "podsecuritypolicies",
+			wantNs:      "",
+			wantName:    "restricted",
+			// PSPs aren't in the built-in SPA route set; falls through
+			// to customresources. The version flagged as deprecated
+			// is preserved in the deep link — the editor will surface
+			// the load error when the apiserver no longer serves it.
+			wantPath: "/clusters/prod-eu-west-1/customresources/policy/v1beta1/podsecuritypolicies?sel=restricted&selNs=&tab=yaml",
+		},
+		{
+			name:   "empty",
+			uri:    "",
+			wantOK: false,
+		},
+		{
+			name:   "garbage",
+			uri:    "not-a-resource-uri",
+			wantOK: false,
+		},
+		{
+			name:   "missing_name",
+			uri:    "/api/v1/namespaces/default/pods",
+			wantOK: false,
+		},
+		{
+			name:   "missing_version",
+			uri:    "/apis/policy",
+			wantOK: false,
+		},
+		{
+			name:   "core_no_resource",
+			uri:    "/api/v1",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseKubernetesResourceURI(cluster, tc.uri)
+			if ok != tc.wantOK {
+				t.Fatalf("parseKubernetesResourceURI(%q) ok = %v, want %v", tc.uri, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Group != tc.wantGroup {
+				t.Errorf("Group = %q, want %q", got.Group, tc.wantGroup)
+			}
+			if got.Version != tc.wantVersion {
+				t.Errorf("Version = %q, want %q", got.Version, tc.wantVersion)
+			}
+			if got.Plural != tc.wantPlural {
+				t.Errorf("Plural = %q, want %q", got.Plural, tc.wantPlural)
+			}
+			if got.Namespace != tc.wantNs {
+				t.Errorf("Namespace = %q, want %q", got.Namespace, tc.wantNs)
+			}
+			if got.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tc.wantName)
+			}
+			if got.EditorPath != tc.wantPath {
+				t.Errorf("EditorPath = %q, want %q", got.EditorPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestParseKubernetesResourceURI_EmptyCluster guards against the
+// case where the registry name is empty (which would produce a
+// broken /clusters//pods link). The parser refuses to build a path
+// in that case.
+func TestParseKubernetesResourceURI_EmptyCluster(t *testing.T) {
+	if _, ok := parseKubernetesResourceURI("", "/api/v1/namespaces/default/pods/nginx"); ok {
+		t.Fatalf("expected ok=false when cluster name is empty")
+	}
+}

--- a/cmd/periscope/eks_nodegroups_cache.go
+++ b/cmd/periscope/eks_nodegroups_cache.go
@@ -1,0 +1,155 @@
+package main
+
+// eks_nodegroups_cache.go — bounded TTL cache for the managed node
+// group endpoints.
+//
+// Two divergences from eksInsightsCache, both deliberate:
+//
+//   1. Shorter TTL (5 minutes vs 1 hour). Node groups change when an
+//      operator scales / upgrades / rotates them, which can happen
+//      multiple times per day during an upgrade window. The Insights
+//      cache mirrored AWS's daily refresh cadence; node groups don't
+//      have that excuse.
+//
+//   2. Same cluster-keyed shape as the insights cache (no actor in
+//      the key). DescribeNodegroup is not RBAC-filtered at our
+//      boundary; per-actor keying would inflate cardinality without
+//      a security benefit, exactly the same reasoning as insights.
+//
+// One cache shared across the list and detail endpoints. The list
+// entry is keyed "list" and the detail entries are keyed by
+// nodegroup name — both within a per-cluster namespace.
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+const eksNodegroupsCacheMaxEntries = 256
+
+type eksNodegroupsCacheValue struct {
+	List   *NodegroupsListResponse
+	Detail *NodegroupDetail
+}
+
+type eksNodegroupsCache struct {
+	ttl time.Duration
+	max int
+	mu  sync.Mutex
+	m   map[string]eksNodegroupsCacheEntry
+}
+
+type eksNodegroupsCacheEntry struct {
+	value   eksNodegroupsCacheValue
+	expires time.Time
+}
+
+func newEKSNodegroupsCache(ttl time.Duration) *eksNodegroupsCache {
+	return &eksNodegroupsCache{
+		ttl: ttl,
+		max: eksNodegroupsCacheMaxEntries,
+		m:   make(map[string]eksNodegroupsCacheEntry),
+	}
+}
+
+func (c *eksNodegroupsCache) GetList(cluster string) (*NodegroupsListResponse, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[ngListKey(cluster)]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.m, ngListKey(cluster))
+		return nil, false
+	}
+	return e.value.List, e.value.List != nil
+}
+
+func (c *eksNodegroupsCache) PutList(cluster string, val NodegroupsListResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[ngListKey(cluster)] = eksNodegroupsCacheEntry{
+		value:   eksNodegroupsCacheValue{List: &val},
+		expires: time.Now().Add(c.ttl),
+	}
+	if len(c.m) > c.max {
+		c.evictLocked()
+	}
+}
+
+func (c *eksNodegroupsCache) GetDetail(cluster, name string) (*NodegroupDetail, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[ngDetailKey(cluster, name)]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.m, ngDetailKey(cluster, name))
+		return nil, false
+	}
+	return e.value.Detail, e.value.Detail != nil
+}
+
+func (c *eksNodegroupsCache) PutDetail(cluster, name string, val NodegroupDetail) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[ngDetailKey(cluster, name)] = eksNodegroupsCacheEntry{
+		value:   eksNodegroupsCacheValue{Detail: &val},
+		expires: time.Now().Add(c.ttl),
+	}
+	if len(c.m) > c.max {
+		c.evictLocked()
+	}
+}
+
+// InvalidateCluster drops every entry for the given cluster. Not yet
+// wired to a callsite — reserved for a future refresh button on the
+// UI ("force re-fetch from AWS"). Cheap to add now since iterating
+// the map under lock is O(n) and n ≤ max.
+func (c *eksNodegroupsCache) InvalidateCluster(cluster string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prefix := cluster + "|"
+	for k := range c.m {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			delete(c.m, k)
+		}
+	}
+}
+
+func (c *eksNodegroupsCache) evictLocked() {
+	now := time.Now()
+	for k, e := range c.m {
+		if now.After(e.expires) {
+			delete(c.m, k)
+		}
+	}
+	if len(c.m) <= c.max {
+		return
+	}
+	type kv struct {
+		key string
+		exp time.Time
+	}
+	all := make([]kv, 0, len(c.m))
+	for k, e := range c.m {
+		all = append(all, kv{key: k, exp: e.expires})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].exp.Before(all[j].exp) })
+	target := c.max * 9 / 10
+	for i := 0; i < len(all)-target; i++ {
+		delete(c.m, all[i].key)
+	}
+}
+
+func (c *eksNodegroupsCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.m)
+}
+
+func ngListKey(cluster string) string         { return cluster + "|list" }
+func ngDetailKey(cluster, name string) string { return cluster + "|d|" + name }

--- a/cmd/periscope/eks_nodegroups_cache_test.go
+++ b/cmd/periscope/eks_nodegroups_cache_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEKSNodegroupsCache_ListPutGet(t *testing.T) {
+	c := newEKSNodegroupsCache(time.Hour)
+	val := NodegroupsListResponse{
+		Nodegroups: []NodegroupSummary{{Name: "ng-1"}},
+		Counts:     NodegroupsCounts{Total: 1},
+	}
+	c.PutList("prod", val)
+
+	got, ok := c.GetList("prod")
+	if !ok || len(got.Nodegroups) != 1 || got.Nodegroups[0].Name != "ng-1" {
+		t.Fatalf("got %+v", got)
+	}
+	if _, ok := c.GetList("staging"); ok {
+		t.Fatalf("staging miss expected")
+	}
+}
+
+func TestEKSNodegroupsCache_DetailKeying(t *testing.T) {
+	c := newEKSNodegroupsCache(time.Hour)
+	c.PutDetail("prod", "ng-a", NodegroupDetail{NodegroupSummary: NodegroupSummary{Name: "ng-a"}})
+
+	if _, ok := c.GetDetail("prod", "ng-a"); !ok {
+		t.Fatalf("expected hit")
+	}
+	if _, ok := c.GetDetail("prod", "ng-b"); ok {
+		t.Fatalf("different name should miss")
+	}
+	if _, ok := c.GetDetail("other", "ng-a"); ok {
+		t.Fatalf("different cluster should miss")
+	}
+}
+
+func TestEKSNodegroupsCache_Expiry(t *testing.T) {
+	c := newEKSNodegroupsCache(time.Millisecond)
+	c.PutList("prod", NodegroupsListResponse{})
+	time.Sleep(10 * time.Millisecond)
+	if _, ok := c.GetList("prod"); ok {
+		t.Fatalf("expected expired entry to miss")
+	}
+}
+
+func TestEKSNodegroupsCache_InvalidateCluster(t *testing.T) {
+	c := newEKSNodegroupsCache(time.Hour)
+	c.PutList("prod", NodegroupsListResponse{})
+	c.PutDetail("prod", "ng-1", NodegroupDetail{})
+	c.PutList("staging", NodegroupsListResponse{})
+
+	c.InvalidateCluster("prod")
+
+	if _, ok := c.GetList("prod"); ok {
+		t.Errorf("prod list should be evicted")
+	}
+	if _, ok := c.GetDetail("prod", "ng-1"); ok {
+		t.Errorf("prod detail should be evicted")
+	}
+	if _, ok := c.GetList("staging"); !ok {
+		t.Errorf("staging list should survive")
+	}
+}
+
+func TestEKSNodegroupsCache_Eviction(t *testing.T) {
+	c := newEKSNodegroupsCache(time.Hour)
+	c.max = 3
+	c.PutList("a", NodegroupsListResponse{})
+	c.PutList("b", NodegroupsListResponse{})
+	c.PutList("c", NodegroupsListResponse{})
+	c.PutList("d", NodegroupsListResponse{})
+	if got := c.Len(); got > 3 {
+		t.Fatalf("cache exceeded cap: len = %d", got)
+	}
+}

--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -164,16 +164,13 @@ type NodegroupDetail struct {
 
 // ── Handlers ─────────────────────────────────────────────────────────
 
-func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
-	return eksNodegroupsListHandlerWithDrift(reg, cache, nil, emitter)
-}
-
-// eksNodegroupsListHandlerWithDrift is the drift-aware handler.
-// `amiCache` may be nil in tests; in that case drift fields stay
-// zero (DriftComputed=false on every row). main.go always passes a
-// non-nil cache so production responses populate drift for
-// AWS-managed (non-CUSTOM) nodegroups.
-func eksNodegroupsListHandlerWithDrift(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+// eksNodegroupsListHandler returns the cluster's managed node group
+// list with drift fields folded onto each row. `amiCache` may be
+// nil in tests; in that case drift stays uncomputed
+// (DriftComputed=false on every row) and the SPA renders "—" in the
+// drift column. main.go always passes a non-nil cache so production
+// responses populate drift for AWS-managed (non-CUSTOM) nodegroups.
+func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
 	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
 		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
 		if !ok {
@@ -269,11 +266,9 @@ func eksNodegroupsListHandlerWithDrift(reg *clusters.Registry, cache *eksNodegro
 	}
 }
 
-func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
-	return eksNodegroupsGetHandlerWithDrift(reg, cache, nil, emitter)
-}
-
-func eksNodegroupsGetHandlerWithDrift(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+// eksNodegroupsGetHandler is the per-nodegroup detail handler.
+// Same amiCache nil-handling contract as the list handler.
+func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
 	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
 		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
 		if !ok {

--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -1,0 +1,437 @@
+package main
+
+// eks_nodegroups_handler.go — read-only EKS managed node group
+// endpoints.
+//
+//   GET /api/clusters/{cluster}/eks/nodegroups
+//   GET /api/clusters/{cluster}/eks/nodegroups/{name}
+//
+// Wraps eks.ListNodegroups + eks.DescribeNodegroup. Same EKS-only
+// gating + audit pattern as eks_insights_handler.go: 422 +
+// E_BACKEND_NOT_EKS for non-EKS, 502 for AWS failures, audit row on
+// every call regardless of outcome.
+//
+// PR-2 scope (this commit): nodegroup list with current AMI release
+// version + custom-AMI flag. NO drift computation — the
+// DriftComputed flag is always false on responses produced here.
+// PR-3 wires the SSM-based "latest AMI" lookup and fills the drift
+// fields onto the response.
+//
+// Custom AMIs (AmiType == "CUSTOM"): we surface the launch template
+// reference and a `customAmi: true` flag so the SPA can render a
+// "drift not tracked" badge. PR-3 explicitly skips the drift hop
+// for these — when an operator ships a custom image, freshness is
+// the operator's responsibility.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// eksNodegroupsListMaxResults caps the AWS-side page size. EKS
+// allows up to ~30 nodegroups per cluster in practice; 100 is a
+// safe ceiling. We do not paginate — same rationale as the insights
+// list handler: a NextToken response is logged as a truncation
+// warning rather than silently fetching every page (which would
+// make the cache TTL story confusing).
+const eksNodegroupsListMaxResults = 100
+
+// eksNodegroupsAPI is the SDK seam for testability. The real client
+// returned by eks.NewFromConfig satisfies this implicitly.
+type eksNodegroupsAPI interface {
+	ListNodegroups(ctx context.Context, in *eks.ListNodegroupsInput, opts ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error)
+	DescribeNodegroup(ctx context.Context, in *eks.DescribeNodegroupInput, opts ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
+}
+
+// newEKSNodegroupsClient is swapped by tests for a fake. Default
+// builds the real eks.Client from the request's Provider — same
+// shape as newEKSInsightsClient.
+var newEKSNodegroupsClient = defaultNewEKSNodegroupsClient
+
+func defaultNewEKSNodegroupsClient(p credentials.Provider, c clusters.Cluster) eksNodegroupsAPI {
+	return eks.NewFromConfig(aws.Config{
+		Region:      c.Region,
+		Credentials: p,
+	})
+}
+
+// ── Wire types ───────────────────────────────────────────────────────
+
+// NodegroupSummary is one row in the list response. The drift fields
+// are present on the wire so the SPA can pre-allocate columns; in
+// PR-2 they always come back zero/false (DriftComputed=false).
+type NodegroupSummary struct {
+	Name              string `json:"name"`
+	Status            string `json:"status"`
+	AmiType           string `json:"amiType"`
+	CapacityType      string `json:"capacityType,omitempty"`
+	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+	ReleaseVersion    string `json:"releaseVersion,omitempty"`
+	// CustomAMI is true iff AmiType == "CUSTOM". Surfaced explicitly
+	// so the SPA doesn't need to pattern-match the AmiType string.
+	CustomAMI bool `json:"customAmi"`
+	// InstanceTypesPreview is at most three instance type strings
+	// joined with ", ", suitable for a single table cell. The full
+	// list is on the detail blob.
+	InstanceTypesPreview string `json:"instanceTypesPreview,omitempty"`
+	DesiredSize          int32  `json:"desiredSize"`
+	MinSize              int32  `json:"minSize"`
+	MaxSize              int32  `json:"maxSize"`
+	HealthIssueCount     int    `json:"healthIssueCount"`
+	CreatedAt            *time.Time `json:"createdAt,omitempty"`
+
+	// Drift fields. Populated by PR-3; always zero in PR-2.
+	DriftComputed       bool   `json:"driftComputed"`
+	LatestReleaseVersion string `json:"latestReleaseVersion,omitempty"`
+	DaysBehind          int    `json:"daysBehind,omitempty"`
+	IsBehind            bool   `json:"isBehind,omitempty"`
+}
+
+// NodegroupsListResponse is the GET /eks/nodegroups payload.
+type NodegroupsListResponse struct {
+	Nodegroups []NodegroupSummary `json:"nodegroups"`
+	// CountsBehind / CountsCustom are precomputed for the overview
+	// card so it doesn't have to iterate. PR-2: CountsBehind is
+	// always 0 because nothing has drift computed yet.
+	Counts NodegroupsCounts `json:"counts"`
+}
+
+type NodegroupsCounts struct {
+	Total   int `json:"total"`
+	Behind  int `json:"behind"`
+	Custom  int `json:"custom"`
+	Healthy int `json:"healthy"`
+}
+
+// NodegroupHealthIssue mirrors the AWS shape verbatim for the SPA's
+// error panel. Pointer-typed time so "AWS didn't tell us" stays
+// distinguishable from the zero time.
+type NodegroupHealthIssue struct {
+	Code        string   `json:"code,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	ResourceIDs []string `json:"resourceIds,omitempty"`
+}
+
+// LaunchTemplateRef captures the (id, name, version) tuple AWS
+// returns when a nodegroup was created from a launch template. For
+// CUSTOM AMI nodegroups this is also where the operator specified
+// the AMI ID — but we don't fetch the launch template's contents
+// (would require ec2:DescribeLaunchTemplateVersions, which is out
+// of scope for v1).
+type LaunchTemplateRef struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// NodegroupDetail is the GET /eks/nodegroups/{name} payload. Embeds
+// the summary so callers that already cached the row from the list
+// endpoint don't need to diff every field.
+type NodegroupDetail struct {
+	NodegroupSummary
+	ARN              string                 `json:"arn,omitempty"`
+	NodeRole         string                 `json:"nodeRole,omitempty"`
+	InstanceTypes    []string               `json:"instanceTypes,omitempty"`
+	Subnets          []string               `json:"subnets,omitempty"`
+	DiskSize         int32                  `json:"diskSize,omitempty"`
+	Labels           map[string]string      `json:"labels,omitempty"`
+	Tags             map[string]string      `json:"tags,omitempty"`
+	HealthIssues     []NodegroupHealthIssue `json:"healthIssues,omitempty"`
+	LaunchTemplate   *LaunchTemplateRef     `json:"launchTemplate,omitempty"`
+	ModifiedAt       *time.Time             `json:"modifiedAt,omitempty"`
+	AutoScalingGroups []string              `json:"autoScalingGroups,omitempty"`
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────
+
+func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		if !isEKSBackend(c) {
+			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
+				errBackendNotEKSCode,
+				"managed node group introspection is only available for EKS-backed clusters")
+			return
+		}
+
+		if cached, ok := cache.GetList(c.Name); ok {
+			writeJSON(w, http.StatusOK, *cached)
+			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "list:cache_hit", "")
+			return
+		}
+
+		client := newEKSNodegroupsClient(p, c)
+		eksName := c.EKSName()
+
+		// Step 1: list names. Step 2: DescribeNodegroup per name in
+		// sequence. We don't fan out concurrently — typical clusters
+		// have ~5 node groups, AWS rate-limits Describe* on the same
+		// connection, and serial keeps the audit log linear.
+		names, err := listAllNodegroupNames(r.Context(), client, eksName)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.Warn("eks nodegroups list failed", "cluster", c.Name, "err", err)
+			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeFailure, "list", err.Error())
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"failed to list node groups: "+err.Error())
+			return
+		}
+
+		summaries := make([]NodegroupSummary, 0, len(names))
+		for _, name := range names {
+			out, err := client.DescribeNodegroup(r.Context(), &eks.DescribeNodegroupInput{
+				ClusterName:   &eksName,
+				NodegroupName: &name,
+			})
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				// One failed describe shouldn't sink the whole list —
+				// surface a placeholder row so the operator knows the
+				// nodegroup exists but its details are unavailable.
+				slog.Warn("eks nodegroup describe failed (list step)",
+					"cluster", c.Name, "nodegroup", name, "err", err)
+				summaries = append(summaries, NodegroupSummary{
+					Name:   name,
+					Status: "DEGRADED_DESCRIBE",
+				})
+				continue
+			}
+			if out.Nodegroup != nil {
+				summaries = append(summaries, buildNodegroupSummary(out.Nodegroup))
+			}
+		}
+
+		// Sort: CUSTOM nodegroups first (they're the operator-managed
+		// ones the operator likely cares about reviewing manually),
+		// then alphabetical. The SPA renders the order verbatim.
+		sort.SliceStable(summaries, func(i, j int) bool {
+			if summaries[i].CustomAMI != summaries[j].CustomAMI {
+				return summaries[i].CustomAMI
+			}
+			return summaries[i].Name < summaries[j].Name
+		})
+
+		resp := NodegroupsListResponse{
+			Nodegroups: summaries,
+			Counts:     buildNodegroupsCounts(summaries),
+		}
+		cache.PutList(c.Name, resp)
+		writeJSON(w, http.StatusOK, resp)
+		emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "list", "")
+	}
+}
+
+func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		if !isEKSBackend(c) {
+			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
+				errBackendNotEKSCode,
+				"managed node group introspection is only available for EKS-backed clusters")
+			return
+		}
+		name := chi.URLParam(r, "name")
+		if name == "" {
+			http.Error(w, "missing node group name", http.StatusBadRequest)
+			return
+		}
+
+		if cached, ok := cache.GetDetail(c.Name, name); ok {
+			writeJSON(w, http.StatusOK, *cached)
+			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "detail:cache_hit", "")
+			return
+		}
+
+		client := newEKSNodegroupsClient(p, c)
+		eksName := c.EKSName()
+		out, err := client.DescribeNodegroup(r.Context(), &eks.DescribeNodegroupInput{
+			ClusterName:   &eksName,
+			NodegroupName: &name,
+		})
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.Warn("eks nodegroup describe failed",
+				"cluster", c.Name, "nodegroup", name, "err", err)
+			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeFailure, "detail", err.Error())
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"failed to describe node group: "+err.Error())
+			return
+		}
+		if out.Nodegroup == nil {
+			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeFailure, "detail", "empty response")
+			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+				"DescribeNodegroup returned empty response")
+			return
+		}
+
+		detail := buildNodegroupDetail(out.Nodegroup)
+		cache.PutDetail(c.Name, name, detail)
+		writeJSON(w, http.StatusOK, detail)
+		emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "detail", "")
+	}
+}
+
+// ── SDK → wire mapping ───────────────────────────────────────────────
+
+func listAllNodegroupNames(ctx context.Context, client eksNodegroupsAPI, clusterName string) ([]string, error) {
+	out, err := client.ListNodegroups(ctx, &eks.ListNodegroupsInput{
+		ClusterName: &clusterName,
+		MaxResults:  int32Ptr(eksNodegroupsListMaxResults),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if out.NextToken != nil && *out.NextToken != "" {
+		// Same truncation policy as eks_insights_handler.go: log and
+		// return what we got. >100 nodegroups in one cluster is
+		// outside the realistic operator scenario this UI targets.
+		slog.Warn("eks nodegroups list truncated; not paginating",
+			"cluster", clusterName, "page_size", eksNodegroupsListMaxResults)
+	}
+	return out.Nodegroups, nil
+}
+
+func buildNodegroupSummary(in *ekstypes.Nodegroup) NodegroupSummary {
+	amiType := string(in.AmiType)
+	out := NodegroupSummary{
+		Name:              deref(in.NodegroupName),
+		Status:            string(in.Status),
+		AmiType:           amiType,
+		CapacityType:      string(in.CapacityType),
+		KubernetesVersion: deref(in.Version),
+		ReleaseVersion:    deref(in.ReleaseVersion),
+		CustomAMI:         amiType == string(ekstypes.AMITypesCustom),
+		CreatedAt:         in.CreatedAt,
+	}
+	if in.ScalingConfig != nil {
+		out.DesiredSize = derefInt32(in.ScalingConfig.DesiredSize)
+		out.MinSize = derefInt32(in.ScalingConfig.MinSize)
+		out.MaxSize = derefInt32(in.ScalingConfig.MaxSize)
+	}
+	if len(in.InstanceTypes) > 0 {
+		out.InstanceTypesPreview = joinPreview(in.InstanceTypes, 3)
+	}
+	if in.Health != nil {
+		out.HealthIssueCount = len(in.Health.Issues)
+	}
+	return out
+}
+
+func buildNodegroupDetail(in *ekstypes.Nodegroup) NodegroupDetail {
+	out := NodegroupDetail{
+		NodegroupSummary: buildNodegroupSummary(in),
+		ARN:              deref(in.NodegroupArn),
+		NodeRole:         deref(in.NodeRole),
+		InstanceTypes:    in.InstanceTypes,
+		Subnets:          in.Subnets,
+		Labels:           in.Labels,
+		Tags:             in.Tags,
+		ModifiedAt:       in.ModifiedAt,
+	}
+	if in.DiskSize != nil {
+		out.DiskSize = *in.DiskSize
+	}
+	if in.LaunchTemplate != nil {
+		out.LaunchTemplate = &LaunchTemplateRef{
+			ID:      deref(in.LaunchTemplate.Id),
+			Name:    deref(in.LaunchTemplate.Name),
+			Version: deref(in.LaunchTemplate.Version),
+		}
+	}
+	if in.Health != nil {
+		for _, issue := range in.Health.Issues {
+			out.HealthIssues = append(out.HealthIssues, NodegroupHealthIssue{
+				Code:        string(issue.Code),
+				Message:     deref(issue.Message),
+				ResourceIDs: issue.ResourceIds,
+			})
+		}
+	}
+	if in.Resources != nil {
+		for _, asg := range in.Resources.AutoScalingGroups {
+			out.AutoScalingGroups = append(out.AutoScalingGroups, deref(asg.Name))
+		}
+	}
+	return out
+}
+
+func buildNodegroupsCounts(summaries []NodegroupSummary) NodegroupsCounts {
+	c := NodegroupsCounts{Total: len(summaries)}
+	for _, s := range summaries {
+		if s.CustomAMI {
+			c.Custom++
+		}
+		if s.IsBehind {
+			c.Behind++
+		}
+		if s.HealthIssueCount == 0 && s.Status == string(ekstypes.NodegroupStatusActive) {
+			c.Healthy++
+		}
+	}
+	return c
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+func derefInt32(p *int32) int32 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// joinPreview joins up to N strings with ", "; if the slice is
+// longer than N, appends " +M more". Used for the table cell
+// preview so a 12-instance-type nodegroup doesn't blow up the row.
+func joinPreview(items []string, n int) string {
+	if len(items) <= n {
+		return strings.Join(items, ", ")
+	}
+	return strings.Join(items[:n], ", ") + " +" + strconv.Itoa(len(items)-n) + " more"
+}
+
+func emitNodegroupsRead(ctx context.Context, emitter *audit.Emitter, c clusters.Cluster, outcome audit.Outcome, op, reason string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Record(ctx, audit.Event{
+		Actor:   actorFromContext(ctx),
+		Verb:    audit.VerbEKSNodegroupsRead,
+		Outcome: outcome,
+		Cluster: c.Name,
+		Reason:  reason,
+		Extra: map[string]any{
+			"op": op,
+		},
+	})
+}
+

--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -204,7 +205,8 @@ func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache,
 			}
 			slog.Warn("eks nodegroups list failed", "cluster", c.Name, "err", err)
 			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeFailure, "list", err.Error())
-			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+			status, code := awsErrorToStatus(err)
+			writeAPIErrorJSON(w, status, code,
 				"failed to list node groups: "+err.Error())
 			return
 		}
@@ -249,11 +251,25 @@ func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache,
 		// rows are skipped inside applyDrift. The catalog client is
 		// built once per request and reused across rows so the
 		// 30min cache amortizes calls within the same fleet view.
+		//
+		// Fan-out is parallel: each applyDrift carries its own
+		// driftLookupTimeout (4s), the cache is sync-safe via its
+		// own mutex, and iterations write to disjoint &summaries[i]
+		// slots — no race window. Worst-case wall-clock collapses
+		// from N×SSM-latency to one SSM-latency on a cold cache.
+		// Mirrors fleet_handler.go's WaitGroup pattern; no errgroup
+		// dependency.
 		if amiCache != nil {
 			catalogClient := newAMICatalogClient(p, c)
+			var wg sync.WaitGroup
 			for i := range summaries {
-				applyDrift(r.Context(), &summaries[i], catalogClient, amiCache)
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					applyDrift(r.Context(), &summaries[i], catalogClient, amiCache)
+				}(i)
 			}
+			wg.Wait()
 		}
 
 		resp := NodegroupsListResponse{
@@ -306,7 +322,8 @@ func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, 
 			slog.Warn("eks nodegroup describe failed",
 				"cluster", c.Name, "nodegroup", name, "err", err)
 			emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeFailure, "detail", err.Error())
-			writeAPIErrorJSON(w, http.StatusBadGateway, "E_AWS_API",
+			status, code := awsErrorToStatus(err)
+			writeAPIErrorJSON(w, status, code,
 				"failed to describe node group: "+err.Error())
 			return
 		}

--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -51,6 +51,11 @@ import (
 // make the cache TTL story confusing).
 const eksNodegroupsListMaxResults = 100
 
+// driftLookupTimeout caps a single SSM/EC2 call. A misbehaving SSM
+// in one region must not stall the whole list response — we'd
+// rather skip drift on that nodegroup than block the page.
+const driftLookupTimeout = 4 * time.Second
+
 // eksNodegroupsAPI is the SDK seam for testability. The real client
 // returned by eks.NewFromConfig satisfies this implicitly.
 type eksNodegroupsAPI interface {
@@ -160,6 +165,15 @@ type NodegroupDetail struct {
 // ── Handlers ─────────────────────────────────────────────────────────
 
 func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return eksNodegroupsListHandlerWithDrift(reg, cache, nil, emitter)
+}
+
+// eksNodegroupsListHandlerWithDrift is the drift-aware handler.
+// `amiCache` may be nil in tests; in that case drift fields stay
+// zero (DriftComputed=false on every row). main.go always passes a
+// non-nil cache so production responses populate drift for
+// AWS-managed (non-CUSTOM) nodegroups.
+func eksNodegroupsListHandlerWithDrift(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
 	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
 		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
 		if !ok {
@@ -234,6 +248,17 @@ func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache,
 			return summaries[i].Name < summaries[j].Name
 		})
 
+		// Drift fold-in. AmiCache being non-nil is the gate; CUSTOM
+		// rows are skipped inside applyDrift. The catalog client is
+		// built once per request and reused across rows so the
+		// 30min cache amortizes calls within the same fleet view.
+		if amiCache != nil {
+			catalogClient := newAMICatalogClient(p, c)
+			for i := range summaries {
+				applyDrift(r.Context(), &summaries[i], catalogClient, amiCache)
+			}
+		}
+
 		resp := NodegroupsListResponse{
 			Nodegroups: summaries,
 			Counts:     buildNodegroupsCounts(summaries),
@@ -245,6 +270,10 @@ func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache,
 }
 
 func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
+	return eksNodegroupsGetHandlerWithDrift(reg, cache, nil, emitter)
+}
+
+func eksNodegroupsGetHandlerWithDrift(reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, emitter *audit.Emitter) func(http.ResponseWriter, *http.Request, credentials.Provider) {
 	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
 		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
 		if !ok {
@@ -294,10 +323,49 @@ func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, 
 		}
 
 		detail := buildNodegroupDetail(out.Nodegroup)
+		if amiCache != nil {
+			catalogClient := newAMICatalogClient(p, c)
+			applyDrift(r.Context(), &detail.NodegroupSummary, catalogClient, amiCache)
+		}
 		cache.PutDetail(c.Name, name, detail)
 		writeJSON(w, http.StatusOK, detail)
 		emitNodegroupsRead(r.Context(), emitter, c, audit.OutcomeSuccess, "detail", "")
 	}
+}
+
+// applyDrift folds the catalog lookup onto a nodegroup summary in
+// place. CUSTOM AMIs are skipped — the SPA renders "drift not
+// tracked" for them based on CustomAMI=true. Errors are logged and
+// leave DriftComputed=false; the nodegroup row simply shows "—" in
+// the drift column. The per-row cap on AWS calls bounds the
+// fleet-view fan-out.
+func applyDrift(parent context.Context, ng *NodegroupSummary, client amiCatalogAPI, cache *amiCatalogCache) {
+	if ng.CustomAMI {
+		return
+	}
+	amiType := ekstypes.AMITypes(ng.AmiType)
+	k8s := ng.KubernetesVersion
+	if k8s == "" {
+		return
+	}
+
+	cached, cachedErr, hit := cache.Get(amiType, k8s)
+	if !hit {
+		ctx, cancel := context.WithTimeout(parent, driftLookupTimeout)
+		defer cancel()
+		latest, err := latestForNodegroup(ctx, client, amiType, k8s)
+		cache.Put(amiType, k8s, latest, err)
+		cached, cachedErr = latest, err
+	}
+	if cachedErr != nil || cached == nil {
+		return
+	}
+
+	d := computeDrift(ng.ReleaseVersion, cached)
+	ng.DriftComputed = true
+	ng.LatestReleaseVersion = d.LatestReleaseVersion
+	ng.IsBehind = d.IsBehind
+	ng.DaysBehind = d.DaysBehind
 }
 
 // ── SDK → wire mapping ───────────────────────────────────────────────

--- a/cmd/periscope/eks_nodegroups_handler_test.go
+++ b/cmd/periscope/eks_nodegroups_handler_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/go-chi/chi/v5"
 
 	"github.com/gnana997/periscope/internal/audit"
@@ -61,14 +64,22 @@ func withFakeNodegroupsClient(t *testing.T, fake *fakeEKSNodegroupsClient) {
 // invokeNodegroups drives the list or detail handler with a planted
 // session. Reuses the recordingSink + fakeProvider from the package
 // scaffolding (audit_test_helpers_test.go / cani_handler_test.go).
+//
+// The amiCache is optional — pass nil to test the no-drift path
+// (PR-2 commit 2 behavior); pass a cache to exercise drift fold-in
+// (PR-3 commit 3 behavior).
 func invokeNodegroups(t *testing.T, reg *clusters.Registry, cache *eksNodegroupsCache, sink *recordingSink, url string, params map[string]string, isDetail bool) *httptest.ResponseRecorder {
+	return invokeNodegroupsWithDrift(t, reg, cache, nil, sink, url, params, isDetail)
+}
+
+func invokeNodegroupsWithDrift(t *testing.T, reg *clusters.Registry, cache *eksNodegroupsCache, amiCache *amiCatalogCache, sink *recordingSink, url string, params map[string]string, isDetail bool) *httptest.ResponseRecorder {
 	t.Helper()
 	emitter := audit.New(sink)
 	var h credentials.Handler
 	if isDetail {
-		h = eksNodegroupsGetHandler(reg, cache, emitter)
+		h = eksNodegroupsGetHandlerWithDrift(reg, cache, amiCache, emitter)
 	} else {
-		h = eksNodegroupsListHandler(reg, cache, emitter)
+		h = eksNodegroupsListHandlerWithDrift(reg, cache, amiCache, emitter)
 	}
 	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
 	rctx := chi.NewRouteContext()
@@ -382,6 +393,188 @@ func TestEKSNodegroupsGet_MissingName(t *testing.T) {
 		map[string]string{"cluster": "prod-eu-west-1"}, true)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// withFakeAMICatalog swaps the catalog client constructor for the
+// duration of the test. Mirrors the eks-insights/eks-nodegroups
+// pattern so each handler-integration test can supply its own
+// fake without globals.
+func withFakeAMICatalog(t *testing.T, fake amiCatalogAPI) {
+	t.Helper()
+	orig := newAMICatalogClient
+	newAMICatalogClient = func(_ credentials.Provider, _ clusters.Cluster) amiCatalogAPI {
+		return fake
+	}
+	t.Cleanup(func() { newAMICatalogClient = orig })
+}
+
+// Drift fold-in on the list response: SSM returns a newer release
+// than the nodegroup is on, IsBehind=true and DaysBehind > 0.
+func TestEKSNodegroupsList_DriftFoldedIntoSummary(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+
+	nodegroupsFake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"ng-1"}}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			ng := mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now)
+			oldRelease := "1.30.0-20240819"
+			ng.ReleaseVersion = &oldRelease
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, nodegroupsFake)
+
+	latestImage := "ami-latest"
+	latestVersion := "1.30.0-20240901"
+	catalogFake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			val := latestImage
+			if in.Name != nil && lastTokenIs(*in.Name, "release_version") {
+				val = latestVersion
+			}
+			return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: &val}}, nil
+		},
+	}
+	withFakeAMICatalog(t, catalogFake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	amiCache := newAMICatalogCache(time.Hour)
+
+	rec := invokeNodegroupsWithDrift(t, reg, cache, amiCache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", rec.Code, rec.Body.String())
+	}
+	var got NodegroupsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Nodegroups) != 1 {
+		t.Fatalf("Nodegroups = %d", len(got.Nodegroups))
+	}
+	row := got.Nodegroups[0]
+	if !row.DriftComputed {
+		t.Errorf("DriftComputed = false, want true")
+	}
+	if !row.IsBehind {
+		t.Errorf("IsBehind = false, want true")
+	}
+	if row.LatestReleaseVersion != latestVersion {
+		t.Errorf("LatestReleaseVersion = %q", row.LatestReleaseVersion)
+	}
+	// 2024-09-01 minus 2024-08-19 = 13 days.
+	if row.DaysBehind != 13 {
+		t.Errorf("DaysBehind = %d, want 13", row.DaysBehind)
+	}
+	if got.Counts.Behind != 1 {
+		t.Errorf("Counts.Behind = %d, want 1", got.Counts.Behind)
+	}
+}
+
+// Custom AMI rows must NEVER have drift folded onto them, even when
+// the catalog is wired and would otherwise return a "latest".
+func TestEKSNodegroupsList_CustomAMISkipsDrift(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+
+	nodegroupsFake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"ng-custom"}}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now),
+			}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, nodegroupsFake)
+
+	// Catalog SSM/EC2 must never be called for CUSTOM rows. If
+	// either is invoked, the test fails the assertion.
+	catalogCalled := false
+	catalogFake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			catalogCalled = true
+			return nil, errors.New("should not be called for CUSTOM AMI")
+		},
+		ec2Fn: func(_ context.Context, _ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+			catalogCalled = true
+			return nil, errors.New("should not be called for CUSTOM AMI")
+		},
+	}
+	withFakeAMICatalog(t, catalogFake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	amiCache := newAMICatalogCache(time.Hour)
+
+	rec := invokeNodegroupsWithDrift(t, reg, cache, amiCache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if catalogCalled {
+		t.Errorf("catalog was invoked for CUSTOM AMI nodegroup")
+	}
+	var got NodegroupsListResponse
+	_ = json.NewDecoder(rec.Body).Decode(&got)
+	if len(got.Nodegroups) != 1 || got.Nodegroups[0].DriftComputed {
+		t.Errorf("CUSTOM row should leave DriftComputed=false; got = %+v", got.Nodegroups)
+	}
+}
+
+// Catalog failure should NOT fail the whole list — the drift fields
+// stay zero (DriftComputed=false) and the row still renders with
+// the rest of the nodegroup metadata.
+func TestEKSNodegroupsList_CatalogFailureDoesNotBlockList(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+
+	nodegroupsFake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"ng-1"}}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now),
+			}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, nodegroupsFake)
+
+	catalogFake := &fakeAMICatalogClient{
+		ssmFn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, errors.New("AccessDenied: GetParameter")
+		},
+		ec2Fn: func(_ context.Context, _ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+			return nil, errors.New("AccessDenied: DescribeImages")
+		},
+	}
+	withFakeAMICatalog(t, catalogFake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	amiCache := newAMICatalogCache(time.Hour)
+	rec := invokeNodegroupsWithDrift(t, reg, cache, amiCache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var got NodegroupsListResponse
+	_ = json.NewDecoder(rec.Body).Decode(&got)
+	if len(got.Nodegroups) != 1 || got.Nodegroups[0].DriftComputed {
+		t.Errorf("expected drift not computed on catalog failure; got %+v", got.Nodegroups)
 	}
 }
 

--- a/cmd/periscope/eks_nodegroups_handler_test.go
+++ b/cmd/periscope/eks_nodegroups_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -197,6 +198,61 @@ func TestEKSNodegroupsList_AWSListErrorEmitsFailureAudit(t *testing.T) {
 	events := sink.snapshot()
 	if len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
 		t.Errorf("expected one failure event")
+	}
+}
+
+// TestEKSNodegroupsList_ClassifiesAWSErrors mirrors the insights test:
+// each smithy-typed exception flips the response to a structured
+// status + code so the SPA renders the right diagnostic.
+func TestEKSNodegroupsList_ClassifiesAWSErrors(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "AccessDenied → 403/E_AWS_FORBIDDEN",
+			err:        &ekstypes.AccessDeniedException{Message: strPtr("denied")},
+			wantStatus: http.StatusForbidden,
+			wantCode:   "E_AWS_FORBIDDEN",
+		},
+		{
+			name:       "ResourceNotFound → 404/E_AWS_NOT_FOUND",
+			err:        &ekstypes.ResourceNotFoundException{Message: strPtr("missing")},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "E_AWS_NOT_FOUND",
+		},
+		{
+			name:       "Throttling → 429/E_AWS_THROTTLED",
+			err:        &ekstypes.ThrottlingException{Message: strPtr("slow down")},
+			wantStatus: http.StatusTooManyRequests,
+			wantCode:   "E_AWS_THROTTLED",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+			fake := &fakeEKSNodegroupsClient{
+				listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+					return nil, tc.err
+				},
+			}
+			withFakeNodegroupsClient(t, fake)
+
+			rec := invokeNodegroups(t, reg, newEKSNodegroupsCache(time.Hour),
+				&recordingSink{},
+				"/api/clusters/prod-eu-west-1/eks/nodegroups",
+				map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s",
+					rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantCode) {
+				t.Errorf("body missing %q: %s", tc.wantCode, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/cmd/periscope/eks_nodegroups_handler_test.go
+++ b/cmd/periscope/eks_nodegroups_handler_test.go
@@ -1,0 +1,441 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// fakeEKSNodegroupsClient implements eksNodegroupsAPI. The list +
+// describe fns are pluggable per-test.
+type fakeEKSNodegroupsClient struct {
+	mu        sync.Mutex
+	listCalls int
+	descCalls int
+	listFn    func(ctx context.Context, in *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error)
+	descFn    func(ctx context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error)
+}
+
+func (f *fakeEKSNodegroupsClient) ListNodegroups(ctx context.Context, in *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+	f.mu.Lock()
+	f.listCalls++
+	f.mu.Unlock()
+	if f.listFn == nil {
+		return nil, errors.New("listFn not set")
+	}
+	return f.listFn(ctx, in)
+}
+
+func (f *fakeEKSNodegroupsClient) DescribeNodegroup(ctx context.Context, in *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+	f.mu.Lock()
+	f.descCalls++
+	f.mu.Unlock()
+	if f.descFn == nil {
+		return nil, errors.New("descFn not set")
+	}
+	return f.descFn(ctx, in)
+}
+
+func withFakeNodegroupsClient(t *testing.T, fake *fakeEKSNodegroupsClient) {
+	t.Helper()
+	orig := newEKSNodegroupsClient
+	newEKSNodegroupsClient = func(_ credentials.Provider, _ clusters.Cluster) eksNodegroupsAPI {
+		return fake
+	}
+	t.Cleanup(func() { newEKSNodegroupsClient = orig })
+}
+
+// invokeNodegroups drives the list or detail handler with a planted
+// session. Reuses the recordingSink + fakeProvider from the package
+// scaffolding (audit_test_helpers_test.go / cani_handler_test.go).
+func invokeNodegroups(t *testing.T, reg *clusters.Registry, cache *eksNodegroupsCache, sink *recordingSink, url string, params map[string]string, isDetail bool) *httptest.ResponseRecorder {
+	t.Helper()
+	emitter := audit.New(sink)
+	var h credentials.Handler
+	if isDetail {
+		h = eksNodegroupsGetHandler(reg, cache, emitter)
+	} else {
+		h = eksNodegroupsListHandler(reg, cache, emitter)
+	}
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	req = req.WithContext(credentials.WithSession(
+		context.WithValue(req.Context(), chi.RouteCtxKey, rctx),
+		credentials.Session{Subject: "alice@corp", Email: "alice@corp", Groups: []string{"eng"}},
+	))
+	rec := httptest.NewRecorder()
+	h(rec, req, fakeProvider{actor: "alice@corp"})
+	return rec
+}
+
+// ── List ─────────────────────────────────────────────────────────────
+
+func TestEKSNodegroupsList_HappyPath(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, in *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			if in.ClusterName == nil || *in.ClusterName != "prod-eu-west-1" {
+				t.Errorf("expected cluster from ARN, got %v", in.ClusterName)
+			}
+			return &eks.ListNodegroupsOutput{
+				Nodegroups: []string{"ng-system", "ng-spot", "ng-custom"},
+			}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now),
+			}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got NodegroupsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Nodegroups) != 3 {
+		t.Fatalf("Nodegroups = %d, want 3", len(got.Nodegroups))
+	}
+	// Custom-AMI nodegroup must sort first.
+	if got.Nodegroups[0].Name != "ng-custom" {
+		t.Errorf("expected ng-custom first (CUSTOM AMI sort), got %q", got.Nodegroups[0].Name)
+	}
+	if !got.Nodegroups[0].CustomAMI {
+		t.Errorf("ng-custom should have CustomAMI=true")
+	}
+	if got.Counts.Total != 3 || got.Counts.Custom != 1 {
+		t.Errorf("Counts = %+v", got.Counts)
+	}
+	// PR-2: no drift computed yet.
+	for _, ng := range got.Nodegroups {
+		if ng.DriftComputed {
+			t.Errorf("PR-2 should not set DriftComputed; got true for %q", ng.Name)
+		}
+	}
+
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Verb != audit.VerbEKSNodegroupsRead {
+		t.Errorf("expected one VerbEKSNodegroupsRead event, got %+v", events)
+	}
+}
+
+func TestEKSNodegroupsList_NonEKSReturns422(t *testing.T) {
+	reg := eksRegistry(t, "kind-local", clusters.BackendInCluster)
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/kind-local/eks/nodegroups",
+		map[string]string{"cluster": "kind-local"}, false)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	var body apiError
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Code != errBackendNotEKSCode {
+		t.Errorf("code = %q", body.Code)
+	}
+}
+
+func TestEKSNodegroupsList_AWSListErrorEmitsFailureAudit(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return nil, errors.New("AccessDenied: ListNodegroups")
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
+		t.Errorf("expected one failure event")
+	}
+}
+
+// One nodegroup that fails Describe should not sink the whole list —
+// the row is replaced with a degraded placeholder so the operator
+// knows it exists but its details are unavailable.
+func TestEKSNodegroupsList_PartialDescribeFailure(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{
+				Nodegroups: []string{"ng-ok", "ng-bad"},
+			}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			if *in.NodegroupName == "ng-bad" {
+				return nil, errors.New("ResourceNotFoundException")
+			}
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now),
+			}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups",
+		map[string]string{"cluster": "prod-eu-west-1"}, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (partial-failure tolerance)", rec.Code)
+	}
+	var got NodegroupsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Nodegroups) != 2 {
+		t.Fatalf("Nodegroups = %d, want 2", len(got.Nodegroups))
+	}
+	// Find ng-bad and confirm the degraded placeholder.
+	var bad *NodegroupSummary
+	for i := range got.Nodegroups {
+		if got.Nodegroups[i].Name == "ng-bad" {
+			bad = &got.Nodegroups[i]
+		}
+	}
+	if bad == nil || bad.Status != "DEGRADED_DESCRIBE" {
+		t.Errorf("ng-bad placeholder missing or wrong: %+v", bad)
+	}
+}
+
+func TestEKSNodegroupsList_CacheHitSkipsAWS(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSNodegroupsClient{
+		listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"ng-1"}}, nil
+		},
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now),
+			}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	for i := 0; i < 2; i++ {
+		rec := invokeNodegroups(t, reg, cache, sink,
+			"/api/clusters/prod-eu-west-1/eks/nodegroups",
+			map[string]string{"cluster": "prod-eu-west-1"}, false)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("call %d status = %d", i, rec.Code)
+		}
+	}
+	if fake.listCalls != 1 {
+		t.Errorf("ListNodegroups calls = %d, want 1 (second served from cache)", fake.listCalls)
+	}
+	if fake.descCalls != 1 {
+		t.Errorf("DescribeNodegroup calls = %d, want 1", fake.descCalls)
+	}
+	events := sink.snapshot()
+	if len(events) != 2 {
+		t.Errorf("audit events = %d, want 2", len(events))
+	}
+	if op, _ := events[1].Extra["op"].(string); op != "list:cache_hit" {
+		t.Errorf("second event op = %q, want list:cache_hit", op)
+	}
+}
+
+// ── Detail ───────────────────────────────────────────────────────────
+
+func TestEKSNodegroupsGet_HappyPath(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSNodegroupsClient{
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			if in.NodegroupName == nil || *in.NodegroupName != "ng-1" {
+				t.Errorf("name = %v", in.NodegroupName)
+			}
+			ng := mkNodegroup("ng-1", ekstypes.NodegroupStatusActive, &now)
+			arn := "arn:aws:eks:eu-west-1:111:nodegroup/prod-eu-west-1/ng-1/x"
+			role := "arn:aws:iam::111:role/eks-node"
+			ng.NodegroupArn = &arn
+			ng.NodeRole = &role
+			ng.Subnets = []string{"subnet-a", "subnet-b"}
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups/ng-1",
+		map[string]string{"cluster": "prod-eu-west-1", "name": "ng-1"}, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got NodegroupDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Name != "ng-1" || got.NodeRole == "" || len(got.Subnets) != 2 {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestEKSNodegroupsGet_CustomAMIFlag(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	now := time.Now().UTC()
+	fake := &fakeEKSNodegroupsClient{
+		descFn: func(_ context.Context, in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			ng := mkNodegroup(*in.NodegroupName, ekstypes.NodegroupStatusActive, &now)
+			ng.AmiType = ekstypes.AMITypesCustom
+			ltID := "lt-0abc"
+			ltVer := "3"
+			ng.LaunchTemplate = &ekstypes.LaunchTemplateSpecification{
+				Id:      &ltID,
+				Version: &ltVer,
+			}
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups/ng-x",
+		map[string]string{"cluster": "prod-eu-west-1", "name": "ng-x"}, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var got NodegroupDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.CustomAMI {
+		t.Errorf("CustomAMI = false, want true")
+	}
+	if got.AmiType != "CUSTOM" {
+		t.Errorf("AmiType = %q", got.AmiType)
+	}
+	if got.LaunchTemplate == nil || got.LaunchTemplate.ID != "lt-0abc" {
+		t.Errorf("LaunchTemplate = %+v", got.LaunchTemplate)
+	}
+}
+
+func TestEKSNodegroupsGet_NonEKSReturns422(t *testing.T) {
+	reg := eksRegistry(t, "kind-local", clusters.BackendInCluster)
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/kind-local/eks/nodegroups/ng-1",
+		map[string]string{"cluster": "kind-local", "name": "ng-1"}, true)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}
+
+func TestEKSNodegroupsGet_MissingName(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups/",
+		map[string]string{"cluster": "prod-eu-west-1"}, true)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEKSNodegroupsGet_AWSError(t *testing.T) {
+	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
+	fake := &fakeEKSNodegroupsClient{
+		descFn: func(_ context.Context, _ *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+			return nil, errors.New("ResourceNotFoundException")
+		},
+	}
+	withFakeNodegroupsClient(t, fake)
+
+	sink := &recordingSink{}
+	cache := newEKSNodegroupsCache(time.Hour)
+	rec := invokeNodegroups(t, reg, cache, sink,
+		"/api/clusters/prod-eu-west-1/eks/nodegroups/missing",
+		map[string]string{"cluster": "prod-eu-west-1", "name": "missing"}, true)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if events := sink.snapshot(); len(events) != 1 || events[0].Outcome != audit.OutcomeFailure {
+		t.Errorf("expected one failure event")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+func mkNodegroup(name string, status ekstypes.NodegroupStatus, ts *time.Time) *ekstypes.Nodegroup {
+	nameCopy := name
+	version := "1.30"
+	releaseVersion := "1.30.0-20240819"
+	desired := int32(3)
+	minSize := int32(1)
+	maxSize := int32(5)
+
+	// CUSTOM is signaled via name suffix so the test fixtures stay simple.
+	amiType := ekstypes.AMITypesAl2023X8664Standard
+	if name == "ng-custom" {
+		amiType = ekstypes.AMITypesCustom
+	}
+
+	return &ekstypes.Nodegroup{
+		NodegroupName:     &nameCopy,
+		Status:            status,
+		AmiType:           amiType,
+		CapacityType:      ekstypes.CapacityTypesOnDemand,
+		Version:           &version,
+		ReleaseVersion:    &releaseVersion,
+		CreatedAt:         ts,
+		InstanceTypes:     []string{"m5.large"},
+		ScalingConfig: &ekstypes.NodegroupScalingConfig{
+			DesiredSize: &desired,
+			MinSize:     &minSize,
+			MaxSize:     &maxSize,
+		},
+	}
+}

--- a/cmd/periscope/eks_nodegroups_handler_test.go
+++ b/cmd/periscope/eks_nodegroups_handler_test.go
@@ -65,9 +65,9 @@ func withFakeNodegroupsClient(t *testing.T, fake *fakeEKSNodegroupsClient) {
 // session. Reuses the recordingSink + fakeProvider from the package
 // scaffolding (audit_test_helpers_test.go / cani_handler_test.go).
 //
-// The amiCache is optional — pass nil to test the no-drift path
-// (PR-2 commit 2 behavior); pass a cache to exercise drift fold-in
-// (PR-3 commit 3 behavior).
+// `amiCache` is optional — nil exercises the no-drift path (the PR-2
+// shape, where DriftComputed stays false on every row); a non-nil
+// cache exercises the drift fold-in path that production runs.
 func invokeNodegroups(t *testing.T, reg *clusters.Registry, cache *eksNodegroupsCache, sink *recordingSink, url string, params map[string]string, isDetail bool) *httptest.ResponseRecorder {
 	return invokeNodegroupsWithDrift(t, reg, cache, nil, sink, url, params, isDetail)
 }
@@ -77,9 +77,9 @@ func invokeNodegroupsWithDrift(t *testing.T, reg *clusters.Registry, cache *eksN
 	emitter := audit.New(sink)
 	var h credentials.Handler
 	if isDetail {
-		h = eksNodegroupsGetHandlerWithDrift(reg, cache, amiCache, emitter)
+		h = eksNodegroupsGetHandler(reg, cache, amiCache, emitter)
 	} else {
-		h = eksNodegroupsListHandlerWithDrift(reg, cache, amiCache, emitter)
+		h = eksNodegroupsListHandler(reg, cache, amiCache, emitter)
 	}
 	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
 	rctx := chi.NewRouteContext()

--- a/cmd/periscope/errors.go
+++ b/cmd/periscope/errors.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/aws/smithy-go"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/gnana997/periscope/internal/audit"
@@ -108,6 +109,30 @@ func ErrorCodeFor(err error) string {
 		return "apiserver_unreachable"
 	}
 	return "unknown"
+}
+
+// awsErrorToStatus classifies an AWS SDK error into (httpStatus, code)
+// for the EKS read-only handlers. Falls through to (502, "E_AWS_API")
+// for unrecognized errors so the existing default behavior is
+// preserved. Recognized smithy.APIError codes are shared across the
+// EKS / SSM / EC2 services Periscope talks to today; the recognized
+// set covers the failures an operator can actually act on (fix IAM,
+// wait out a throttle, check that the resource exists). Anything else
+// stays a generic 502 — the caller's slog.Warn line still records the
+// raw error for debugging.
+func awsErrorToStatus(err error) (int, string) {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDeniedException", "UnauthorizedOperation":
+			return http.StatusForbidden, "E_AWS_FORBIDDEN"
+		case "ResourceNotFoundException", "NotFoundException":
+			return http.StatusNotFound, "E_AWS_NOT_FOUND"
+		case "ThrottlingException", "TooManyRequestsException", "RequestLimitExceeded":
+			return http.StatusTooManyRequests, "E_AWS_THROTTLED"
+		}
+	}
+	return http.StatusBadGateway, "E_AWS_API"
 }
 
 func isContextTimeout(err error) bool {

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -288,9 +288,9 @@ func main() {
 	amiCatalogCacheTTL := 30 * time.Minute
 	amiCatalogC := newAMICatalogCache(amiCatalogCacheTTL)
 	router.Get("/api/clusters/{cluster}/eks/nodegroups", credentials.Wrap(factory,
-		eksNodegroupsListHandlerWithDrift(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
+		eksNodegroupsListHandler(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
 	router.Get("/api/clusters/{cluster}/eks/nodegroups/{name}", credentials.Wrap(factory,
-		eksNodegroupsGetHandlerWithDrift(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
+		eksNodegroupsGetHandler(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
 
 	// --- Overview / dashboard ---
 

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -259,6 +259,22 @@ func main() {
 	router.Get("/api/clusters/{cluster}/helm/releases/{ns}/{name}/diff", credentials.Wrap(factory,
 		helmDiffHandler(registry)))
 
+	// --- EKS Upgrade Insights (read-only) ---
+	//
+	// EKS scans every cluster's audit log daily and produces a list
+	// of UPGRADE_READINESS insights. We wrap ListInsights /
+	// DescribeInsight, layer a 1h cluster-keyed cache (AWS only
+	// refreshes daily), and decorate each affected resource with a
+	// deep link into the SPA's editor. EKS-only by design: non-EKS
+	// clusters get a 422 with a stable error code. See
+	// eks_insights_handler.go for the audit and 422 contract.
+	eksInsightsCacheTTL := 1 * time.Hour
+	eksInsightsC := newEKSInsightsCache(eksInsightsCacheTTL)
+	router.Get("/api/clusters/{cluster}/eks/upgrade-insights", credentials.Wrap(factory,
+		eksInsightsListHandler(registry, eksInsightsC, auditEmitter)))
+	router.Get("/api/clusters/{cluster}/eks/upgrade-insights/{insightId}", credentials.Wrap(factory,
+		eksInsightsGetHandler(registry, eksInsightsC, auditEmitter)))
+
 	// --- Overview / dashboard ---
 
 	router.Get("/api/clusters/{cluster}/dashboard", credentials.Wrap(factory,

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -275,6 +275,20 @@ func main() {
 	router.Get("/api/clusters/{cluster}/eks/upgrade-insights/{insightId}", credentials.Wrap(factory,
 		eksInsightsGetHandler(registry, eksInsightsC, auditEmitter)))
 
+	// --- EKS managed node groups (read-only, issue #103) ---
+	//
+	// List + per-nodegroup detail. Surfaces the current EKS-optimized
+	// AMI release version, custom-AMI flag, scaling config, and
+	// health issues. Drift computation (latest AMI lookup +
+	// daysBehind) is layered onto the response by a separate code
+	// path; PR-2 lands the SDK plumbing only.
+	eksNodegroupsCacheTTL := 5 * time.Minute
+	eksNodegroupsC := newEKSNodegroupsCache(eksNodegroupsCacheTTL)
+	router.Get("/api/clusters/{cluster}/eks/nodegroups", credentials.Wrap(factory,
+		eksNodegroupsListHandler(registry, eksNodegroupsC, auditEmitter)))
+	router.Get("/api/clusters/{cluster}/eks/nodegroups/{name}", credentials.Wrap(factory,
+		eksNodegroupsGetHandler(registry, eksNodegroupsC, auditEmitter)))
+
 	// --- Overview / dashboard ---
 
 	router.Get("/api/clusters/{cluster}/dashboard", credentials.Wrap(factory,

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -275,19 +275,22 @@ func main() {
 	router.Get("/api/clusters/{cluster}/eks/upgrade-insights/{insightId}", credentials.Wrap(factory,
 		eksInsightsGetHandler(registry, eksInsightsC, auditEmitter)))
 
-	// --- EKS managed node groups (read-only, issue #103) ---
+	// --- EKS managed node groups + AMI drift (read-only, issue #103) ---
 	//
-	// List + per-nodegroup detail. Surfaces the current EKS-optimized
-	// AMI release version, custom-AMI flag, scaling config, and
-	// health issues. Drift computation (latest AMI lookup +
-	// daysBehind) is layered onto the response by a separate code
-	// path; PR-2 lands the SDK plumbing only.
+	// List + per-nodegroup detail with drift detection layered in
+	// from the AMI catalog (SSM public parameters as primary,
+	// DescribeImages as fallback). Two caches: the nodegroup cache
+	// is per-cluster (5min TTL — operator changes); the AMI catalog
+	// cache is per-(amiType, k8sVersion) at 30min TTL (AWS publishes
+	// new EKS-optimized AMIs roughly weekly), shared across clusters.
 	eksNodegroupsCacheTTL := 5 * time.Minute
 	eksNodegroupsC := newEKSNodegroupsCache(eksNodegroupsCacheTTL)
+	amiCatalogCacheTTL := 30 * time.Minute
+	amiCatalogC := newAMICatalogCache(amiCatalogCacheTTL)
 	router.Get("/api/clusters/{cluster}/eks/nodegroups", credentials.Wrap(factory,
-		eksNodegroupsListHandler(registry, eksNodegroupsC, auditEmitter)))
+		eksNodegroupsListHandlerWithDrift(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
 	router.Get("/api/clusters/{cluster}/eks/nodegroups/{name}", credentials.Wrap(factory,
-		eksNodegroupsGetHandler(registry, eksNodegroupsC, auditEmitter)))
+		eksNodegroupsGetHandlerWithDrift(registry, eksNodegroupsC, amiCatalogC, auditEmitter)))
 
 	// --- Overview / dashboard ---
 

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -185,25 +185,45 @@ The trust policy above only says *who* can assume the role. The *permissions* po
 |---|---|
 | `eks:DescribeCluster` | Resolves the apiserver endpoint and CA on every K8s call (auth path). |
 | `eks:ListInsights`, `eks:DescribeInsight` | Upgrade Insights surface (`/api/clusters/{c}/eks/upgrade-insights*`). EKS-only by design; non-EKS clusters return 422. Cached server-side for 1 hour since AWS itself only refreshes daily. |
+| `eks:ListNodegroups`, `eks:DescribeNodegroup` | Managed node group surface (`/api/clusters/{c}/eks/nodegroups*`). |
+| `ssm:GetParameter` (scoped to `arn:aws:ssm:*::parameter/aws/service/eks/*` and `arn:aws:ssm:*::parameter/aws/service/bottlerocket/*`) | AMI drift detection — primary "latest AMI" lookup against AWS public parameters. |
+| `ec2:DescribeImages` | AMI drift detection — fallback used when the SSM lookup fails (denied / not found / throttled). |
 
 Minimum permissions policy:
 
 ```json
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-      "eks:DescribeCluster",
-      "eks:ListInsights",
-      "eks:DescribeInsight"
-    ],
-    "Resource": "arn:aws:eks:*:111111111111:cluster/*"
-  }]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster",
+        "eks:ListInsights", "eks:DescribeInsight",
+        "eks:ListNodegroups", "eks:DescribeNodegroup"
+      ],
+      "Resource": "arn:aws:eks:*:111111111111:cluster/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:*::parameter/aws/service/eks/*",
+        "arn:aws:ssm:*::parameter/aws/service/bottlerocket/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DescribeImages",
+      "Resource": "*"
+    }
+  ]
 }
 ```
 
-Tighten the resource ARN to specific cluster ARNs once you've decided which clusters Periscope manages. The Insights actions are read-only and produce no mutation surface, so they are safe to grant cluster-wide if your registry is small.
+Tighten the EKS resource ARN to specific cluster ARNs once you've decided which clusters Periscope manages. The Insights / node group / SSM-public / `DescribeImages` actions are read-only and produce no mutation surface, so they are safe to grant if your registry is small. `ec2:DescribeImages` only supports `Resource: *` because the API has no resource-level ARN for image lookups.
+
+For the full surface map of what each action enables in the UI, see [`eks-upgrade-readiness.md`](./eks-upgrade-readiness.md).
 
 ---
 

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -177,6 +177,34 @@ The role's trust policy uses the cluster's OIDC provider:
 Periscope code is identical for both. Pick whichever your platform team
 already runs.
 
+### 4.1. AWS API permissions on the role
+
+The trust policy above only says *who* can assume the role. The *permissions* policy attached to the role is what determines which AWS APIs Periscope can call. Required for every EKS-backed cluster:
+
+| Action | Used by |
+|---|---|
+| `eks:DescribeCluster` | Resolves the apiserver endpoint and CA on every K8s call (auth path). |
+| `eks:ListInsights`, `eks:DescribeInsight` | Upgrade Insights surface (`/api/clusters/{c}/eks/upgrade-insights*`). EKS-only by design; non-EKS clusters return 422. Cached server-side for 1 hour since AWS itself only refreshes daily. |
+
+Minimum permissions policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "eks:DescribeCluster",
+      "eks:ListInsights",
+      "eks:DescribeInsight"
+    ],
+    "Resource": "arn:aws:eks:*:111111111111:cluster/*"
+  }]
+}
+```
+
+Tighten the resource ARN to specific cluster ARNs once you've decided which clusters Periscope manages. The Insights actions are read-only and produce no mutation surface, so they are safe to grant cluster-wide if your registry is small.
+
 ---
 
 ## 4.5. Single-cluster install (in-cluster backend)

--- a/docs/setup/eks-upgrade-readiness.md
+++ b/docs/setup/eks-upgrade-readiness.md
@@ -87,6 +87,10 @@ Minimum policy snippet to add to the existing periscope role (extends the snippe
 
 `ec2:DescribeImages` only supports `Resource: *` because the API doesn't have resource-level ARNs for image lookups. The action is read-only.
 
+> **Diagnosing missing permissions in the SPA.** When the role lacks one of these IAM actions, the upgrade-readiness and node-groups pages render a permission-specific hint (`Periscope's AWS role does not have permission to read…`) instead of a generic red error banner. The backend translates AWS `AccessDeniedException` to HTTP 403 with the stable code `E_AWS_FORBIDDEN`; AWS `ThrottlingException` becomes 429 with `E_AWS_THROTTLED` (transient — refresh after a moment). All other AWS errors keep the legacy 502 / `E_AWS_API` shape.
+
+> **Partition support.** The IAM matrix above and the `ec2:DescribeImages` fallback list both Amazon-owned AMIs and the historical EKS-optimized AMI account `602401143452`. This covers every AWS commercial region. **GovCloud and China partitions are not covered for AMI drift detection in v1** — the EC2 AMI account IDs differ there, and the SSM `/aws/service/eks/*` parameter tree may not be published. The SPA will show "—" in the drift column for nodegroups in those partitions.
+
 ---
 
 ## Refresh cadence

--- a/docs/setup/eks-upgrade-readiness.md
+++ b/docs/setup/eks-upgrade-readiness.md
@@ -1,0 +1,154 @@
+# EKS upgrade readiness
+
+Two surfaces, both EKS-only, both pure read-only:
+
+- **Upgrade Insights** — the `UPGRADE_READINESS` insights AWS produces from your cluster's audit log every day (deprecated APIs, add-on prerequisites, IAM and networking gotchas). Surfaced via [`ListInsights`](https://docs.aws.amazon.com/eks/latest/APIReference/API_ListInsights.html) + [`DescribeInsight`](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeInsight.html).
+- **Managed node group AMI drift** — current AMI release version per node group, plus how many days behind the latest AWS-published EKS-optimized AMI it is. Surfaced via [`ListNodegroups`](https://docs.aws.amazon.com/eks/latest/APIReference/API_ListNodegroups.html) + [`DescribeNodegroup`](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeNodegroup.html), with a follow-on SSM (or EC2 fallback) lookup for the latest AMI.
+
+Both surfaces ship as part of issue #103 and are paired in the UI on the cluster overview page so an operator preparing an upgrade can see "are my manifests OK *and* are my node images current?" in one place.
+
+---
+
+## What you see
+
+### Upgrade readiness card / page
+
+```
+Upgrade readiness · prod-eu-west-1 → 1.32
+  ●  4 PASSING        cluster health / iam / network
+  ▲  2 WARNING        2 admin Roles use deprecated apiGroups
+  ✕  1 ERROR          12 resources use APIs removed in v1.32
+```
+
+Click an `ERROR` insight to expand the affected resources. Each resource is a deep link into Periscope's existing YAML editor — one click from "EKS flagged this" to editing the object.
+
+**Caveat — deprecated apiVersions**: when AWS flags a resource at a deprecated apiVersion (e.g. `policy/v1beta1` for a PodDisruptionBudget), the editor opens the resource at its currently-served version. This is generally what you want — you see live state. For CRDs at no-longer-served versions, the editor will surface a load error from the apiserver.
+
+### Node groups card / page
+
+```
+Node groups · prod-eu-west-1
+  ●  3 healthy   ▲ 1 behind   — 1 custom
+
+  Name        AMI                          Release             Drift
+  ng-spot     custom                       —                   not tracked
+  ng-system   AL2023_x86_64_STANDARD       1.30.0-20240819     14d behind
+  ng-gpu      AL2_x86_64_GPU               1.30.0-20240901     current
+```
+
+Custom-AMI node groups (`AmiType=CUSTOM`) are sorted first and explicitly badged "not tracked" — AWS does not publish a "latest" for custom images, so drift detection cannot apply.
+
+---
+
+## IAM permissions
+
+The periscope role (whether assumed via Pod Identity or IRSA — see [deploy.md §4](./deploy.md#4-aws-auth-pod-identity-vs-irsa)) needs the following actions for these surfaces:
+
+| Action | Surface |
+|---|---|
+| `eks:DescribeCluster` | always required (cluster auth path) |
+| `eks:ListInsights`, `eks:DescribeInsight` | Upgrade Insights |
+| `eks:ListNodegroups`, `eks:DescribeNodegroup` | Node groups (always) |
+| `ssm:GetParameter` (resource: `arn:aws:ssm:*::parameter/aws/service/eks/*` and `parameter/aws/service/bottlerocket/*`) | AMI drift (primary lookup) |
+| `ec2:DescribeImages` | AMI drift (fallback when SSM is denied / unavailable) |
+
+The Insights and node group actions are read-only; nothing in this surface can mutate AWS state. The `ssm:GetParameter` resource scope intentionally matches only the public-parameter trees AWS publishes for EKS / Bottlerocket — it does **not** grant access to your own Parameter Store secrets.
+
+Minimum policy snippet to add to the existing periscope role (extends the snippet in [deploy.md §4.1](./deploy.md#41-aws-api-permissions-on-the-role)):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:ListInsights", "eks:DescribeInsight",
+        "eks:ListNodegroups", "eks:DescribeNodegroup"
+      ],
+      "Resource": "arn:aws:eks:*:111111111111:cluster/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:*::parameter/aws/service/eks/*",
+        "arn:aws:ssm:*::parameter/aws/service/bottlerocket/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DescribeImages",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+`ec2:DescribeImages` only supports `Resource: *` because the API doesn't have resource-level ARNs for image lookups. The action is read-only.
+
+---
+
+## Refresh cadence
+
+These caches are sized to AWS's own update frequency. The latency you see can be a multiple of the cache TTL on a fleet-wide refresh, but the underlying truth in AWS doesn't update faster than these intervals anyway, so polling more aggressively just burns API calls.
+
+| Data | Source TTL | Cache TTL | Notes |
+|---|---|---|---|
+| Upgrade Insights list / detail | AWS refreshes daily | 1 hour | The first cache hit after a daily AWS refresh may still be stale by up to an hour. |
+| Managed node groups (per cluster) | changes on operator action | 5 minutes | Short enough that a node-group rotation shows up promptly. |
+| Latest AMI for `(family, k8sVersion)` | AWS publishes new AL2023 EKS-optimized AMIs roughly weekly; Bottlerocket on its own cadence | 30 minutes | Shared across clusters — a fleet view of N AL2023 nodegroups makes one SSM call per `(family, k8sVer)` per half-hour. |
+
+---
+
+## What is NOT in the surface
+
+- **Self-managed nodes** (raw EC2, Karpenter, Fargate profiles). EKS only knows about *managed* node groups; self-managed nodes are invisible to `DescribeNodegroup` and therefore invisible here.
+- **Security advisories / CVEs against AMIs.** There is no AWS API for "AMI X has CVEs Y/Z" — the data lives in HTML release notes (`awslabs/amazon-eks-ami` releases, Bottlerocket security bulletins) and in account-scoped scan results (Inspector v2). We deliberately do not surface a CVE list here because faking one when AWS doesn't expose the data risks giving operators false confidence. The detail page links out to AWS's authoritative release notes; chase from there.
+- **Windows + FIPS variants of the AMI catalog.** The SSM parameter shape diverges (no `release_version` subkey for Windows), and these variants are rare enough we'd rather punt than half-implement. Windows / FIPS node groups still appear in the list with their current AMI release version; the drift column reads "—".
+
+---
+
+## NetworkPolicy
+
+If you've enabled `networkPolicy.enabled=true` (see [networkpolicy.md](./networkpolicy.md)), Periscope needs egress to:
+
+- the AWS EKS regional endpoints (already needed for `DescribeCluster`)
+- the AWS SSM regional endpoints (for the AMI catalog)
+- the AWS EC2 regional endpoints (for the drift fallback path)
+
+All three are TCP/443. The most permissive default — "allow all internet HTTPS but no in-cluster traffic" — already covers them. For a tighter posture, list the regional endpoints you use explicitly; AWS publishes the IP ranges in the [`ip-ranges.json`](https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html) feed under service codes `EC2` (covers EC2 + STS), `AMAZON_CONNECT`, and the regional AMI service.
+
+---
+
+## Audit trail
+
+Both surfaces emit a row to the audit log on every read, regardless of outcome:
+
+- `verb=eks_insights_read` for the Upgrade Insights surface
+- `verb=eks_nodegroups_read` for the node groups + drift surface
+
+These are the first **read verbs** in Periscope's audit taxonomy — every other verb (`apply`, `delete`, `exec_open`, `secret_reveal`, …) covers a privileged mutation. We added these specifically because compliance reviewers asked for a record of who looked at upgrade readiness before a version bump. Other read endpoints (helm list, resource list) remain unaudited.
+
+---
+
+## Troubleshooting
+
+**"Drift not computed" on every AWS-managed node group.** Almost certainly an IAM issue. Check the periscope pod's logs for `eks ami catalog: ssm lookup failed` — the wrapped error names the missing permission. The 30-minute sticky-error cache means a fresh permission grant takes up to half an hour to take effect; restart the pod to apply immediately.
+
+**"Drift not computed" on Windows or FIPS node groups.** Expected. The catalog does not cover those variants in v1; see *What is NOT in the surface* above.
+
+**Upgrade insights tab shows "load failed".** The pod's role is missing `eks:ListInsights` / `eks:DescribeInsight`. The 422 path is for non-EKS clusters; a real load failure (5xx or 4xx other than 422) means the AWS call itself errored. The audit log has the full reason on the matching `eks_insights_read` row.
+
+**Affected resource link in an insight 404s.** Two causes: (1) the deprecated apiVersion is no longer served by your apiserver — the editor's load failure is the genuine answer; or (2) the resource was deleted between the AWS daily scan and your click. Re-run the insights scan from the AWS console to refresh.
+
+---
+
+## References
+
+- [AWS EKS — Cluster insights (upgrade readiness)](https://docs.aws.amazon.com/eks/latest/userguide/cluster-insights.html)
+- [AWS — accelerate EKS upgrades with upgrade insights](https://aws.amazon.com/blogs/containers/accelerate-the-testing-and-verification-of-amazon-eks-upgrades-with-upgrade-insights/)
+- [AWS — retrieve recommended Amazon Linux EKS AMI IDs](https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html)
+- [AWS — retrieve recommended Bottlerocket AMI IDs](https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id-bottlerocket.html)
+- [`awslabs/amazon-eks-ami` releases (drift baseline + release notes)](https://github.com/awslabs/amazon-eks-ami/releases)
+- [Bottlerocket security advisories](https://github.com/bottlerocket-os/bottlerocket/security/advisories)

--- a/docs/setup/networkpolicy.md
+++ b/docs/setup/networkpolicy.md
@@ -75,6 +75,8 @@ sanity check:
 | **Audit stdout shipping** | Whatever your log-aggregator agent (Fluent Bit, Vector, etc.) needs — that runs alongside Periscope, not inside it. |
 | **OIDC / IdP** | TCP/443 to the issuer host. Already in the minimum policy above. |
 | **AWS STS / EKS DescribeCluster** | TCP/443 to `sts.amazonaws.com` and the regional EKS endpoints. Already needed for cluster auth. |
+| **EKS Upgrade Insights** | TCP/443 to the regional EKS endpoint. Same target as `DescribeCluster` — no new rule. |
+| **Managed node groups + AMI drift** | TCP/443 to the regional EKS, SSM, and EC2 endpoints. SSM is the primary "latest AMI" lookup (`/aws/service/eks/optimized-ami/...` public parameters); EC2 `DescribeImages` is the fallback. The "all internet HTTPS but no in-cluster traffic" rule above already covers them. |
 
 In short: the only outbound traffic Periscope generates is to (a) the
 IdP, (b) AWS STS / EKS, and (c) each managed cluster's apiserver.

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.26.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6
+	github.com/aws/smithy-go v1.25.1
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/go-chi/chi/v5 v5.2.5
@@ -36,14 +38,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueO
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0 h1:HgOfUy9Sm2Q9UQAyj9I/7NZhIaymTEakGA/FnLw65lw=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -47,6 +47,18 @@ const (
 	// emission site exists yet; declared so the taxonomy is visible
 	// and a follow-up PR can wire it without revisiting this file.
 	VerbLogOpen Verb = "log_open"
+	// VerbEKSInsightsRead records a read against the EKS Upgrade
+	// Insights surface (ListInsights / DescribeInsight). It is the
+	// first read verb in the taxonomy — the rest of the audit trail
+	// captures privileged mutations only, but compliance reviewers
+	// asked specifically for a record that an operator checked
+	// upgrade readiness on a cluster, since "did anyone look before
+	// we shipped 1.32?" is an answerable question only if the look
+	// itself is logged. The verb is scoped to this AWS-side surface;
+	// other read endpoints (helm list, resource list, …) remain
+	// unaudited and a separate decision is required to broaden the
+	// pattern.
+	VerbEKSInsightsRead Verb = "eks_insights_read"
 )
 
 // Outcome is the result classification.

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -59,6 +59,16 @@ const (
 	// unaudited and a separate decision is required to broaden the
 	// pattern.
 	VerbEKSInsightsRead Verb = "eks_insights_read"
+	// VerbEKSNodegroupsRead records a read against the managed node
+	// group surface (ListNodegroups / DescribeNodegroup, plus the
+	// derived AMI drift). Same precedent as VerbEKSInsightsRead:
+	// compliance wants a record of who checked node-pool freshness
+	// before an upgrade, so the read itself is auditable. Drift
+	// computation pulls in additional AWS API calls (SSM
+	// GetParameter, ec2 DescribeImages) under the same row — we do
+	// not split those into separate verbs because the caller's
+	// intent is the same operator action.
+	VerbEKSNodegroupsRead Verb = "eks_nodegroups_read"
 )
 
 // Outcome is the result classification.

--- a/web/src/components/eks/NodeGroupsCard.tsx
+++ b/web/src/components/eks/NodeGroupsCard.tsx
@@ -1,0 +1,114 @@
+import { useNavigate } from "react-router-dom";
+import { useNodegroups } from "../../hooks/useNodegroups";
+import { isBackendNotEKS } from "../../lib/api";
+import { cn } from "../../lib/cn";
+
+// NodeGroupsCard — at-a-glance status pill on the cluster overview
+// page, sized to sit next to UpgradeReadinessCard.
+//
+// Empty / error / loading states mirror the insights card so the
+// two surfaces feel consistent. Drift counts ("N behind") are only
+// shown when the backend actually computed drift (PR-3); in PR-2
+// the row simply reads "N node groups · M custom".
+
+export function NodeGroupsCard({ cluster }: { cluster: string }) {
+  const navigate = useNavigate();
+  const { data, isLoading, isError, error } = useNodegroups(cluster);
+
+  if (isError && isBackendNotEKS(error)) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        navigate(`/clusters/${encodeURIComponent(cluster)}/nodegroups`)
+      }
+      className="w-full rounded-md border border-border bg-surface px-4 py-3 text-left transition-colors hover:bg-surface-2"
+    >
+      <div className="flex items-center justify-between">
+        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+          Node groups
+        </div>
+        {data?.counts && (
+          <div className="font-mono text-[11px] text-ink-faint">
+            {data.counts.total} total
+          </div>
+        )}
+      </div>
+      <div className="mt-2 min-h-[28px]">
+        {isLoading ? (
+          <div className="text-[12px] italic text-ink-faint">Loading…</div>
+        ) : isError ? (
+          <div className="text-[12px] text-red">Failed to load node groups.</div>
+        ) : data ? (
+          <CountsRow
+            healthy={data.counts.healthy}
+            behind={data.counts.behind}
+            custom={data.counts.custom}
+            driftAvailable={data.nodegroups.some((n) => n.driftComputed)}
+          />
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+function CountsRow({
+  healthy,
+  behind,
+  custom,
+  driftAvailable,
+}: {
+  healthy: number;
+  behind: number;
+  custom: number;
+  driftAvailable: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-4 text-[13px]">
+      <Bucket glyph="●" tone="green" count={healthy} label="healthy" />
+      {driftAvailable ? (
+        <Bucket
+          glyph={behind > 0 ? "▲" : "●"}
+          tone={behind > 0 ? "yellow" : "green"}
+          count={behind}
+          label={behind === 1 ? "behind" : "behind"}
+        />
+      ) : null}
+      {custom > 0 && (
+        <Bucket glyph="—" tone="faint" count={custom} label="custom" />
+      )}
+    </div>
+  );
+}
+
+function Bucket({
+  glyph,
+  tone,
+  count,
+  label,
+}: {
+  glyph: string;
+  tone: "green" | "yellow" | "red" | "faint";
+  count: number;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          "font-mono text-[14px] leading-none",
+          tone === "green" && "text-green",
+          tone === "yellow" && "text-yellow",
+          tone === "red" && "text-red",
+          tone === "faint" && "text-ink-faint",
+        )}
+        aria-hidden
+      >
+        {glyph}
+      </span>
+      <span className="font-mono tabular-nums">{count}</span>
+      <span className="text-[11px] text-ink-faint">{label}</span>
+    </div>
+  );
+}

--- a/web/src/components/eks/UpgradeReadinessCard.tsx
+++ b/web/src/components/eks/UpgradeReadinessCard.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from "react-router-dom";
+import { useUpgradeInsights } from "../../hooks/useUpgradeInsights";
+import { isBackendNotEKS } from "../../lib/api";
+import { cn } from "../../lib/cn";
+
+// UpgradeReadinessCard — at-a-glance status pill on the cluster
+// overview page. Three-bucket count + target K8s version, click
+// through to the dedicated tab for the full insight list.
+//
+// Empty states:
+//   - non-EKS cluster (422 / E_BACKEND_NOT_EKS) → renders nothing.
+//     The full surface lives on the dedicated page; the overview
+//     card is purely a forwarder, and showing "this cluster is not
+//     EKS" on the overview adds noise for every kubeconfig user.
+//   - other errors → small inline error message; does not block
+//     the rest of the overview.
+
+export function UpgradeReadinessCard({ cluster }: { cluster: string }) {
+  const navigate = useNavigate();
+  const { data, isLoading, isError, error } = useUpgradeInsights(cluster);
+
+  if (isError && isBackendNotEKS(error)) return null;
+
+  const goToTab = () =>
+    navigate(`/clusters/${encodeURIComponent(cluster)}/upgrade-readiness`);
+
+  return (
+    <button
+      type="button"
+      onClick={goToTab}
+      className="w-full rounded-md border border-border bg-surface px-4 py-3 text-left transition-colors hover:bg-surface-2"
+    >
+      <div className="flex items-center justify-between">
+        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+          Upgrade readiness
+        </div>
+        {data?.targetKubernetesVersion && (
+          <div className="font-mono text-[11px] text-ink-faint">
+            target {data.targetKubernetesVersion}
+          </div>
+        )}
+      </div>
+      <div className="mt-2 min-h-[28px]">
+        {isLoading ? (
+          <div className="text-[12px] italic text-ink-faint">Loading…</div>
+        ) : isError ? (
+          <div className="text-[12px] text-red">Failed to load insights.</div>
+        ) : data ? (
+          <CountsRow
+            passing={data.counts.passing}
+            warning={data.counts.warning}
+            error={data.counts.error}
+            unknown={data.counts.unknown}
+          />
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+function CountsRow({
+  passing,
+  warning,
+  error,
+  unknown,
+}: {
+  passing: number;
+  warning: number;
+  error: number;
+  unknown: number;
+}) {
+  return (
+    <div className="flex items-center gap-4 text-[13px]">
+      <Bucket glyph="●" tone="green" count={passing} label="passing" />
+      <Bucket glyph="▲" tone="yellow" count={warning} label="warning" />
+      <Bucket glyph="✕" tone="red" count={error} label="error" />
+      {unknown > 0 && (
+        <Bucket glyph="?" tone="faint" count={unknown} label="unknown" />
+      )}
+    </div>
+  );
+}
+
+function Bucket({
+  glyph,
+  tone,
+  count,
+  label,
+}: {
+  glyph: string;
+  tone: "green" | "yellow" | "red" | "faint";
+  count: number;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          "font-mono text-[14px] leading-none",
+          tone === "green" && "text-green",
+          tone === "yellow" && "text-yellow",
+          tone === "red" && "text-red",
+          tone === "faint" && "text-ink-faint",
+        )}
+        aria-hidden
+      >
+        {glyph}
+      </span>
+      <span className="font-mono tabular-nums">{count}</span>
+      <span className="text-[11px] text-ink-faint">{label}</span>
+    </div>
+  );
+}

--- a/web/src/components/shell/ResourceNav.tsx
+++ b/web/src/components/shell/ResourceNav.tsx
@@ -25,6 +25,7 @@ function groupForPath(pathname: string): string | null {
 	// Custom (non-resource) sections first.
 	if (pathname.includes("/audit")) return "History";
 	if (pathname.includes("/helm")) return "Packages";
+	if (pathname.includes("/upgrade-readiness")) return "EKS";
   for (const group of RESOURCE_GROUPS) {
     for (const r of resourcesByGroup(group)) {
       // match /clusters/:cluster/<resource>
@@ -176,6 +177,40 @@ export function ResourceNav() {
               </div>
             </div>
           </div>
+          {group === "Cluster" && cluster && (
+            <CollapsibleSection
+              id="EKS"
+              label="EKS"
+              isOpen={openGroups.has("EKS")}
+              onToggle={toggleGroup}
+            >
+              <li>
+                <NavLink
+                  to={`/clusters/${encodeURIComponent(cluster)}/upgrade-readiness`}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex items-center gap-2 rounded-sm px-3 py-1.5 text-[12.5px] transition-colors",
+                      isActive
+                        ? "bg-accent-soft text-accent"
+                        : "text-ink hover:bg-surface-2",
+                    )
+                  }
+                >
+                  {({ isActive }) => (
+                    <>
+                      <span
+                        className={cn(
+                          "block size-1 shrink-0 rounded-full",
+                          isActive ? "bg-accent" : "bg-transparent",
+                        )}
+                      />
+                      <span className="flex-1">Upgrade readiness</span>
+                    </>
+                  )}
+                </NavLink>
+              </li>
+            </CollapsibleSection>
+          )}
           {group === "Workloads" && cluster && (
             <CollapsibleSection
               id="Packages"

--- a/web/src/components/shell/ResourceNav.tsx
+++ b/web/src/components/shell/ResourceNav.tsx
@@ -26,6 +26,7 @@ function groupForPath(pathname: string): string | null {
 	if (pathname.includes("/audit")) return "History";
 	if (pathname.includes("/helm")) return "Packages";
 	if (pathname.includes("/upgrade-readiness")) return "EKS";
+	if (pathname.includes("/nodegroups")) return "EKS";
   for (const group of RESOURCE_GROUPS) {
     for (const r of resourcesByGroup(group)) {
       // match /clusters/:cluster/<resource>
@@ -205,6 +206,31 @@ export function ResourceNav() {
                         )}
                       />
                       <span className="flex-1">Upgrade readiness</span>
+                    </>
+                  )}
+                </NavLink>
+              </li>
+              <li>
+                <NavLink
+                  to={`/clusters/${encodeURIComponent(cluster)}/nodegroups`}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex items-center gap-2 rounded-sm px-3 py-1.5 text-[12.5px] transition-colors",
+                      isActive
+                        ? "bg-accent-soft text-accent"
+                        : "text-ink hover:bg-surface-2",
+                    )
+                  }
+                >
+                  {({ isActive }) => (
+                    <>
+                      <span
+                        className={cn(
+                          "block size-1 shrink-0 rounded-full",
+                          isActive ? "bg-accent" : "bg-transparent",
+                        )}
+                      />
+                      <span className="flex-1">Node groups</span>
                     </>
                   )}
                 </NavLink>

--- a/web/src/hooks/useNodegroups.ts
+++ b/web/src/hooks/useNodegroups.ts
@@ -1,0 +1,54 @@
+// useNodegroups — TanStack Query hooks for the EKS managed node
+// group surface (issue #103, PR-2/3).
+//
+// Two hooks:
+//   useNodegroups(cluster)              → list + counts
+//   useNodegroup(cluster, name)         → detail
+//
+// staleTime is 60s (vs 5min for the backend cache) — the SPA pulls
+// fresh on tab refocus / window mount so a cluster operator who
+// just kicked off a node-group rotation sees the new state quickly.
+// The 5min backend cache still bounds AWS-side cost across users.
+
+import { skipToken, useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import { queryKeys } from "../lib/queryKeys";
+import type {
+  NodegroupDetail,
+  NodegroupsListResponse,
+} from "../lib/types";
+
+const STALE_MS = 60_000;
+
+export function useNodegroups(cluster: string) {
+  return useQuery<NodegroupsListResponse>({
+    queryKey: queryKeys.cluster(cluster).nodegroups.list(),
+    queryFn: cluster
+      ? ({ signal }) => api.nodegroups(cluster, signal)
+      : skipToken,
+    staleTime: STALE_MS,
+    retry: (count, err) => {
+      if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 422) {
+        return false;
+      }
+      return count < 2;
+    },
+  });
+}
+
+export function useNodegroup(cluster: string, name: string) {
+  const enabled = Boolean(cluster && name);
+  return useQuery<NodegroupDetail>({
+    queryKey: queryKeys.cluster(cluster).nodegroups.detail(name),
+    queryFn: enabled
+      ? ({ signal }) => api.nodegroup(cluster, name, signal)
+      : skipToken,
+    staleTime: STALE_MS,
+    retry: (count, err) => {
+      if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 422) {
+        return false;
+      }
+      return count < 2;
+    },
+  });
+}

--- a/web/src/hooks/useUpgradeInsights.ts
+++ b/web/src/hooks/useUpgradeInsights.ts
@@ -1,0 +1,58 @@
+// useUpgradeInsights — TanStack Query hooks for the EKS Upgrade
+// Insights surface (issue #103, PR-1).
+//
+// Two hooks, one per backend endpoint:
+//   useUpgradeInsights(cluster)            → list + bucket counts
+//   useUpgradeInsight(cluster, insightId)  → detail with affected resources
+//
+// staleTime is generous (5 min) because the backend already caches
+// for an hour and AWS itself only refreshes daily — extra invalidations
+// from the SPA don't shorten the AWS-side latency, they just burn
+// React renders. Errors keep their default React Query lifecycle so
+// callers can branch on `isBackendNotEKS(error)` to show the empty
+// state.
+
+import { skipToken, useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import { queryKeys } from "../lib/queryKeys";
+import type {
+  UpgradeInsightDetail,
+  UpgradeInsightsListResponse,
+} from "../lib/types";
+
+const STALE_MS = 5 * 60_000;
+
+export function useUpgradeInsights(cluster: string) {
+  return useQuery<UpgradeInsightsListResponse>({
+    queryKey: queryKeys.cluster(cluster).upgradeInsights.list(),
+    queryFn: cluster
+      ? ({ signal }) => api.upgradeInsights(cluster, signal)
+      : skipToken,
+    staleTime: STALE_MS,
+    // 422 is a structured "this isn't an EKS cluster" signal, not a
+    // transient error. No point retrying.
+    retry: (count, err) => {
+      if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 422) {
+        return false;
+      }
+      return count < 2;
+    },
+  });
+}
+
+export function useUpgradeInsight(cluster: string, insightId: string) {
+  const enabled = Boolean(cluster && insightId);
+  return useQuery<UpgradeInsightDetail>({
+    queryKey: queryKeys.cluster(cluster).upgradeInsights.detail(insightId),
+    queryFn: enabled
+      ? ({ signal }) => api.upgradeInsight(cluster, insightId, signal)
+      : skipToken,
+    staleTime: STALE_MS,
+    retry: (count, err) => {
+      if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 422) {
+        return false;
+      }
+      return count < 2;
+    },
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -78,6 +78,8 @@ import type {
   HelmReleaseDetail,
   HelmHistoryResponse,
   HelmDiffResponse,
+  UpgradeInsightsListResponse,
+  UpgradeInsightDetail,
 } from "./types";
 
 class ApiError extends Error {
@@ -817,7 +819,35 @@ export const api = {
       signal,
     );
   },
+
+  // --- EKS Upgrade Insights (read-only, issue #103) ---------------
+  //
+  // Both endpoints 422 with `E_BACKEND_NOT_EKS` for non-EKS clusters.
+  // Callers should branch on ApiError.status === 422 + bodyText that
+  // contains the code (or use isBackendNotEKS) and render the empty
+  // state instead of an error banner.
+
+  upgradeInsights: (cluster: string, signal?: AbortSignal) =>
+    getJSON<UpgradeInsightsListResponse>(
+      `/api/clusters/${enc(cluster)}/eks/upgrade-insights`,
+      signal,
+    ),
+
+  upgradeInsight: (cluster: string, insightId: string, signal?: AbortSignal) =>
+    getJSON<UpgradeInsightDetail>(
+      `/api/clusters/${enc(cluster)}/eks/upgrade-insights/${enc(insightId)}`,
+      signal,
+    ),
 };
+
+/** True when an ApiError is the structured 422/E_BACKEND_NOT_EKS
+ *  response from one of the EKS-only surfaces. Lets callers render
+ *  a clear empty state rather than a generic error. */
+export function isBackendNotEKS(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status !== 422) return false;
+  return (err.bodyText ?? "").includes("E_BACKEND_NOT_EKS");
+}
 
 // --- write helpers (kept out of `api` block so the call sites stay readable) ---
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,8 @@ import type {
   HelmDiffResponse,
   UpgradeInsightsListResponse,
   UpgradeInsightDetail,
+  NodegroupsListResponse,
+  NodegroupDetail,
 } from "./types";
 
 class ApiError extends Error {
@@ -836,6 +838,23 @@ export const api = {
   upgradeInsight: (cluster: string, insightId: string, signal?: AbortSignal) =>
     getJSON<UpgradeInsightDetail>(
       `/api/clusters/${enc(cluster)}/eks/upgrade-insights/${enc(insightId)}`,
+      signal,
+    ),
+
+  // --- EKS managed node groups (read-only, issue #103) ------------
+  //
+  // Same E_BACKEND_NOT_EKS contract as upgrade insights — callers
+  // branch on isBackendNotEKS for the empty state.
+
+  nodegroups: (cluster: string, signal?: AbortSignal) =>
+    getJSON<NodegroupsListResponse>(
+      `/api/clusters/${enc(cluster)}/eks/nodegroups`,
+      signal,
+    ),
+
+  nodegroup: (cluster: string, name: string, signal?: AbortSignal) =>
+    getJSON<NodegroupDetail>(
+      `/api/clusters/${enc(cluster)}/eks/nodegroups/${enc(name)}`,
       signal,
     ),
 };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -872,6 +872,25 @@ export function isBackendNotEKS(err: unknown): boolean {
   return (err.bodyText ?? "").includes("E_BACKEND_NOT_EKS");
 }
 
+/** True when an ApiError is a 403/E_AWS_FORBIDDEN — i.e. the
+ *  pod-identity / IRSA role lacks the IAM permission for the call.
+ *  The SPA renders a permission-specific hint instead of the generic
+ *  red banner so the operator chases the right diagnostic. */
+export function isAWSForbidden(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status !== 403) return false;
+  return (err.bodyText ?? "").includes("E_AWS_FORBIDDEN");
+}
+
+/** True when an ApiError is a 429/E_AWS_THROTTLED — AWS rate-limited
+ *  the call. Transient; the SPA suggests a retry rather than a
+ *  permanent error. */
+export function isAWSThrottled(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status !== 429) return false;
+  return (err.bodyText ?? "").includes("E_AWS_THROTTLED");
+}
+
 // --- write helpers (kept out of `api` block so the call sites stay readable) ---
 
 function resourceURL(args: {

--- a/web/src/lib/nodegroups.test.ts
+++ b/web/src/lib/nodegroups.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { classifyDrift } from "./nodegroups";
+import type { NodegroupSummary } from "./types";
+
+function ng(overrides: Partial<NodegroupSummary>): NodegroupSummary {
+  return {
+    name: "ng",
+    status: "ACTIVE",
+    amiType: "AL2023_x86_64_STANDARD",
+    customAmi: false,
+    desiredSize: 1,
+    minSize: 1,
+    maxSize: 1,
+    healthIssueCount: 0,
+    driftComputed: false,
+    ...overrides,
+  };
+}
+
+describe("classifyDrift", () => {
+  it("custom AMI always returns kind=custom, even when drift is computed elsewhere", () => {
+    const got = classifyDrift(
+      ng({
+        customAmi: true,
+        driftComputed: true,
+        isBehind: true,
+        daysBehind: 30,
+      }),
+    );
+    expect(got).toEqual({ kind: "custom" });
+  });
+
+  it("non-custom AMI without driftComputed returns kind=uncomputed (PR-2 default)", () => {
+    expect(classifyDrift(ng({}))).toEqual({ kind: "uncomputed" });
+  });
+
+  it("driftComputed + not behind = current", () => {
+    expect(
+      classifyDrift(ng({ driftComputed: true, isBehind: false })),
+    ).toEqual({ kind: "current" });
+  });
+
+  it("driftComputed + behind surfaces days + latest release", () => {
+    const got = classifyDrift(
+      ng({
+        driftComputed: true,
+        isBehind: true,
+        daysBehind: 14,
+        latestReleaseVersion: "1.30.0-20240901",
+      }),
+    );
+    expect(got).toEqual({
+      kind: "behind",
+      days: 14,
+      latest: "1.30.0-20240901",
+    });
+  });
+
+  it("driftComputed + behind without daysBehind defaults to 0", () => {
+    expect(
+      classifyDrift(ng({ driftComputed: true, isBehind: true })),
+    ).toEqual({ kind: "behind", days: 0, latest: undefined });
+  });
+});

--- a/web/src/lib/nodegroups.ts
+++ b/web/src/lib/nodegroups.ts
@@ -1,0 +1,33 @@
+// Pure helpers for the EKS managed node group surface (issue #103).
+//
+// The drift formatter is the most reused piece — both the page
+// table and the card pill display the same string. Centralizing
+// here keeps PR-3's drift-text tweaks a single-file change.
+
+import type { NodegroupSummary } from "./types";
+
+export type DriftLabel =
+  | { kind: "custom" } // CUSTOM AMI — drift not tracked by AWS
+  | { kind: "uncomputed" } // PR-2 / drift not yet computed
+  | { kind: "current" } // up to date with the latest published AMI
+  | { kind: "behind"; days: number; latest?: string };
+
+/**
+ * Classifies a nodegroup's drift state for UI rendering. Pure —
+ * does not mutate or fetch anything.
+ *
+ * Order matters: CUSTOM AMI takes precedence over driftComputed
+ * because even when the backend computes drift across the fleet,
+ * we still want to render "not tracked" for custom-AMI rows
+ * rather than a misleading "current" / "behind" badge.
+ */
+export function classifyDrift(ng: NodegroupSummary): DriftLabel {
+  if (ng.customAmi) return { kind: "custom" };
+  if (!ng.driftComputed) return { kind: "uncomputed" };
+  if (!ng.isBehind) return { kind: "current" };
+  return {
+    kind: "behind",
+    days: ng.daysBehind ?? 0,
+    latest: ng.latestReleaseVersion,
+  };
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -90,6 +90,15 @@ export const queryKeys = {
         ["cluster", c, "helm", "diff", ns, name, from, to] as const,
     },
 
+    // EKS Upgrade Insights (issue #103). Cluster-scoped; the
+    // backend cache is also cluster-keyed so the same shape mirrors
+    // through the React Query layer cleanly.
+    upgradeInsights: {
+      list: () => ["cluster", c, "upgradeInsights", "list"] as const,
+      detail: (id: string) =>
+        ["cluster", c, "upgradeInsights", "detail", id] as const,
+    },
+
     // Custom resources are addressed by GVR (no static registry), so
     // they get a parallel subtree keyed on (group, version, plural).
     cr: (group: string, version: string, plural: string) => ({

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -99,6 +99,15 @@ export const queryKeys = {
         ["cluster", c, "upgradeInsights", "detail", id] as const,
     },
 
+    // EKS managed node groups (issue #103). Drift fields share the
+    // same query subtree because the data is computed on the same
+    // backend handler — no point invalidating drift independently.
+    nodegroups: {
+      list: () => ["cluster", c, "nodegroups", "list"] as const,
+      detail: (name: string) =>
+        ["cluster", c, "nodegroups", "detail", name] as const,
+    },
+
     // Custom resources are addressed by GVR (no static registry), so
     // they get a parallel subtree keyed on (group, version, plural).
     cr: (group: string, version: string, plural: string) => ({

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1438,3 +1438,81 @@ export interface HelmDiffResponse {
   to: HelmDiffSide;
   changes: HelmDiffItem[];
 }
+
+// --- EKS Upgrade Insights (issue #103) ---------------------------------
+//
+// Mirrors cmd/periscope/eks_insights_handler.go. Three observations
+// for the SPA developer:
+//
+//   1. `status` is one of PASSING / WARNING / ERROR / UNKNOWN — the
+//      same string AWS returns. Render with the existing traffic-
+//      light glyphs.
+//   2. `editorPath` on a UpgradeInsightResource is empty when the
+//      backend couldn't parse the kubernetesResourceUri. The SPA
+//      should render the raw URI as monospace text in that case
+//      rather than a broken link.
+//   3. The 422 error envelope has `code: "E_BACKEND_NOT_EKS"` for
+//      non-EKS clusters; branch on that to render the empty state.
+
+export interface UpgradeInsightCounts {
+  passing: number;
+  warning: number;
+  error: number;
+  unknown: number;
+}
+
+export type UpgradeInsightStatus = "PASSING" | "WARNING" | "ERROR" | "UNKNOWN";
+
+export interface UpgradeInsightSummary {
+  id: string;
+  name: string;
+  category: string;
+  kubernetesVersion?: string;
+  status: UpgradeInsightStatus;
+  statusReason?: string;
+  lastRefreshTime?: string;
+  lastTransitionTime?: string;
+  description?: string;
+}
+
+export interface UpgradeInsightsListResponse {
+  insights: UpgradeInsightSummary[];
+  counts: UpgradeInsightCounts;
+  targetKubernetesVersion?: string;
+}
+
+export interface UpgradeInsightResource {
+  kubernetesResourceUri: string;
+  arn?: string;
+  group?: string;
+  version?: string;
+  resource?: string;
+  namespace?: string;
+  name?: string;
+  /** Cluster-rooted SPA path that opens the resource's YAML editor.
+   *  Empty when the backend couldn't map the URI to a known route. */
+  editorPath?: string;
+  status?: UpgradeInsightStatus;
+  statusReason?: string;
+}
+
+export interface DeprecationClientStat {
+  userAgent?: string;
+  numberOfRequestsLast30Days?: number;
+  lastRequestTime?: string;
+}
+
+export interface DeprecationDetail {
+  usage?: string;
+  replacedWith?: string;
+  stopServingVersion?: string;
+  startServingReplacementVersion?: string;
+  clientStats?: DeprecationClientStat[];
+}
+
+export interface UpgradeInsightDetail extends UpgradeInsightSummary {
+  recommendation?: string;
+  additionalInfo?: Record<string, string>;
+  resources: UpgradeInsightResource[];
+  deprecationDetails?: DeprecationDetail[];
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1516,3 +1516,75 @@ export interface UpgradeInsightDetail extends UpgradeInsightSummary {
   resources: UpgradeInsightResource[];
   deprecationDetails?: DeprecationDetail[];
 }
+
+// --- EKS managed node groups (issue #103) ------------------------------
+//
+// Mirrors cmd/periscope/eks_nodegroups_handler.go.
+//
+// PR-2: drift fields are present in the type but always come back
+// false / empty until PR-3 wires the SSM-based latest-AMI lookup.
+// The SPA renders drift badges only when `driftComputed` is true.
+//
+// Custom AMIs (`customAmi: true`, AmiType="CUSTOM") never get drift
+// computed by design — when an operator ships a custom image, AWS
+// can't tell us what "latest" means.
+
+export interface NodegroupSummary {
+  name: string;
+  status: string;
+  amiType: string;
+  capacityType?: string;
+  kubernetesVersion?: string;
+  releaseVersion?: string;
+  customAmi: boolean;
+  instanceTypesPreview?: string;
+  desiredSize: number;
+  minSize: number;
+  maxSize: number;
+  healthIssueCount: number;
+  createdAt?: string;
+
+  // Drift fields — populated only when driftComputed is true.
+  driftComputed: boolean;
+  latestReleaseVersion?: string;
+  daysBehind?: number;
+  isBehind?: boolean;
+}
+
+export interface NodegroupsCounts {
+  total: number;
+  behind: number;
+  custom: number;
+  healthy: number;
+}
+
+export interface NodegroupsListResponse {
+  nodegroups: NodegroupSummary[];
+  counts: NodegroupsCounts;
+}
+
+export interface NodegroupHealthIssue {
+  code?: string;
+  message?: string;
+  resourceIds?: string[];
+}
+
+export interface LaunchTemplateRef {
+  id?: string;
+  name?: string;
+  version?: string;
+}
+
+export interface NodegroupDetail extends NodegroupSummary {
+  arn?: string;
+  nodeRole?: string;
+  instanceTypes?: string[];
+  subnets?: string[];
+  diskSize?: number;
+  labels?: Record<string, string>;
+  tags?: Record<string, string>;
+  healthIssues?: NodegroupHealthIssue[];
+  launchTemplate?: LaunchTemplateRef;
+  modifiedAt?: string;
+  autoScalingGroups?: string[];
+}

--- a/web/src/lib/upgradeInsights.test.ts
+++ b/web/src/lib/upgradeInsights.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { ApiError, isBackendNotEKS } from "./api";
+import { sortInsightsByStatus } from "./upgradeInsights";
+import type { UpgradeInsightSummary } from "./types";
+
+function row(
+  id: string,
+  status: UpgradeInsightSummary["status"],
+  name?: string,
+): UpgradeInsightSummary {
+  return {
+    id,
+    name: name ?? id,
+    category: "UPGRADE_READINESS",
+    status,
+  };
+}
+
+describe("sortInsightsByStatus", () => {
+  it("ERROR/WARNING/UNKNOWN/PASSING — worst first", () => {
+    const sorted = sortInsightsByStatus([
+      row("a-passing", "PASSING"),
+      row("b-warning", "WARNING"),
+      row("c-error", "ERROR"),
+      row("d-unknown", "UNKNOWN"),
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual([
+      "c-error",
+      "b-warning",
+      "d-unknown",
+      "a-passing",
+    ]);
+  });
+
+  it("ties broken by display name", () => {
+    const sorted = sortInsightsByStatus([
+      row("zzz", "ERROR", "z-name"),
+      row("aaa", "ERROR", "a-name"),
+      row("mmm", "ERROR", "m-name"),
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual(["aaa", "mmm", "zzz"]);
+  });
+
+  it("falls back to id when name is empty", () => {
+    const sorted = sortInsightsByStatus([
+      { id: "z", name: "", category: "UPGRADE_READINESS", status: "ERROR" },
+      { id: "a", name: "", category: "UPGRADE_READINESS", status: "ERROR" },
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "z"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [row("b", "WARNING"), row("a", "ERROR")];
+    const snapshot = input.map((r) => r.id);
+    sortInsightsByStatus(input);
+    expect(input.map((r) => r.id)).toEqual(snapshot);
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(sortInsightsByStatus([])).toEqual([]);
+  });
+});
+
+describe("isBackendNotEKS", () => {
+  it("matches a 422 ApiError carrying the E_BACKEND_NOT_EKS code", () => {
+    const err = new ApiError(
+      "422 Unprocessable Entity on /api/clusters/x/eks/upgrade-insights",
+      422,
+      JSON.stringify({ code: "E_BACKEND_NOT_EKS", message: "non-EKS" }),
+    );
+    expect(isBackendNotEKS(err)).toBe(true);
+  });
+
+  it("rejects 422 errors that don't carry the code", () => {
+    const err = new ApiError("422 something else", 422, "{}");
+    expect(isBackendNotEKS(err)).toBe(false);
+  });
+
+  it("rejects non-422 errors", () => {
+    const err = new ApiError("500 internal", 500, "E_BACKEND_NOT_EKS");
+    expect(isBackendNotEKS(err)).toBe(false);
+  });
+
+  it("rejects non-ApiError values", () => {
+    expect(isBackendNotEKS(new Error("plain"))).toBe(false);
+    expect(isBackendNotEKS(undefined)).toBe(false);
+    expect(isBackendNotEKS(null)).toBe(false);
+    expect(isBackendNotEKS({ status: 422 })).toBe(false);
+  });
+});

--- a/web/src/lib/upgradeInsights.ts
+++ b/web/src/lib/upgradeInsights.ts
@@ -1,0 +1,39 @@
+// Pure helpers for the EKS Upgrade Insights surface (issue #103).
+//
+// The page-level component delegates to these so tests can pin the
+// behavior without spinning up a full DOM renderer — same pattern
+// as buildCanIDecision in useCanI.
+
+import type {
+  UpgradeInsightStatus,
+  UpgradeInsightSummary,
+} from "./types";
+
+// ERROR first, PASSING last — operators open this page when planning
+// an upgrade and want the blockers up top. UNKNOWN is bucketed
+// between WARNING and PASSING so it doesn't dilute the actionable
+// rows but also isn't filed alongside "all clear".
+const STATUS_ORDER: Record<UpgradeInsightStatus, number> = {
+  ERROR: 0,
+  WARNING: 1,
+  UNKNOWN: 2,
+  PASSING: 3,
+};
+
+/**
+ * Returns a copy of `rows` sorted ERROR → WARNING → UNKNOWN → PASSING,
+ * with ties broken by display name (or id when name is empty). Pure
+ * — does not mutate the input.
+ */
+export function sortInsightsByStatus(
+  rows: UpgradeInsightSummary[],
+): UpgradeInsightSummary[] {
+  const copy = rows.slice();
+  copy.sort((a, b) => {
+    const da = STATUS_ORDER[a.status] ?? 99;
+    const db = STATUS_ORDER[b.status] ?? 99;
+    if (da !== db) return da - db;
+    return (a.name || a.id).localeCompare(b.name || b.id);
+  });
+  return copy;
+}

--- a/web/src/pages/NodeGroupsPage.tsx
+++ b/web/src/pages/NodeGroupsPage.tsx
@@ -1,0 +1,349 @@
+import { useState } from "react";
+import { useNodegroup, useNodegroups } from "../hooks/useNodegroups";
+import { isBackendNotEKS } from "../lib/api";
+import { cn } from "../lib/cn";
+import { classifyDrift } from "../lib/nodegroups";
+import type { NodegroupSummary } from "../lib/types";
+
+// NodeGroupsPage — dedicated view for managed node groups (issue
+// #103, sequenced PR-2 / PR-3).
+//
+// Layout: a table of nodegroups; click a row to expand the full
+// detail panel. CUSTOM AMI rows get a "drift not tracked" badge
+// (the issue's prescribed UX); for AWS-managed nodegroups, the
+// drift column is empty in PR-2 and populated in PR-3.
+
+export function NodeGroupsPage({ cluster }: { cluster: string }) {
+  const { data, isLoading, isError, error } = useNodegroups(cluster);
+
+  if (isError && isBackendNotEKS(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Node groups</h1>
+        <p className="text-[13px] text-ink-faint">
+          Managed node group introspection is an EKS feature; this
+          cluster is not backed by EKS, so no node group data is
+          available.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <span className="block size-4 animate-spin rounded-full border-[1.5px] border-border-strong border-t-accent" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Node groups</h1>
+        <p className="text-[13px] text-red">
+          Failed to load node groups:{" "}
+          {(error as Error)?.message ?? "unknown error"}.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const rows = data.nodegroups;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto px-6 py-5">
+      <header className="mb-4">
+        <h1 className="text-[16px] font-medium">Node groups</h1>
+        <p className="mt-0.5 text-[12px] text-ink-faint">
+          {data.counts.total} total · {data.counts.healthy} healthy
+          {data.counts.custom > 0 && ` · ${data.counts.custom} custom`}
+          {data.nodegroups.some((n) => n.driftComputed) &&
+            ` · ${data.counts.behind} behind`}
+        </p>
+      </header>
+
+      {rows.length === 0 ? (
+        <p className="text-[13px] text-ink-faint">
+          This cluster has no managed node groups. Self-managed nodes (raw
+          EC2 / Karpenter / Fargate profiles) are not surfaced here.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border bg-surface">
+          <table className="w-full text-[12.5px]">
+            <thead className="border-b border-border bg-surface-2/40 text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+              <tr>
+                <th className="px-3 py-2 text-left">Name</th>
+                <th className="px-3 py-2 text-left">AMI</th>
+                <th className="px-3 py-2 text-left">Release</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-left">Scale</th>
+                <th className="px-3 py-2 text-left">Drift</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <NodegroupRow
+                  key={row.name}
+                  cluster={cluster}
+                  ng={row}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NodegroupRow({
+  cluster,
+  ng,
+}: {
+  cluster: string;
+  ng: NodegroupSummary;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <tr
+        className={cn(
+          "cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-surface-2",
+          open && "bg-surface-2",
+        )}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <td className="px-3 py-2 font-mono">{ng.name}</td>
+        <td className="px-3 py-2">
+          {ng.customAmi ? (
+            <span className="rounded-sm border border-border-strong px-1.5 py-px font-mono text-[10px] uppercase tracking-[0.06em] text-ink-muted">
+              custom
+            </span>
+          ) : (
+            <span className="font-mono text-ink-muted">{ng.amiType || "—"}</span>
+          )}
+        </td>
+        <td className="px-3 py-2 font-mono text-ink-muted">
+          {ng.releaseVersion || (ng.customAmi ? "—" : "")}
+        </td>
+        <td className="px-3 py-2">
+          <StatusBadge status={ng.status} />
+        </td>
+        <td className="px-3 py-2 font-mono tabular-nums text-ink-muted">
+          {ng.desiredSize}
+          <span className="text-ink-faint">
+            {" "}({ng.minSize}–{ng.maxSize})
+          </span>
+        </td>
+        <td className="px-3 py-2">
+          <DriftCell ng={ng} />
+        </td>
+      </tr>
+      {open && (
+        <tr>
+          <td colSpan={6} className="border-b border-border bg-surface-2/40 px-6 py-3">
+            <NodegroupDetailBody cluster={cluster} name={ng.name} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone =
+    status === "ACTIVE"
+      ? "text-green"
+      : status === "CREATE_FAILED" || status === "DELETE_FAILED" || status === "DEGRADED" || status === "DEGRADED_DESCRIBE"
+      ? "text-red"
+      : "text-ink-muted";
+  return (
+    <span className={cn("font-mono text-[11px] uppercase tracking-[0.06em]", tone)}>
+      {status || "unknown"}
+    </span>
+  );
+}
+
+function DriftCell({ ng }: { ng: NodegroupSummary }) {
+  const label = classifyDrift(ng);
+  switch (label.kind) {
+    case "custom":
+      return (
+        <span
+          className="text-[11px] italic text-ink-faint"
+          title="AWS does not publish a 'latest' for custom AMIs; freshness is the operator's responsibility."
+        >
+          not tracked
+        </span>
+      );
+    case "uncomputed":
+      return <span className="text-[11px] text-ink-faint">—</span>;
+    case "current":
+      return <span className="text-[11px] font-mono text-green">current</span>;
+    case "behind":
+      return (
+        <span
+          className="text-[11px] font-mono text-yellow"
+          title={`Latest release: ${label.latest ?? "unknown"}`}
+        >
+          {label.days}d behind
+        </span>
+      );
+  }
+}
+
+function NodegroupDetailBody({
+  cluster,
+  name,
+}: {
+  cluster: string;
+  name: string;
+}) {
+  const { data, isLoading, isError, error } = useNodegroup(cluster, name);
+  if (isLoading) {
+    return <p className="text-[12px] italic text-ink-faint">Loading…</p>;
+  }
+  if (isError) {
+    return (
+      <p className="text-[12px] text-red">
+        Failed to load detail: {(error as Error)?.message ?? "unknown error"}.
+      </p>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="space-y-3">
+      <FieldGrid>
+        <Field label="Kubernetes version">
+          {data.kubernetesVersion ?? "—"}
+        </Field>
+        <Field label="Capacity type">{data.capacityType ?? "—"}</Field>
+        <Field label="Disk size">
+          {data.diskSize ? `${data.diskSize} GiB` : "—"}
+        </Field>
+        <Field label="Created">
+          {data.createdAt ? new Date(data.createdAt).toUTCString() : "—"}
+        </Field>
+      </FieldGrid>
+
+      {data.instanceTypes && data.instanceTypes.length > 0 && (
+        <Section label="Instance types">
+          <div className="flex flex-wrap gap-1 font-mono text-[11px]">
+            {data.instanceTypes.map((t) => (
+              <span
+                key={t}
+                className="rounded-sm border border-border bg-surface px-1.5 py-px text-ink-muted"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {data.launchTemplate && (
+        <Section label="Launch template">
+          <div className="font-mono text-[11.5px]">
+            {data.launchTemplate.id ?? data.launchTemplate.name ?? "—"}
+            {data.launchTemplate.version &&
+              ` · version ${data.launchTemplate.version}`}
+          </div>
+          {data.customAmi && (
+            <p className="mt-1 text-[11.5px] italic text-ink-faint">
+              Custom AMI: launch template controls the image. AWS-side
+              drift detection does not apply.
+            </p>
+          )}
+        </Section>
+      )}
+
+      {data.healthIssues && data.healthIssues.length > 0 && (
+        <Section label="Health issues">
+          <ul className="space-y-1.5 text-[12px]">
+            {data.healthIssues.map((issue, i) => (
+              <li key={i} className="text-red">
+                <span className="font-mono">{issue.code}</span>
+                {issue.message && <> — {issue.message}</>}
+                {issue.resourceIds && issue.resourceIds.length > 0 && (
+                  <div className="ml-3 mt-1 font-mono text-[11px] text-ink-faint">
+                    {issue.resourceIds.join(", ")}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {data.subnets && data.subnets.length > 0 && (
+        <Section label="Subnets">
+          <div className="font-mono text-[11.5px] text-ink-muted">
+            {data.subnets.join(", ")}
+          </div>
+        </Section>
+      )}
+
+      {data.autoScalingGroups && data.autoScalingGroups.length > 0 && (
+        <Section label="Auto Scaling groups">
+          <div className="font-mono text-[11.5px] text-ink-muted">
+            {data.autoScalingGroups.join(", ")}
+          </div>
+        </Section>
+      )}
+
+      {data.nodeRole && (
+        <Section label="Node IAM role">
+          <div className="break-all font-mono text-[11px] text-ink-muted">
+            {data.nodeRole}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FieldGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-2 gap-x-6 gap-y-2 lg:grid-cols-4">
+      {children}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        {label}
+      </div>
+      <div className="mt-0.5 text-[12.5px]">{children}</div>
+    </div>
+  );
+}

--- a/web/src/pages/NodeGroupsPage.tsx
+++ b/web/src/pages/NodeGroupsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNodegroup, useNodegroups } from "../hooks/useNodegroups";
-import { isBackendNotEKS } from "../lib/api";
+import { isAWSForbidden, isAWSThrottled, isBackendNotEKS } from "../lib/api";
 import { cn } from "../lib/cn";
 import { classifyDrift } from "../lib/nodegroups";
 import type { NodegroupSummary } from "../lib/types";
@@ -24,6 +24,37 @@ export function NodeGroupsPage({ cluster }: { cluster: string }) {
           Managed node group introspection is an EKS feature; this
           cluster is not backed by EKS, so no node group data is
           available.
+        </p>
+      </div>
+    );
+  }
+
+  if (isError && isAWSForbidden(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Node groups</h1>
+        <p className="text-[13px] text-ink-faint">
+          Periscope's AWS role does not have permission to read managed
+          node groups for this cluster. Required IAM actions:{" "}
+          <code className="font-mono text-[12px]">eks:ListNodegroups</code>,{" "}
+          <code className="font-mono text-[12px]">eks:DescribeNodegroup</code>,
+          plus{" "}
+          <code className="font-mono text-[12px]">ssm:GetParameter</code> and{" "}
+          <code className="font-mono text-[12px]">ec2:DescribeImages</code>{" "}
+          for the AMI drift lookups. See{" "}
+          <code className="font-mono text-[12px]">docs/setup/deploy.md</code>.
+        </p>
+      </div>
+    );
+  }
+
+  if (isError && isAWSThrottled(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Node groups</h1>
+        <p className="text-[13px] text-ink-faint">
+          AWS rate-limited this request. Refresh the page in a moment;
+          the cache will absorb subsequent calls.
         </p>
       </div>
     );

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -4,6 +4,7 @@ import { CircularGauge } from "../components/ui/CircularGauge";
 import { ThemeToggle } from "../components/shell/ThemeToggle";
 import { ApplyYamlEntry } from "../components/apply/ApplyYamlEntry";
 import { UpgradeReadinessCard } from "../components/eks/UpgradeReadinessCard";
+import { NodeGroupsCard } from "../components/eks/NodeGroupsCard";
 import { ageFrom } from "../lib/format";
 import { cn } from "../lib/cn";
 import type {
@@ -70,11 +71,13 @@ export function OverviewPage({ cluster }: { cluster: string }) {
       <ClusterIdentityBanner cluster={cluster} data={data} />
 
       <div className="space-y-6 px-6 py-5">
-        {/* EKS Upgrade readiness card (issue #103). The component
-            renders nothing for non-EKS clusters, so the row simply
-            collapses for kubeconfig / agent / in-cluster backends. */}
-        <section>
+        {/* EKS Upgrade readiness + Node groups cards (issue #103).
+            Both components render nothing for non-EKS clusters, so
+            the section simply collapses for kubeconfig / agent /
+            in-cluster backends. */}
+        <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <UpgradeReadinessCard cluster={cluster} />
+          <NodeGroupsCard cluster={cluster} />
         </section>
 
         {/* Capacity row: CPU gauge / Memory gauge / Pod phase chart -- */}

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -3,6 +3,7 @@ import { useClusterSummary, useClusterEvents } from "../hooks/useResource";
 import { CircularGauge } from "../components/ui/CircularGauge";
 import { ThemeToggle } from "../components/shell/ThemeToggle";
 import { ApplyYamlEntry } from "../components/apply/ApplyYamlEntry";
+import { UpgradeReadinessCard } from "../components/eks/UpgradeReadinessCard";
 import { ageFrom } from "../lib/format";
 import { cn } from "../lib/cn";
 import type {
@@ -69,6 +70,13 @@ export function OverviewPage({ cluster }: { cluster: string }) {
       <ClusterIdentityBanner cluster={cluster} data={data} />
 
       <div className="space-y-6 px-6 py-5">
+        {/* EKS Upgrade readiness card (issue #103). The component
+            renders nothing for non-EKS clusters, so the row simply
+            collapses for kubeconfig / agent / in-cluster backends. */}
+        <section>
+          <UpgradeReadinessCard cluster={cluster} />
+        </section>
+
         {/* Capacity row: CPU gauge / Memory gauge / Pod phase chart -- */}
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
           <Card title="CPU">

--- a/web/src/pages/UpgradeReadinessPage.tsx
+++ b/web/src/pages/UpgradeReadinessPage.tsx
@@ -1,0 +1,348 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useUpgradeInsight, useUpgradeInsights } from "../hooks/useUpgradeInsights";
+import { isBackendNotEKS } from "../lib/api";
+import { cn } from "../lib/cn";
+import type {
+  UpgradeInsightStatus,
+  UpgradeInsightSummary,
+} from "../lib/types";
+import { sortInsightsByStatus } from "../lib/upgradeInsights";
+
+// UpgradeReadinessPage — the dedicated tab/page for EKS Upgrade
+// Insights.
+//
+// Layout:
+//   - Header: target K8s version + three-bucket count.
+//   - Body: insight rows sorted ERROR → WARNING → UNKNOWN → PASSING
+//           (worst-first, since the operator opens this page when
+//           planning an upgrade and wants the blockers up top).
+//   - Each row is expandable. Expanded body shows description,
+//     recommendation, and the affected-resources list with deep
+//     links to Periscope's editor.
+//
+// Empty states:
+//   - Non-EKS cluster (HTTP 422 with E_BACKEND_NOT_EKS) → renders
+//     the issue's prescribed one-line note rather than a generic
+//     error banner.
+//   - No insights returned → "no upgrade readiness checks have run
+//     yet" with a hint that AWS refreshes daily.
+
+export function UpgradeReadinessPage({ cluster }: { cluster: string }) {
+  const { data, isLoading, isError, error } = useUpgradeInsights(cluster);
+  const sorted = useMemo(
+    () => sortInsightsByStatus(data?.insights ?? []),
+    [data?.insights],
+  );
+
+  if (isError && isBackendNotEKS(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Upgrade readiness</h1>
+        <p className="text-[13px] text-ink-faint">
+          Upgrade insights are an EKS feature; this cluster is not
+          backed by EKS, so no upgrade-readiness data is available.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <span className="block size-4 animate-spin rounded-full border-[1.5px] border-border-strong border-t-accent" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Upgrade readiness</h1>
+        <p className="text-[13px] text-red">
+          Failed to load upgrade insights:{" "}
+          {(error as Error)?.message ?? "unknown error"}.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto px-6 py-5">
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-[16px] font-medium">Upgrade readiness</h1>
+          {data.targetKubernetesVersion && (
+            <p className="mt-0.5 text-[12px] text-ink-faint">
+              Target Kubernetes version: {data.targetKubernetesVersion}
+            </p>
+          )}
+        </div>
+        <CountsHeader
+          passing={data.counts.passing}
+          warning={data.counts.warning}
+          error={data.counts.error}
+          unknown={data.counts.unknown}
+        />
+      </header>
+
+      {sorted.length === 0 ? (
+        <p className="text-[13px] text-ink-faint">
+          No upgrade-readiness checks have produced findings on this cluster.
+          AWS refreshes upgrade insights once per day; the absence of rows
+          here means EKS has not flagged any issues.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border border-border bg-surface">
+          {sorted.map((row) => (
+            <li key={row.id}>
+              <InsightRow cluster={cluster} insight={row} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Header ───────────────────────────────────────────────────────────
+
+function CountsHeader({
+  passing,
+  warning,
+  error,
+  unknown,
+}: {
+  passing: number;
+  warning: number;
+  error: number;
+  unknown: number;
+}) {
+  return (
+    <div className="flex items-center gap-3 text-[13px]">
+      <CountChip glyph="●" tone="green" count={passing} label="passing" />
+      <CountChip glyph="▲" tone="yellow" count={warning} label="warning" />
+      <CountChip glyph="✕" tone="red" count={error} label="error" />
+      {unknown > 0 && (
+        <CountChip glyph="?" tone="faint" count={unknown} label="unknown" />
+      )}
+    </div>
+  );
+}
+
+function CountChip({
+  glyph,
+  tone,
+  count,
+  label,
+}: {
+  glyph: string;
+  tone: "green" | "yellow" | "red" | "faint";
+  count: number;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 rounded-sm border border-border px-2 py-0.5">
+      <span
+        className={cn(
+          "font-mono leading-none",
+          tone === "green" && "text-green",
+          tone === "yellow" && "text-yellow",
+          tone === "red" && "text-red",
+          tone === "faint" && "text-ink-faint",
+        )}
+        aria-hidden
+      >
+        {glyph}
+      </span>
+      <span className="font-mono tabular-nums">{count}</span>
+      <span className="text-[11px] text-ink-faint">{label}</span>
+    </div>
+  );
+}
+
+// ── Rows ─────────────────────────────────────────────────────────────
+
+function InsightRow({
+  cluster,
+  insight,
+}: {
+  cluster: string;
+  insight: UpgradeInsightSummary;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-surface-2"
+      >
+        <StatusGlyph status={insight.status} />
+        <div className="flex-1 truncate">
+          <div className="text-[13px]">{insight.name || insight.id}</div>
+          {insight.kubernetesVersion && (
+            <div className="text-[11px] text-ink-faint">
+              for Kubernetes {insight.kubernetesVersion}
+            </div>
+          )}
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+          {open ? "hide" : "details"}
+        </span>
+      </button>
+      {open && (
+        <div className="border-t border-border bg-surface-2/40 px-6 py-3">
+          <InsightDetailBody cluster={cluster} insightId={insight.id} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusGlyph({ status }: { status: UpgradeInsightStatus }) {
+  const map = {
+    PASSING: { g: "●", c: "text-green" },
+    WARNING: { g: "▲", c: "text-yellow" },
+    ERROR: { g: "✕", c: "text-red" },
+    UNKNOWN: { g: "?", c: "text-ink-faint" },
+  } as const;
+  const v = map[status] ?? map.UNKNOWN;
+  return (
+    <span
+      className={cn("font-mono text-[14px] leading-none shrink-0", v.c)}
+      aria-label={status.toLowerCase()}
+    >
+      {v.g}
+    </span>
+  );
+}
+
+function InsightDetailBody({
+  cluster,
+  insightId,
+}: {
+  cluster: string;
+  insightId: string;
+}) {
+  const { data, isLoading, isError, error } = useUpgradeInsight(cluster, insightId);
+  if (isLoading) {
+    return <p className="text-[12px] italic text-ink-faint">Loading details…</p>;
+  }
+  if (isError) {
+    return (
+      <p className="text-[12px] text-red">
+        Failed to load insight: {(error as Error)?.message ?? "unknown error"}.
+      </p>
+    );
+  }
+  if (!data) return null;
+  return (
+    <div className="space-y-3">
+      {data.description && (
+        <Section label="Description">
+          <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+            {data.description}
+          </p>
+        </Section>
+      )}
+      {data.recommendation && (
+        <Section label="Recommendation">
+          <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+            {data.recommendation}
+          </p>
+        </Section>
+      )}
+      {data.deprecationDetails && data.deprecationDetails.length > 0 && (
+        <Section label="Deprecated APIs">
+          <ul className="space-y-1.5 text-[12px]">
+            {data.deprecationDetails.map((d, i) => (
+              <li key={i} className="font-mono text-ink-muted">
+                <span>{d.usage ?? "(unknown usage)"}</span>
+                {d.replacedWith && (
+                  <>
+                    {" → "}
+                    <span className="text-green">{d.replacedWith}</span>
+                  </>
+                )}
+                {d.stopServingVersion && (
+                  <span className="ml-2 text-red">
+                    stops in {d.stopServingVersion}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+      <Section label={`Affected resources (${data.resources.length})`}>
+        {data.resources.length === 0 ? (
+          <p className="text-[12px] italic text-ink-faint">
+            No specific resources flagged. The insight applies cluster-wide
+            (e.g. add-on compatibility, IAM, networking).
+          </p>
+        ) : (
+          <ul className="space-y-1 font-mono text-[11.5px]">
+            {data.resources.map((r, i) => (
+              <li key={i} className="break-all">
+                {r.editorPath ? (
+                  <Link
+                    to={r.editorPath}
+                    className="text-accent underline-offset-2 hover:underline"
+                  >
+                    {r.kubernetesResourceUri}
+                  </Link>
+                ) : (
+                  <span
+                    className="text-ink-faint"
+                    title="could not map this URI to an editor route"
+                  >
+                    {r.kubernetesResourceUri}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+      {data.additionalInfo && Object.keys(data.additionalInfo).length > 0 && (
+        <Section label="Further reading">
+          <ul className="space-y-1 text-[11.5px]">
+            {Object.entries(data.additionalInfo).map(([k, v]) => (
+              <li key={k}>
+                <a
+                  href={v}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent underline-offset-2 hover:underline"
+                >
+                  {k}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+

--- a/web/src/pages/UpgradeReadinessPage.tsx
+++ b/web/src/pages/UpgradeReadinessPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUpgradeInsight, useUpgradeInsights } from "../hooks/useUpgradeInsights";
-import { isBackendNotEKS } from "../lib/api";
+import { isAWSForbidden, isAWSThrottled, isBackendNotEKS } from "../lib/api";
 import { cn } from "../lib/cn";
 import type {
   UpgradeInsightStatus,
@@ -42,6 +42,36 @@ export function UpgradeReadinessPage({ cluster }: { cluster: string }) {
         <p className="text-[13px] text-ink-faint">
           Upgrade insights are an EKS feature; this cluster is not
           backed by EKS, so no upgrade-readiness data is available.
+        </p>
+      </div>
+    );
+  }
+
+  if (isError && isAWSForbidden(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Upgrade readiness</h1>
+        <p className="text-[13px] text-ink-faint">
+          Periscope's AWS role does not have permission to read upgrade
+          insights for this cluster. Required IAM actions:{" "}
+          <code className="font-mono text-[12px]">eks:ListInsights</code>{" "}
+          and{" "}
+          <code className="font-mono text-[12px]">eks:DescribeInsight</code>.
+          See{" "}
+          <code className="font-mono text-[12px]">docs/setup/deploy.md</code>{" "}
+          for the full permission matrix.
+        </p>
+      </div>
+    );
+  }
+
+  if (isError && isAWSThrottled(error)) {
+    return (
+      <div className="px-6 py-8">
+        <h1 className="mb-2 text-[16px] font-medium">Upgrade readiness</h1>
+        <p className="text-[13px] text-ink-faint">
+          AWS rate-limited this request. Refresh the page in a moment;
+          the cache will absorb subsequent calls.
         </p>
       </div>
     );

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -72,6 +72,7 @@ const ExecPage = lazyNamed(() => import("./pages/ExecPage"), "ExecPage");
 const HelmReleasesPage = lazyNamed(() => import("./pages/HelmReleasesPage"), "HelmReleasesPage");
 const HelmReleasePage = lazyNamed(() => import("./pages/HelmReleasePage"), "HelmReleasePage");
 const HelmDiffPage = lazyNamed(() => import("./pages/HelmDiffPage"), "HelmDiffPage");
+const UpgradeReadinessPage = lazyNamed(() => import("./pages/UpgradeReadinessPage"), "UpgradeReadinessPage");
 
 export const router = createBrowserRouter(
   createRoutesFromElements(
@@ -124,6 +125,7 @@ export const router = createBrowserRouter(
         <Route path="helm" element={<WithCluster Page={HelmReleasesPage} />} />
         <Route path="helm/:namespace/:name" element={<HelmReleasePage />} />
         <Route path="helm/:namespace/:name/diff" element={<HelmDiffPage />} />
+        <Route path="upgrade-readiness" element={<WithCluster Page={UpgradeReadinessPage} />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Route>,

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -73,6 +73,7 @@ const HelmReleasesPage = lazyNamed(() => import("./pages/HelmReleasesPage"), "He
 const HelmReleasePage = lazyNamed(() => import("./pages/HelmReleasePage"), "HelmReleasePage");
 const HelmDiffPage = lazyNamed(() => import("./pages/HelmDiffPage"), "HelmDiffPage");
 const UpgradeReadinessPage = lazyNamed(() => import("./pages/UpgradeReadinessPage"), "UpgradeReadinessPage");
+const NodeGroupsPage = lazyNamed(() => import("./pages/NodeGroupsPage"), "NodeGroupsPage");
 
 export const router = createBrowserRouter(
   createRoutesFromElements(
@@ -126,6 +127,7 @@ export const router = createBrowserRouter(
         <Route path="helm/:namespace/:name" element={<HelmReleasePage />} />
         <Route path="helm/:namespace/:name/diff" element={<HelmDiffPage />} />
         <Route path="upgrade-readiness" element={<WithCluster Page={UpgradeReadinessPage} />} />
+        <Route path="nodegroups" element={<WithCluster Page={NodeGroupsPage} />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Route>,


### PR DESCRIPTION
## Summary

Implements read-only EKS Upgrade Insights endpoints that wrap AWS EKS SDK calls to surface upgrade readiness checks. The unique value-add is decorating affected resources with `editorPath` deep links into Periscope's per-kind YAML editors, enabling "from scan to fix in one click" workflows that AWS Console and kubectl cannot provide.

Two endpoints:
- `GET /api/clusters/{cluster}/eks/upgrade-insights` — list insights with bucket counts and target K8s version
- `GET /api/clusters/{cluster}/eks/upgrade-insights/{insightId}` — detail view with affected resources and deprecation info

Both are EKS-only by design; non-EKS clusters receive 422 + stable `E_BACKEND_NOT_EKS` code so the SPA can render a clear empty state rather than a generic error.

## Related issue / RFC

Closes #103

## Type of change

- [x] New feature (non-breaking)

## Surfaces touched

- [x] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
- [x] Audit / RBAC
- [x] SPA / frontend
- [x] Documentation

## How was this tested?

**Backend:**
- `eks_insights_handler_test.go`: 516 lines of comprehensive test coverage including happy path, non-EKS rejection, cluster not found, AWS errors with failure audit, cache hits, pagination warnings, and detail endpoint scenarios.
- `eks_insights_uri_test.go`: 204 lines covering URI parsing for all shapes (namespaced/cluster-scoped × core/named-group × built-in/CRD plurals) plus malformed inputs.
- `eks_insights_cache_test.go`: Tests for list/detail put/get, expiry, and eviction.

**Frontend:**
- `upgradeInsights.test.ts`: Tests for sort order (ERROR/WARNING/UNKNOWN/PASSING) and tie-breaking by name.
- Manual verification of the UpgradeReadinessPage and UpgradeReadinessCard components with mock data.

All existing tests pass; CI will validate the full suite.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests added or updated where it makes sense.
- [x] Docs updated (`docs/setup/deploy.md` with AWS API permissions table).
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.

https://claude.ai/code/session_01XXTzVEgKYGvgwz83ZznPtC