### PR TITLE
Add regex validation for chart fetch URLs to prevent SSRF

### DIFF
--- a/internal/k8s/helm_chart_http.go
+++ b/internal/k8s/helm_chart_http.go
@@ -8,10 +8,26 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
 	"sigs.k8s.io/yaml"
+)
+
+// chartFetchHostRe gates the Host field of a parsed chart-fetch URL.
+// Matches RFC-1123 DNS names, IPv4 dotted literals, and bracketed
+// IPv6, each with an optional :port. Rejecting on no-match gives
+// CodeQL go/request-forgery a recognizable regex barrier guard
+// between the operator-supplied ref and net/http's request
+// constructor — the dial-time SSRF guard remains the runtime
+// authority on which destinations actually connect.
+var chartFetchHostRe = regexp.MustCompile(
+	`^(` +
+		`([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*` +
+		`|([0-9]{1,3}(\.[0-9]{1,3}){3})` +
+		`|(\[[0-9a-fA-F:.]+\])` +
+		`)(:[0-9]{1,5})?$`,
 )
 
 // HTTP chart-repo client. A chart repo is "any HTTP server that
@@ -223,11 +239,11 @@ func classifyHTTPErr(err error) error {
 
 // sanitizeChartFetchURL parses target, validates the scheme and host,
 // and returns a reconstructed URL string built from the typed
-// *url.URL components. The reconstruction is the load-bearing piece
-// for CodeQL's go/request-forgery query: data flow from the
-// untrusted string to the request constructor passes through a
-// scheme allow-list (http / https only) and a *url.URL field
-// reassembly, which the query treats as a sanitizer.
+// *url.URL components. Two checks compose to give CodeQL's
+// go/request-forgery query a sanitizer it recognizes: a scheme
+// allow-list (http / https only) and a regex match on the parsed
+// Host. The reconstructed URL is then assembled from those validated
+// parts.
 //
 // Functionally equivalent to using `target` directly when the input
 // is well-formed, but rejects upfront:
@@ -235,6 +251,8 @@ func classifyHTTPErr(err error) error {
 //   - non-http(s) schemes (defends against file://, gopher://, etc.)
 //   - missing host (rejects relative URLs that would otherwise
 //     resolve against nothing)
+//   - hosts that don't look like a DNS name / IPv4 / bracketed IPv6
+//     with optional port
 //
 // The dial-time SSRF guard (helm_chart_ssrf.go) is still the runtime
 // authority on which destinations are allowed; this function adds an
@@ -252,6 +270,16 @@ func sanitizeChartFetchURL(target string) (string, error) {
 	}
 	if parsed.Host == "" {
 		return "", fmt.Errorf("%w: missing host", ErrChartUnsupportedRef)
+	}
+	// Regex-check the host shape. This is the load-bearing barrier for
+	// CodeQL go/request-forgery: branching on a regex match of the
+	// untrusted Host gives the query a recognizable guard before the
+	// reassembled URL flows into http.NewRequestWithContext. Functionally
+	// this rejects malformed hosts (embedded paths, control chars, IDN
+	// surrogates) that url.Parse would otherwise accept; the dial-time
+	// SSRF guard still owns the IP-range policy.
+	if !chartFetchHostRe.MatchString(parsed.Host) {
+		return "", fmt.Errorf("%w: invalid host %q", ErrChartUnsupportedRef, parsed.Host)
 	}
 	// Reassemble from validated parts. Note: we don't preserve
 	// userinfo (parsed.User) — chart fetches in v1.1 are anonymous,

--- a/internal/k8s/helm_chart_test.go
+++ b/internal/k8s/helm_chart_test.go
@@ -489,6 +489,10 @@ func TestSanitizeChartFetchURL(t *testing.T) {
 		{name: "rejects gopher", in: "gopher://example.com", wantErr: true},
 		{name: "rejects relative", in: "/just/a/path", wantErr: true},
 		{name: "rejects empty", in: "", wantErr: true},
+		{name: "ipv4 with port", in: "http://127.0.0.1:8080/x", want: "http://127.0.0.1:8080/x"},
+		{name: "ipv6 with port", in: "http://[::1]:8080/x", want: "http://[::1]:8080/x"},
+		{name: "rejects host with control char", in: "http://exa\nmple.com/", wantErr: true},
+		{name: "rejects host with space", in: "http://exa mple.com/", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a regex-based host validation check to `sanitizeChartFetchURL()` to strengthen SSRF defenses. The regex validates that the parsed Host field matches RFC-1123 DNS names, IPv4 dotted literals, or bracketed IPv6 addresses with optional ports. This provides CodeQL's go/request-forgery query with a recognizable sanitizer guard before the URL is passed to `http.NewRequestWithContext()`.

## Related issue / RFC

No issue linked. This is a security hardening measure to improve static analysis detection of potential SSRF vulnerabilities.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (user-visible API, config shape, or Helm values)
- [ ] Docs only
- [ ] Refactor / internal cleanup
- [ ] Test or CI only

## Surfaces touched

- [ ] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
- [ ] Helm values — see `deploy/helm/periscope/values.yaml` schema
- [ ] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [ ] SPA / frontend
- [ ] Documentation
- [x] None of the above

## How was this tested?

Added unit tests covering:
- IPv4 addresses with ports
- IPv6 addresses with ports (bracketed notation)
- Rejection of hosts with control characters (newline)
- Rejection of hosts with spaces

Existing tests for scheme validation, relative URLs, and empty inputs continue to pass.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests added or updated where it makes sense.
- [ ] Docs updated (`docs/`, `README.md`, or `CHANGELOG.md` under `[Unreleased]`).
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.

https://claude.ai/code/session_01AdeSnGqiEAW6mGJMVrfzzY