### PR TITLE
Add configuration for watch streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,16 @@ tag.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- SSE watch streams for ConfigMaps, ResourceQuotas, LimitRanges, and
+  ServiceAccounts (#17).
+
+### Changed
+
+- Helm `values.schema.json` now strictly validates
+  `watchStreams.kinds`; deployments with typos that previously
+  silently dropped now fail at helm install time.
 
 ## [1.0.0]
 

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -2569,7 +2569,10 @@ type watchFn func(ctx context.Context, p credentials.Provider, args k8s.WatchArg
 //   - the route loop below (router.Get registration)
 //
 // To add a new kind: define WatchFoo in internal/k8s and append a
-// kindReg entry to watchKinds. No other call site needs an edit.
+// kindReg entry to watchKinds. Keep the operator-facing allowlist and
+// frontend metadata in sync: deploy/helm/periscope/values.schema.json,
+// docs/setup/watch-streams.md, and web/src/lib/api.ts all enumerate the
+// supported tokens/groups.
 //
 // Group is an optional alias used by the env-var grammar so operators
 // can write "PERISCOPE_WATCH_STREAMS=workloads" instead of enumerating

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -963,8 +963,8 @@ func main() {
 
 	// --- Watch (SSE streaming) endpoints ---
 	//
-	// Real-time push for resource lists. On by default for the four
-	// supported kinds; the PERISCOPE_WATCH_STREAMS env var lets operators
+	// Real-time push for resource lists. On by default for every
+	// registered kind; the PERISCOPE_WATCH_STREAMS env var lets operators
 	// opt out ("off" / "none") or restrict to a subset. When a kind is
 	// disabled the route literally does not exist and the frontend
 	// downgrades to polling via 404. See issue #4.
@@ -2574,7 +2574,8 @@ type watchFn func(ctx context.Context, p credentials.Provider, args k8s.WatchArg
 // Group is an optional alias used by the env-var grammar so operators
 // can write "PERISCOPE_WATCH_STREAMS=workloads" instead of enumerating
 // every workload kind. Groups follow K8s API conventions loosely
-// ("core" = core/v1, "workloads" = apps/v1 + batch/v1, "networking" =
+// ("core" = pods/events, "config" = core/v1 config/policy/account
+// resources, "workloads" = apps/v1 + batch/v1, "networking" =
 // networking.k8s.io/v1, "storage" = storage.k8s.io/v1 + core PVCs).
 // An empty Group disables alias selection for that kind — it can only
 // be enabled by its exact Name.
@@ -2589,6 +2590,10 @@ type kindReg struct {
 var watchKinds = []kindReg{
 	{Name: "pods", Group: "core", Watch: k8s.WatchPods},
 	{Name: "events", Group: "core", Watch: k8s.WatchEvents},
+	{Name: "configmaps", Group: "config", Watch: k8s.WatchConfigMaps},
+	{Name: "resourcequotas", Group: "config", Watch: k8s.WatchResourceQuotas},
+	{Name: "limitranges", Group: "config", Watch: k8s.WatchLimitRanges},
+	{Name: "serviceaccounts", Group: "config", Watch: k8s.WatchServiceAccounts},
 	{Name: "deployments", Group: "workloads", Watch: k8s.WatchDeployments},
 	{Name: "statefulsets", Group: "workloads", Watch: k8s.WatchStatefulSets},
 	{Name: "daemonsets", Group: "workloads", Watch: k8s.WatchDaemonSets},

--- a/cmd/periscope/main_test.go
+++ b/cmd/periscope/main_test.go
@@ -5,6 +5,9 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -54,6 +57,10 @@ func TestParseWatchStreamsEnv(t *testing.T) {
 		// typo in the registry's Name field shows up as a test failure.
 		{name: "pods", raw: "pods", want: watchStreamsConfig{"pods": true}},
 		{name: "events", raw: "events", want: watchStreamsConfig{"events": true}},
+		{name: "configmaps", raw: "configmaps", want: watchStreamsConfig{"configmaps": true}},
+		{name: "resourcequotas", raw: "resourcequotas", want: watchStreamsConfig{"resourcequotas": true}},
+		{name: "limitranges", raw: "limitranges", want: watchStreamsConfig{"limitranges": true}},
+		{name: "serviceaccounts", raw: "serviceaccounts", want: watchStreamsConfig{"serviceaccounts": true}},
 		{name: "deployments", raw: "deployments", want: watchStreamsConfig{"deployments": true}},
 		{name: "statefulsets", raw: "statefulsets", want: watchStreamsConfig{"statefulsets": true}},
 		{name: "daemonsets", raw: "daemonsets", want: watchStreamsConfig{"daemonsets": true}},
@@ -68,7 +75,9 @@ func TestParseWatchStreamsEnv(t *testing.T) {
 		// expands them to every kind in that group. Both group and kind
 		// tokens may mix freely in a single comma-separated value.
 		{name: "core group", raw: "core", want: groupOn("core")},
+		{name: "config group", raw: "config", want: groupOn("config")},
 		{name: "workloads group", raw: "workloads", want: groupOn("workloads")},
+		{name: "core,config", raw: "core,config", want: merge(groupOn("core"), groupOn("config"))},
 		{name: "core,workloads", raw: "core,workloads", want: merge(groupOn("core"), groupOn("workloads"))},
 		{name: "kind plus group", raw: "pods,workloads", want: merge(watchStreamsConfig{"pods": true}, groupOn("workloads"))},
 		{name: "duplicate group is idempotent", raw: "core,core", want: groupOn("core")},
@@ -133,6 +142,61 @@ func TestFeaturesHandler(t *testing.T) {
 				t.Fatalf("watchStreams = %v, want %v", body.WatchStreams, tt.want)
 			}
 		})
+	}
+}
+
+func TestWatchStreamsHelmSchemaPattern(t *testing.T) {
+	var schema struct {
+		Properties struct {
+			WatchStreams struct {
+				Properties struct {
+					Kinds struct {
+						Pattern string `json:"pattern"`
+					} `json:"kinds"`
+				} `json:"properties"`
+			} `json:"watchStreams"`
+		} `json:"properties"`
+	}
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "deploy", "helm", "periscope", "values.schema.json"))
+	if err != nil {
+		t.Fatalf("read values schema: %v", err)
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("decode values schema: %v", err)
+	}
+
+	re, err := regexp.Compile(schema.Properties.WatchStreams.Properties.Kinds.Pattern)
+	if err != nil {
+		t.Fatalf("compile watchStreams.kinds pattern: %v", err)
+	}
+
+	accepted := []string{
+		"",
+		"all",
+		"off",
+		"none",
+		"pods,config",
+		" pods , config ",
+		"configmaps,resourcequotas,limitranges,serviceaccounts",
+		"core,workloads,networking,storage,cluster,config",
+	}
+	for _, value := range accepted {
+		if !re.MatchString(value) {
+			t.Errorf("schema rejected %q, want accepted", value)
+		}
+	}
+
+	rejected := []string{
+		"banana",
+		"pods,banana",
+		"configmap",
+		"pods,,events",
+	}
+	for _, value := range rejected {
+		if re.MatchString(value) {
+			t.Errorf("schema accepted %q, want rejected", value)
+		}
 	}
 }
 

--- a/deploy/helm/periscope/Chart.yaml
+++ b/deploy/helm/periscope/Chart.yaml
@@ -46,7 +46,7 @@ annotations:
     - kind: added
       description: initial v1.0 stable release
     - kind: added
-      description: real-time SSE updates for 21+ resource kinds
+      description: real-time SSE updates for registered resource kinds
     - kind: added
       description: searchable SQLite-backed audit log
     - kind: added

--- a/deploy/helm/periscope/values.schema.json
+++ b/deploy/helm/periscope/values.schema.json
@@ -138,8 +138,8 @@
       "properties": {
         "kinds": {
           "type": "string",
-          "description": "Empty/unset or 'all' = all on (server default). 'off'/'none' = disable. Otherwise a comma-separated mix of per-kind tokens (pods, events, deployments, services, …) and group aliases (core, workloads, networking, storage, cluster). The server is the source of truth for the registry — see cmd/periscope/main.go::watchKinds; this schema only enforces the surface character set so unknown tokens reach the server's silent-drop validator.",
-          "pattern": "^\\s*$|^\\s*[a-z][a-z0-9_,\\s-]*$"
+          "description": "Empty/unset or 'all' = all on (server default). 'off'/'none' = disable. Otherwise a comma-separated mix of per-kind tokens (pods, events, configmaps, deployments, services, …) and group aliases (core, config, workloads, networking, storage, cluster). The server is the source of truth for the registry — see cmd/periscope/main.go::watchKinds; this schema mirrors the current tokens so unknown values fail at deploy time.",
+          "pattern": "^\\s*$|^\\s*(?:all|off|none)\\s*$|^\\s*(?:(?:pods|events|configmaps|resourcequotas|limitranges|serviceaccounts|deployments|statefulsets|daemonsets|replicasets|jobs|cronjobs|horizontalpodautoscalers|poddisruptionbudgets|services|ingresses|networkpolicies|endpointslices|ingressclasses|pvs|pvcs|storageclasses|nodes|namespaces|priorityclasses|runtimeclasses|core|config|workloads|networking|storage|cluster)(?:\\s*,\\s*(?:pods|events|configmaps|resourcequotas|limitranges|serviceaccounts|deployments|statefulsets|daemonsets|replicasets|jobs|cronjobs|horizontalpodautoscalers|poddisruptionbudgets|services|ingresses|networkpolicies|endpointslices|ingressclasses|pvs|pvcs|storageclasses|nodes|namespaces|priorityclasses|runtimeclasses|core|config|workloads|networking|storage|cluster))*\\s*)$"
         },
         "perUserLimit": {
           "type": "integer",

--- a/deploy/helm/periscope/values.yaml
+++ b/deploy/helm/periscope/values.yaml
@@ -419,13 +419,13 @@ exec:
 # -----------------------------------------------------------------------------
 # Watch streams (SSE push for live resource lists)
 #
-# Periscope serves the four highest-churn resource lists (pods, events,
-# replicasets, jobs) over Server-Sent Events so the UI updates in real
-# time instead of polling on a 15s tick. The frontend has a tested
+# Periscope serves registered resource lists over Server-Sent Events
+# so the UI updates in real time instead of polling on a timer. The
+# frontend has a tested
 # polling-fallback path for any kind whose stream cannot be opened, so
 # the bad case is graceful degradation, not a hard failure.
 #
-# Default: enabled for all four kinds.
+# Default: enabled for all registered kinds.
 #
 # Set .Values.watchStreams.kinds to one of:
 #
@@ -433,11 +433,12 @@ exec:
 #   "all"          same as unset; explicit form
 #   "off"          disable all SSE routes; UI uses polling everywhere
 #   "none"         same as "off"
-#   "pods,events"  comma-separated subset of per-kind tokens
+#   "pods,configmaps"  comma-separated subset of per-kind tokens
 #   "workloads"    group alias — every kind in the workloads group
-#   "core,workloads"  multiple groups, one token each
+#   "core,config"  multiple groups, one token each
 #
-# Per-kind tokens (current registry): pods, events, deployments,
+# Per-kind tokens (current registry): pods, events, configmaps,
+# resourcequotas, limitranges, serviceaccounts, deployments,
 # statefulsets, daemonsets, replicasets, jobs, cronjobs,
 # horizontalpodautoscalers, poddisruptionbudgets, services,
 # ingresses, networkpolicies, endpointslices, ingressclasses,
@@ -445,6 +446,8 @@ exec:
 # runtimeclasses.
 # Group aliases (current registry):
 #   core       = pods, events
+#   config     = configmaps, resourcequotas, limitranges,
+#                serviceaccounts
 #   workloads  = deployments, statefulsets, daemonsets, replicasets,
 #                jobs, cronjobs, horizontalpodautoscalers,
 #                poddisruptionbudgets

--- a/docs/architecture/watch-streams.md
+++ b/docs/architecture/watch-streams.md
@@ -14,8 +14,8 @@ relevant `web/` files; this page covers only the server side.
 
 ## 1. What "watch stream" means here
 
-Periscope's resource list pages (Pods, Events, ReplicaSets, Jobs)
-need to update in near-real-time. The naive answer is "poll every 5s
+Periscope's resource list pages need to update in near-real-time.
+The naive answer is "poll every 5s
 and diff in the client." We do better:
 
 1. The browser opens an `EventSource` to `/api/clusters/{cluster}/{kind}/watch`.
@@ -42,6 +42,10 @@ same DTO shape, so feature parity is automatic.
 |---|---|---|---|
 | Pods | `/api/clusters/{cluster}/pods/watch` | `Pod` | `internal/k8s/watch.go: WatchPods` |
 | Events | `/api/clusters/{cluster}/events/watch` | `ClusterEvent` | `internal/k8s/watch.go: WatchEvents` |
+| ConfigMaps | `/api/clusters/{cluster}/configmaps/watch` | `ConfigMap` | `internal/k8s/watch.go: WatchConfigMaps` |
+| ResourceQuotas | `/api/clusters/{cluster}/resourcequotas/watch` | `ResourceQuota` | `internal/k8s/watch.go: WatchResourceQuotas` |
+| LimitRanges | `/api/clusters/{cluster}/limitranges/watch` | `LimitRange` | `internal/k8s/watch.go: WatchLimitRanges` |
+| ServiceAccounts | `/api/clusters/{cluster}/serviceaccounts/watch` | `ServiceAccount` | `internal/k8s/watch.go: WatchServiceAccounts` |
 | Deployments | `/api/clusters/{cluster}/deployments/watch` | `Deployment` | `internal/k8s/watch.go: WatchDeployments` |
 | StatefulSets | `/api/clusters/{cluster}/statefulsets/watch` | `StatefulSet` | `internal/k8s/watch.go: WatchStatefulSets` |
 | DaemonSets | `/api/clusters/{cluster}/daemonsets/watch` | `DaemonSet` | `internal/k8s/watch.go: WatchDaemonSets` |
@@ -159,8 +163,9 @@ returns HTTP 429. The cap exists to stop a runaway SPA bug from
 opening hundreds of EventSources and exhausting apiserver watch
 budget on the user's behalf.
 
-The 30-stream default reflects "10 list pages × 3 kinds at peak,"
-which is well above realistic usage.
+The 60-stream default reflects "~10 tabs × 6 list views" with
+headroom for the larger kind set unlocked as more controllers gain
+SSE streams.
 
 ---
 
@@ -336,7 +341,7 @@ auth layer broadcasts to every registered stream.
 
 ## 12. Related code
 
-- `internal/k8s/watch.go` — `watchKind`, `watchSpec`, the four
+- `internal/k8s/watch.go` — `watchKind`, `watchSpec`, the
   `Watch*` wrappers
 - `internal/k8s/watch_test.go` — generic primitive tests
 - `internal/sse/` — SSE writer, heartbeat, last-event-id parsing

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -458,8 +458,8 @@ clusters are registered.
 ### 10.5 Real-time list updates (watch streams)
 
 Periscope's resource list pages update in real time via SSE for
-21+ kinds spanning workloads, networking, storage, cluster-scoped,
-and core resources. **Every registered kind is on by default**;
+registered kinds spanning core, config, workloads, networking,
+storage, and cluster-scoped resources. **Every registered kind is on by default**;
 the SPA falls back to polling when the EventSource fails. The
 `watchStreams:` helm block lets operators opt out (e.g. behind a
 proxy that mishandles long-lived connections), restrict to a
@@ -469,8 +469,8 @@ at once:
 ```yaml
 watchStreams:
   # Empty / "all" / "off" / "none" / comma list
-  # Per-kind tokens: pods, events, deployments, statefulsets, …
-  # Group aliases:  core, workloads, networking, storage, cluster
+  # Per-kind tokens: pods, events, configmaps, deployments, …
+  # Group aliases:  core, config, workloads, networking, storage, cluster
   kinds: ""
   perUserLimit: 60    # concurrent SSE streams per OIDC subject
 ```

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -219,20 +219,22 @@ Grammar:
 
 ```
 ""           # unset = "all"
-"all"        # every registered kind (~22)
+"all"        # every registered kind
 "off"        # no SSE; SPA falls back to polling everywhere
 "none"       # synonym for "off"
 "pods"       # one kind
+"config"     # group alias (configmaps, resourcequotas, limitranges, serviceaccounts)
 "workloads"  # group alias (deployments, statefulsets, daemonsets, replicasets, jobs, cronjobs, hpas, pdbs)
-"core,workloads,networking"   # multiple groups
+"core,config,workloads"       # multiple groups
 "pods,workloads"              # mixed kinds and groups
 ```
 
-Group aliases: `core`, `workloads`, `networking`, `storage`,
-`cluster`. The kind ↔ group mapping is the `watchKinds` registry
+Group aliases: `core`, `config`, `workloads`, `networking`,
+`storage`, `cluster`. The kind ↔ group mapping is the `watchKinds` registry
 in `cmd/periscope/main.go`. Unknown tokens are silently dropped;
-operators see a startup `slog` line summarizing what's enabled, so
-typos surface immediately.
+operators see a startup `slog` line summarizing what's enabled.
+When configured through Helm, the chart schema rejects unknown
+tokens before deploy.
 
 Default is "all on" because the SSE plumbing has a per-user stream
 cap and a tested polling-fallback path — restrictive proxies that

--- a/docs/setup/values.md
+++ b/docs/setup/values.md
@@ -222,8 +222,8 @@ group aliases, and fallback behavior.
 | `watchStreams.kinds` | string | `""` | Empty / `all` / `off` / `none` / comma-separated kinds / group aliases. |
 | `watchStreams.perUserLimit` | int | `60` | Per-user concurrent stream cap. `0` disables (not recommended). |
 
-Group aliases: `core`, `workloads`, `networking`, `storage`,
-`cluster`. Per-kind tokens: see `watchStreams:` block in
+Group aliases: `core`, `config`, `workloads`, `networking`,
+`storage`, `cluster`. Per-kind tokens: see `watchStreams:` block in
 `values.yaml`.
 
 ## pdb

--- a/docs/setup/watch-streams.md
+++ b/docs/setup/watch-streams.md
@@ -1,7 +1,7 @@
 # Watch streams (real-time list updates)
 
-Periscope's pod, event, replicaset, and job list pages update in
-real time via Server-Sent Events (SSE) instead of polling. The SPA
+Periscope's registered resource list pages update in real time via
+Server-Sent Events (SSE) instead of polling. The SPA
 falls back to polling for any kind whose stream cannot be opened,
 so the bad case is graceful degradation rather than a hard failure.
 
@@ -19,10 +19,10 @@ list-then-watch lifecycle — see
 
 ## 1. Default behavior
 
-**On by default for all four shipped kinds:** pods, events,
-replicasets, jobs. With no helm config, each list page in the SPA
-opens an `EventSource` to `/api/clusters/{cluster}/{kind}/watch` and
-reconciles deltas into the React Query cache as they arrive.
+**On by default for every registered kind.** With no helm config,
+each supported list page in the SPA opens an `EventSource` to
+`/api/clusters/{cluster}/{kind}/watch` and reconciles deltas into
+the React Query cache as they arrive.
 
 When a stream fails (404, network error, server tear-down), the SPA
 automatically falls back to a polling `useResource` query for that
@@ -58,17 +58,19 @@ The `kinds` value accepts:
 | `"core,workloads"` | Multiple groups, one token each |
 | `"pods,workloads"` | Mixed kinds and groups |
 
-Per-kind tokens (current registry): `pods`, `events`, `deployments`, `statefulsets`, `daemonsets`, `replicasets`, `jobs`, `cronjobs`, `horizontalpodautoscalers`, `poddisruptionbudgets`, `services`, `ingresses`, `networkpolicies`, `endpointslices`, `ingressclasses`, `pvs`, `pvcs`, `storageclasses`, `nodes`, `namespaces`, `priorityclasses`, `runtimeclasses`.
+Per-kind tokens (current registry): `pods`, `events`, `configmaps`, `resourcequotas`, `limitranges`, `serviceaccounts`, `deployments`, `statefulsets`, `daemonsets`, `replicasets`, `jobs`, `cronjobs`, `horizontalpodautoscalers`, `poddisruptionbudgets`, `services`, `ingresses`, `networkpolicies`, `endpointslices`, `ingressclasses`, `pvs`, `pvcs`, `storageclasses`, `nodes`, `namespaces`, `priorityclasses`, `runtimeclasses`.
 
 Group aliases (current registry):
 
 - `core` = `pods`, `events`
+- `config` = `configmaps`, `resourcequotas`, `limitranges`, `serviceaccounts`
 - `workloads` = `deployments`, `statefulsets`, `daemonsets`, `replicasets`, `jobs`, `cronjobs`, `horizontalpodautoscalers`, `poddisruptionbudgets`
 - `networking` = `services`, `ingresses`, `networkpolicies`, `endpointslices`, `ingressclasses`
 - `storage` = `pvs`, `pvcs`, `storageclasses`
 - `cluster` = `nodes`, `namespaces`, `priorityclasses`, `runtimeclasses`
 
-Groups expand as new kinds register; the env grammar is forward-compatible.
+Groups expand as new kinds register; the chart schema is updated
+alongside the server registry.
 
 The schema rejects misspellings (`banana,pods` won't pass `helm
 template`), so a typo fails at deploy time rather than silently
@@ -115,7 +117,7 @@ but mangles event streams):
 
 ```yaml
 watchStreams:
-  kinds: "pods,replicasets,jobs"
+  kinds: "pods,configmaps,jobs"
 ```
 
 ---
@@ -177,7 +179,7 @@ curl -i http://localhost:8080/debug/streams
 
 # 4. Server-side defaults (kinds is unset):
 kubectl -n periscope logs deploy/periscope | grep "watch streams"
-# `watch streams enabled: pods=true events=true replicasets=true jobs=true`
+# `watch streams enabled: pods=true events=true configmaps=true ...`
 ```
 
 ---

--- a/internal/k8s/extras.go
+++ b/internal/k8s/extras.go
@@ -614,13 +614,7 @@ func ListLimitRanges(ctx context.Context, p credentials.Provider, args ListLimit
 	}
 	out := LimitRangeList{LimitRanges: make([]LimitRange, 0, len(raw.Items))}
 	for i := range raw.Items {
-		lr := &raw.Items[i]
-		out.LimitRanges = append(out.LimitRanges, LimitRange{
-			Name:       lr.Name,
-			Namespace:  lr.Namespace,
-			CreatedAt:  lr.CreationTimestamp.Time,
-			LimitCount: len(lr.Spec.Limits),
-		})
+		out.LimitRanges = append(out.LimitRanges, limitRangeSummary(&raw.Items[i]))
 	}
 	return out, nil
 }
@@ -646,12 +640,7 @@ func GetLimitRange(ctx context.Context, p credentials.Provider, args GetLimitRan
 		})
 	}
 	return LimitRangeDetail{
-		LimitRange: LimitRange{
-			Name:       raw.Name,
-			Namespace:  raw.Namespace,
-			CreatedAt:  raw.CreationTimestamp.Time,
-			LimitCount: len(raw.Spec.Limits),
-		},
+		LimitRange:  limitRangeSummary(raw),
 		Limits:      limits,
 		Labels:      raw.Labels,
 		Annotations: raw.Annotations,
@@ -668,6 +657,15 @@ func GetLimitRangeYAML(ctx context.Context, p credentials.Provider, args GetLimi
 		return "", fmt.Errorf("get limitrange: %w", err)
 	}
 	return formatYAML(raw)
+}
+
+func limitRangeSummary(lr *corev1.LimitRange) LimitRange {
+	return LimitRange{
+		Name:       lr.Name,
+		Namespace:  lr.Namespace,
+		CreatedAt:  lr.CreationTimestamp.Time,
+		LimitCount: len(lr.Spec.Limits),
+	}
 }
 
 func quantityMapToStr(m corev1.ResourceList) map[string]string {

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -163,12 +164,7 @@ func ListServiceAccounts(ctx context.Context, p credentials.Provider, args ListS
 	}
 	out := ServiceAccountList{ServiceAccounts: make([]ServiceAccount, 0, len(raw.Items))}
 	for _, sa := range raw.Items {
-		out.ServiceAccounts = append(out.ServiceAccounts, ServiceAccount{
-			Name:      sa.Name,
-			Namespace: sa.Namespace,
-			Secrets:   len(sa.Secrets),
-			CreatedAt: sa.CreationTimestamp.Time,
-		})
+		out.ServiceAccounts = append(out.ServiceAccounts, serviceAccountSummary(&sa))
 	}
 	return out, nil
 }
@@ -285,16 +281,20 @@ func GetServiceAccount(ctx context.Context, p credentials.Provider, args GetServ
 		secrets = append(secrets, s.Name)
 	}
 	return ServiceAccountDetail{
-		ServiceAccount: ServiceAccount{
-			Name:      raw.Name,
-			Namespace: raw.Namespace,
-			Secrets:   len(raw.Secrets),
-			CreatedAt: raw.CreationTimestamp.Time,
-		},
-		SecretNames: secrets,
-		Labels:      raw.Labels,
-		Annotations: raw.Annotations,
+		ServiceAccount: serviceAccountSummary(raw),
+		SecretNames:    secrets,
+		Labels:         raw.Labels,
+		Annotations:    raw.Annotations,
 	}, nil
+}
+
+func serviceAccountSummary(sa *corev1.ServiceAccount) ServiceAccount {
+	return ServiceAccount{
+		Name:      sa.Name,
+		Namespace: sa.Namespace,
+		Secrets:   len(sa.Secrets),
+		CreatedAt: sa.CreationTimestamp.Time,
+	}
 }
 
 // --- YAML ---

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -561,6 +561,98 @@ func WatchServices(ctx context.Context, p credentials.Provider, args WatchArgs, 
 	}, args.ResumeFrom, sink)
 }
 
