### PR TITLE
fix(web): namespace picker — fix clipping/overlay, add search, taller panel

### DIFF
--- a/web/src/components/page/PageHeader.tsx
+++ b/web/src/components/page/PageHeader.tsx
@@ -39,9 +39,13 @@ export function PageHeader({
     // Sticky glass-effect chrome: sits at the top of the page's scroll
     // container, stays visible as content scrolls beneath. Translucent
     // base + backdrop blur so the page underneath shows through subtly
-    // without hurting legibility. z-20 keeps it above table rows but
-    // below modal/drawer overlays (z-40+).
-    <div className="sticky top-0 z-20 flex flex-wrap items-end gap-x-5 gap-y-2 border-b border-border bg-bg/80 px-6 pb-4 pt-6 backdrop-blur-md">
+    // without hurting legibility. z-30 keeps it above the FilterStrip
+    // (z-20) — backdrop-blur creates a stacking context, so any
+    // floating menu (e.g. NamespacePicker) rendered inside `trailing`
+    // is bottled up at the header's z; staying one tier above the
+    // FilterStrip lets those panels overlap it. Modal/drawer overlays
+    // sit at z-40+ and still win.
+    <div className="sticky top-0 z-30 flex flex-wrap items-end gap-x-5 gap-y-2 border-b border-border bg-bg/80 px-6 pb-4 pt-6 backdrop-blur-md">
       <h1
         className="font-display text-[40px] leading-[0.95] tracking-[-0.02em] text-ink"
         style={{ fontWeight: 400 }}

--- a/web/src/components/shell/NamespacePicker.tsx
+++ b/web/src/components/shell/NamespacePicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useNamespaces } from "../../hooks/useClusters";
 import { cn } from "../../lib/cn";
@@ -9,20 +9,35 @@ export function NamespacePicker() {
   const namespace = params.get("ns");
   const { data, isLoading } = useNamespaces(cluster);
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Single close path used by every dismissal route (button toggle,
+  // outside-click, Escape, namespace selection). Resets the filter
+  // here rather than via a cascading effect on `open` — sticky filter
+  // across opens feels surprising on a list that changes per cluster.
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
 
   useEffect(() => {
     if (!open) return;
+    // Auto-focus the search input on open so the user can start
+    // typing immediately. Microtask defer keeps the click that
+    // opened the menu from stealing focus back.
+    queueMicrotask(() => searchRef.current?.focus());
     const onClick = (e: MouseEvent) => {
       if (
         wrapperRef.current &&
         !wrapperRef.current.contains(e.target as Node)
       ) {
-        setOpen(false);
+        closeMenu();
       }
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") closeMenu();
     };
     document.addEventListener("mousedown", onClick);
     document.addEventListener("keydown", onKey);
@@ -30,23 +45,31 @@ export function NamespacePicker() {
       document.removeEventListener("mousedown", onClick);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+  }, [open, closeMenu]);
 
   const setNamespace = (ns: string | null) => {
     const next = new URLSearchParams(params);
     if (ns === null) next.delete("ns");
     else next.set("ns", ns);
     setParams(next, { replace: true });
-    setOpen(false);
+    closeMenu();
   };
 
-  const namespaces = data?.namespaces.map((n) => n.name) ?? [];
+  const namespaces = useMemo(
+    () => data?.namespaces.map((n) => n.name) ?? [],
+    [data],
+  );
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return namespaces;
+    return namespaces.filter((n) => n.toLowerCase().includes(q));
+  }, [namespaces, query]);
 
   return (
     <div ref={wrapperRef} className="relative">
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => (open ? closeMenu() : setOpen(true))}
         disabled={isLoading || !cluster}
         className={cn(
           "flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-[12.5px] transition-colors",
@@ -69,38 +92,63 @@ export function NamespacePicker() {
       </button>
 
       {open && (
-        <div className="absolute left-0 top-[calc(100%+4px)] z-30 max-h-[320px] w-64 overflow-auto rounded-md border border-border-strong bg-surface py-1 shadow-[0_8px_28px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_28px_rgba(0,0,0,0.5)]">
-          <button
-            type="button"
-            onClick={() => setNamespace(null)}
-            className={cn(
-              "flex w-full items-center px-3 py-1.5 text-left text-[12.5px] transition-colors",
-              namespace === null
-                ? "bg-accent-soft text-accent"
-                : "text-ink hover:bg-surface-2",
-            )}
-          >
-            <span className="text-ink-muted">all namespaces</span>
-            <span className="ml-auto font-mono text-[10.5px] text-ink-faint">
-              {namespaces.length}
-            </span>
-          </button>
-          <div className="my-1 h-px bg-border" />
-          {namespaces.map((ns) => (
+        // Outer panel: width fixed at w-64; height is responsive to
+        // viewport via min(70vh, 520px) so big screens get a tall
+        // useful list while small screens still cap inside the
+        // visible area. flex-col + overflow-hidden keeps the search
+        // strip pinned while only the list area scrolls.
+        <div className="absolute right-0 top-[calc(100%+4px)] z-30 flex w-64 max-h-[min(70vh,520px)] flex-col overflow-hidden rounded-md border border-border-strong bg-surface shadow-[0_8px_28px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_28px_rgba(0,0,0,0.5)]">
+          <div className="shrink-0 border-b border-border bg-surface p-2">
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="filter namespaces…"
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-sm border border-border bg-bg px-2 py-1 font-mono text-[12px] text-ink placeholder:text-ink-faint focus:border-border-strong focus:outline-none"
+            />
+          </div>
+          <div className="flex-1 overflow-auto py-1">
             <button
-              key={ns}
               type="button"
-              onClick={() => setNamespace(ns)}
+              onClick={() => setNamespace(null)}
               className={cn(
                 "flex w-full items-center px-3 py-1.5 text-left text-[12.5px] transition-colors",
-                ns === namespace
+                namespace === null
                   ? "bg-accent-soft text-accent"
                   : "text-ink hover:bg-surface-2",
               )}
             >
-              <span className="font-mono">{ns}</span>
+              <span className="text-ink-muted">all namespaces</span>
+              <span className="ml-auto font-mono text-[10.5px] text-ink-faint">
+                {namespaces.length}
+              </span>
             </button>
-          ))}
+            <div className="my-1 h-px bg-border" />
+            {filtered.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] italic text-ink-faint">
+                no namespaces match &ldquo;{query}&rdquo;
+              </div>
+            ) : (
+              filtered.map((ns) => (
+                <button
+                  key={ns}
+                  type="button"
+                  onClick={() => setNamespace(ns)}
+                  className={cn(
+                    "flex w-full items-center px-3 py-1.5 text-left text-[12.5px] transition-colors",
+                    ns === namespace
+                      ? "bg-accent-soft text-accent"
+                      : "text-ink hover:bg-surface-2",
+                  )}
+                >
+                  <span className="font-mono">{ns}</span>
+                </button>
+              ))
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Three issues with the namespace picker, reported via Slack as the dropdown being unusable on prod clusters with ~100 namespaces:

- **Right-edge clipping.** Dropdown was anchored `left-0`, so the 256px panel grew off the right edge of the viewport (the picker lives in the page header's right-hand trailing slot). Flipped to `right-0` so it grows leftward.
- **FilterStrip painting over the dropdown.** `PageHeader` was `sticky z-20 backdrop-blur-md`; `FilterStrip` below is also `z-20 backdrop-blur-md`. `backdrop-blur` creates a stacking context, so the dropdown's inner `z-30` only applied within the header bottle. Same z + later DOM order let FilterStrip paint over the dropdown. Bumped `PageHeader` to `z-30`; modal/drawer overlays at `z-40+` still win.
- **Search + bigger panel.** Added a sticky search input at the top of the picker (autofocus on open, reset on close, case-insensitive substring match). Bumped panel max-height from `320px` to `min(70vh, 520px)` so 100+ namespace clusters don't require scrolling through dozens of rows by hand.

Single dismissal path (`closeMenu`) consolidates the four close routes (toggle, outside-click, Escape, ns-select) so the query reset always fires.

## Test plan

- [ ] Open a Deployments / ConfigMaps / Secrets page on a cluster with the namespace filter bar visible. Click ns picker → panel sits fully on-screen, no right-edge clipping.
- [ ] With the panel open, confirm the FilterStrip "X / Y" count row no longer paints over the dropdown items.
- [ ] Open ns picker on a cluster with 50+ namespaces; confirm panel is taller than before. Resize window down → panel caps at 70vh.
- [ ] Type into the search input → list filters case-insensitively; "all namespaces" reset row stays visible. Type a non-matching string → empty state renders.
- [ ] Press Escape / click outside / pick a namespace → panel closes and query resets (re-open should start empty).
- [ ] Repeat in both light and dark themes.