+// WatchConfigMaps runs a list-then-watch loop on ConfigMaps in the
+// given namespace. See watchKind for lifecycle details.
+func WatchConfigMaps(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {
+	cs, err := newClientFn(ctx, p, args.Cluster)
+	if err != nil {
+		return fmt.Errorf("build clientset: %w", err)
+	}
+	return watchKind(ctx, watchSpec[corev1.ConfigMap, ConfigMap]{
+		Kind: "configmaps",
+		List: func(ctx context.Context, opts metav1.ListOptions) ([]corev1.ConfigMap, string, error) {
+			list, err := cs.CoreV1().ConfigMaps(args.Namespace).List(ctx, opts)
+			if err != nil {
+				return nil, "", err
+			}
+			return list.Items, list.ResourceVersion, nil
+		},
+		Watch: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			return cs.CoreV1().ConfigMaps(args.Namespace).Watch(ctx, opts)
+		},
+		Summary: configMapSummary,
+	}, args.ResumeFrom, sink)
+}
+
+// WatchResourceQuotas runs a list-then-watch loop on ResourceQuotas
+// in the given namespace. See watchKind for lifecycle details.
+func WatchResourceQuotas(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {
+	cs, err := newClientFn(ctx, p, args.Cluster)
+	if err != nil {
+		return fmt.Errorf("build clientset: %w", err)
+	}
+	return watchKind(ctx, watchSpec[corev1.ResourceQuota, ResourceQuota]{
+		Kind: "resourcequotas",
+		List: func(ctx context.Context, opts metav1.ListOptions) ([]corev1.ResourceQuota, string, error) {
+			list, err := cs.CoreV1().ResourceQuotas(args.Namespace).List(ctx, opts)
+			if err != nil {
+				return nil, "", err
+			}
+			return list.Items, list.ResourceVersion, nil
+		},
+		Watch: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			return cs.CoreV1().ResourceQuotas(args.Namespace).Watch(ctx, opts)
+		},
+		Summary: resourceQuotaSummary,
+	}, args.ResumeFrom, sink)
+}
+
+// WatchLimitRanges runs a list-then-watch loop on LimitRanges in the
+// given namespace. See watchKind for lifecycle details.
+func WatchLimitRanges(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {
+	cs, err := newClientFn(ctx, p, args.Cluster)
+	if err != nil {
+		return fmt.Errorf("build clientset: %w", err)
+	}
+	return watchKind(ctx, watchSpec[corev1.LimitRange, LimitRange]{
+		Kind: "limitranges",
+		List: func(ctx context.Context, opts metav1.ListOptions) ([]corev1.LimitRange, string, error) {
+			list, err := cs.CoreV1().LimitRanges(args.Namespace).List(ctx, opts)
+			if err != nil {
+				return nil, "", err
+			}
+			return list.Items, list.ResourceVersion, nil
+		},
+		Watch: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			return cs.CoreV1().LimitRanges(args.Namespace).Watch(ctx, opts)
+		},
+		Summary: limitRangeSummary,
+	}, args.ResumeFrom, sink)
+}
+
+// WatchServiceAccounts runs a list-then-watch loop on ServiceAccounts
+// in the given namespace. See watchKind for lifecycle details.
+func WatchServiceAccounts(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {
+	cs, err := newClientFn(ctx, p, args.Cluster)
+	if err != nil {
+		return fmt.Errorf("build clientset: %w", err)
+	}
+	return watchKind(ctx, watchSpec[corev1.ServiceAccount, ServiceAccount]{
+		Kind: "serviceaccounts",
+		List: func(ctx context.Context, opts metav1.ListOptions) ([]corev1.ServiceAccount, string, error) {
+			list, err := cs.CoreV1().ServiceAccounts(args.Namespace).List(ctx, opts)
+			if err != nil {
+				return nil, "", err
+			}
+			return list.Items, list.ResourceVersion, nil
+		},
+		Watch: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			return cs.CoreV1().ServiceAccounts(args.Namespace).Watch(ctx, opts)
+		},
+		Summary: serviceAccountSummary,
+	}, args.ResumeFrom, sink)
+}
+
 // WatchIngresses runs a list-then-watch loop on Ingresses in the
 // given namespace. See watchKind for lifecycle details.
 func WatchIngresses(ctx context.Context, p credentials.Provider, args WatchArgs, sink WatchSink) error {

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -19,6 +19,7 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -1091,6 +1092,217 @@ func TestWatchServices_SnapshotAndAdded(t *testing.T) {
 	}
 	if svcObj.Name != "svc-b" {
 		t.Errorf("added service name = %q, want svc-b", svcObj.Name)
+	}
+}
+
+// --- Config smoke tests ---
+
+func TestWatchConfigMaps_SnapshotAndAdded(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-a", Namespace: "default", ResourceVersion: "1"},
+		Data:       map[string]string{"app": "demo"},
+	}
+	cs := fake.NewSimpleClientset(cm)
+	swapNewClientFn(t, cs)
+
+	sink := newTestSink(8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = WatchConfigMaps(ctx, stubProvider{}, WatchArgs{
+			Cluster:   clusters.Cluster{Name: "demo", Backend: clusters.BackendKubeconfig},
+			Namespace: "default",
+		}, sink)
+	}()
+
+	snap := awaitEvent(t, sink)
+	if snap.Type != WatchSnapshot {
+		t.Fatalf("first event = %v, want snapshot", snap.Type)
+	}
+	items, ok := snap.Items.([]ConfigMap)
+	if !ok {
+		t.Fatalf("Items type = %T, want []ConfigMap", snap.Items)
+	}
+	if len(items) != 1 || items[0].Name != "cm-a" || items[0].KeyCount != 1 {
+		t.Fatalf("snapshot items = %+v, want one cm-a with one key", items)
+	}
+
+	cm2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-b", Namespace: "default", ResourceVersion: "2"},
+	}
+	if _, err := cs.CoreV1().ConfigMaps("default").Create(ctx, cm2, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create configmap: %v", err)
+	}
+
+	got := awaitEvent(t, sink)
+	if got.Type != WatchAdded {
+		t.Fatalf("event = %v, want added", got.Type)
+	}
+	cmObj, ok := got.Object.(ConfigMap)
+	if !ok {
+		t.Fatalf("Object type = %T, want ConfigMap", got.Object)
+	}
+	if cmObj.Name != "cm-b" {
+		t.Errorf("added configmap name = %q, want cm-b", cmObj.Name)
+	}
+}
+
+func TestWatchResourceQuotas_SnapshotAndAdded(t *testing.T) {
+	rq := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "rq-a", Namespace: "default", ResourceVersion: "1"},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{corev1.ResourcePods: resource.MustParse("10")},
+			Used: corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")},
+		},
+	}
+	cs := fake.NewSimpleClientset(rq)
+	swapNewClientFn(t, cs)
+
+	sink := newTestSink(8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = WatchResourceQuotas(ctx, stubProvider{}, WatchArgs{
+			Cluster:   clusters.Cluster{Name: "demo", Backend: clusters.BackendKubeconfig},
+			Namespace: "default",
+		}, sink)
+	}()
+
+	snap := awaitEvent(t, sink)
+	if snap.Type != WatchSnapshot {
+		t.Fatalf("first event = %v, want snapshot", snap.Type)
+	}
+	items, ok := snap.Items.([]ResourceQuota)
+	if !ok {
+		t.Fatalf("Items type = %T, want []ResourceQuota", snap.Items)
+	}
+	if len(items) != 1 || items[0].Name != "rq-a" || items[0].Items["pods"].Hard != "10" {
+		t.Fatalf("snapshot items = %+v, want one rq-a with pods quota", items)
+	}
+
+	rq2 := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "rq-b", Namespace: "default", ResourceVersion: "2"},
+	}
+	if _, err := cs.CoreV1().ResourceQuotas("default").Create(ctx, rq2, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create resourcequota: %v", err)
+	}
+
+	got := awaitEvent(t, sink)
+	if got.Type != WatchAdded {
+		t.Fatalf("event = %v, want added", got.Type)
+	}
+	rqObj, ok := got.Object.(ResourceQuota)
+	if !ok {
+		t.Fatalf("Object type = %T, want ResourceQuota", got.Object)
+	}
+	if rqObj.Name != "rq-b" {
+		t.Errorf("added resourcequota name = %q, want rq-b", rqObj.Name)
+	}
+}
+
+func TestWatchLimitRanges_SnapshotAndAdded(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Name: "lr-a", Namespace: "default", ResourceVersion: "1"},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{{Type: corev1.LimitTypeContainer}},
+		},
+	}
+	cs := fake.NewSimpleClientset(lr)
+	swapNewClientFn(t, cs)
+
+	sink := newTestSink(8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = WatchLimitRanges(ctx, stubProvider{}, WatchArgs{
+			Cluster:   clusters.Cluster{Name: "demo", Backend: clusters.BackendKubeconfig},
+			Namespace: "default",
+		}, sink)
+	}()
+
+	snap := awaitEvent(t, sink)
+	if snap.Type != WatchSnapshot {
+		t.Fatalf("first event = %v, want snapshot", snap.Type)
+	}
+	items, ok := snap.Items.([]LimitRange)
+	if !ok {
+		t.Fatalf("Items type = %T, want []LimitRange", snap.Items)
+	}
+	if len(items) != 1 || items[0].Name != "lr-a" || items[0].LimitCount != 1 {
+		t.Fatalf("snapshot items = %+v, want one lr-a with one limit", items)
+	}
+
+	lr2 := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Name: "lr-b", Namespace: "default", ResourceVersion: "2"},
+	}
+	if _, err := cs.CoreV1().LimitRanges("default").Create(ctx, lr2, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create limitrange: %v", err)
+	}
+
+	got := awaitEvent(t, sink)
+	if got.Type != WatchAdded {
+		t.Fatalf("event = %v, want added", got.Type)
+	}
+	lrObj, ok := got.Object.(LimitRange)
+	if !ok {
+		t.Fatalf("Object type = %T, want LimitRange", got.Object)
+	}
+	if lrObj.Name != "lr-b" {
+		t.Errorf("added limitrange name = %q, want lr-b", lrObj.Name)
+	}
+}
+
+func TestWatchServiceAccounts_SnapshotAndAdded(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa-a", Namespace: "default", ResourceVersion: "1"},
+		Secrets:    []corev1.ObjectReference{{Name: "token-a"}},
+	}
+	cs := fake.NewSimpleClientset(sa)
+	swapNewClientFn(t, cs)
+
+	sink := newTestSink(8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = WatchServiceAccounts(ctx, stubProvider{}, WatchArgs{
+			Cluster:   clusters.Cluster{Name: "demo", Backend: clusters.BackendKubeconfig},
+			Namespace: "default",
+		}, sink)
+	}()
+
+	snap := awaitEvent(t, sink)
+	if snap.Type != WatchSnapshot {
+		t.Fatalf("first event = %v, want snapshot", snap.Type)
+	}
+	items, ok := snap.Items.([]ServiceAccount)
+	if !ok {
+		t.Fatalf("Items type = %T, want []ServiceAccount", snap.Items)
+	}
+	if len(items) != 1 || items[0].Name != "sa-a" || items[0].Secrets != 1 {
+		t.Fatalf("snapshot items = %+v, want one sa-a with one secret", items)
+	}
+
+	sa2 := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa-b", Namespace: "default", ResourceVersion: "2"},
+	}
+	if _, err := cs.CoreV1().ServiceAccounts("default").Create(ctx, sa2, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create serviceaccount: %v", err)
+	}
+
+	got := awaitEvent(t, sink)
+	if got.Type != WatchAdded {
+		t.Fatalf("event = %v, want added", got.Type)
+	}
+	saObj, ok := got.Object.(ServiceAccount)
+	if !ok {
+		t.Fatalf("Object type = %T, want ServiceAccount", got.Object)
+	}
+	if saObj.Name != "sa-b" {
+		t.Errorf("added serviceaccount name = %q, want sa-b", saObj.Name)
 	}
 }
 

--- a/web/src/hooks/useResource.ts
+++ b/web/src/hooks/useResource.ts
@@ -68,6 +68,10 @@ interface ResourceQueryArgs {
 const LIST_REFETCH_INTERVAL: Partial<Record<ResourceKind, number>> = {
   pods: 15_000,
   events: 15_000,
+  configmaps: 60_000,
+  resourcequotas: 60_000,
+  limitranges: 60_000,
+  serviceaccounts: 60_000,
   deployments: 30_000,
   statefulsets: 30_000,
   daemonsets: 30_000,
@@ -105,6 +109,10 @@ const LIST_REFETCH_INTERVAL: Partial<Record<ResourceKind, number>> = {
 const WATCH_STREAM_KINDS: ReadonlyArray<ResourceKind> = [
   "pods",
   "events",
+  "configmaps",
+  "resourcequotas",
+  "limitranges",
+  "serviceaccounts",
   "deployments",
   "statefulsets",
   "daemonsets",
@@ -241,8 +249,8 @@ export function useResource({
   });
 
   // streamStatus surfaces only when the kind is a watch kind AND the
-  // server has it enabled. Polling-only kinds (deployments, services,
-  // configmaps, …) get undefined — the StreamHealthBadge renders nothing.
+  // server has it enabled. Polling-only kinds get undefined — the
+  // StreamHealthBadge renders nothing.
   return Object.assign(query, {
     streamStatus:
       isWatchStreamKind(resource) && featureEnabled

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -203,6 +203,10 @@ export type YamlKind =
 export type WatchStreamKind =
   | "pods"
   | "events"
+  | "configmaps"
+  | "resourcequotas"
+  | "limitranges"
+  | "serviceaccounts"
   | "deployments"
   | "statefulsets"
   | "daemonsets"


### PR DESCRIPTION
 Closes #17

  ## Summary
  - Added SSE watch support for ConfigMaps, ResourceQuotas, LimitRanges, and ServiceAccounts.
  - Registered the new `config` watch-stream group.
  - Updated frontend watch metadata and fallback polling intervals.
  - Updated Helm schema/comments and watch-stream docs.

  ## Testing
  - go test ./internal/k8s/...
  - go test ./...
  - CGO_ENABLED=1 go test -race ./internal/k8s/...
  - ESLint JSON check reported no lint messages
  - tsc -b
  - Vite production build