### PR TITLE
chore: changelog + Artifact Hub changes for v1.0.3-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,34 +13,110 @@ tag.
 
 ## [Unreleased]
 
+## [1.0.3-rc1] - 2026-05-06
+
 ### Added
 
-- Workload rollback button for Deployment / StatefulSet / DaemonSet
-  (#71). Opens a revision picker with Monaco YAML diff preview of the
-  current pod template vs the target revision. Mirrors `kubectl
-  rollout undo` — strategic-merge-patches `spec.template` and writes
-  the `kubernetes.io/change-cause` annotation. Pre-flight warnings
-  cover the three production footguns: GitOps-managed workloads
-  (ArgoCD / Helm / Flux annotations or labels) get a yellow banner
-  warning that reconcile will revert the rollback; paused Deployments
-  get a "resume rollout" pane instead of the picker; HPA-targeted
-  workloads get an inline note. Optional reason field flows into both
-  the change-cause annotation and the structured audit row. New API
+- **Apply YAML — multi-doc paste / upload, dry-run, server-side apply,
+  per-doc RBAC pre-flight, audit** (#53, #54, #55). New SPA dialog
+  reachable from the page header, the cluster sidebar, the cluster
+  overview banner, and the Cmd+K palette. Drag-drop or paste any number
+  of K8s manifests, get a dry-run + diff before commit, then server-side
+  apply with field-ownership glyphs. Per-doc `SelfSubjectAccessReview`
+  pre-flight blocks docs the user can't write rather than failing
+  mid-stream. Each apply emits one structured audit row per doc with
+  the kind/namespace/name/operation tuple.
+
+- **EKS Upgrade Insights viewer** (#103). New read-only surface wrapping
+  AWS EKS `ListInsights` / `DescribeInsight` (UPGRADE_READINESS
+  category). Worst-first insight rows on a dedicated page, expandable
+  detail with deprecated-API summaries, and per-resource deep links
+  that open the SPA's existing YAML editor on the affected object.
+  Cluster-keyed cache, 1h TTL (AWS itself only refreshes daily).
+  Non-EKS clusters return 422 + stable code `E_BACKEND_NOT_EKS` so the
+  UI renders a calm note instead of a generic error. New audit verb
+  `eks_insights_read` (Periscope's first read verb — added at
+  compliance reviewers' request for upgrade-readiness traceability).
+
+- **EKS managed node groups + AMI drift detection** (#103). New
+  surface listing managed node groups with current AMI release version
+  and days-behind-latest drift. Latest-AMI lookup uses SSM public
+  parameters (`/aws/service/eks/optimized-ami/...`,
+  `/aws/service/bottlerocket/...`) as the primary source and
+  `ec2:DescribeImages` as a fallback when SSM is denied / unavailable.
+  Custom-AMI node groups (`AmiType=CUSTOM`) are explicitly badged "not
+  tracked" — AWS does not publish a "latest" for custom images.
+  Shared `(amiType, k8sVersion)` AMI cache (30 min TTL) so a fleet view
+  of N nodegroups makes 1 SSM call per family per half-hour. New audit
+  verb `eks_nodegroups_read`.
+
+- **Workload rollback** for Deployment / StatefulSet / DaemonSet
+  (#71). Revision picker with Monaco YAML diff preview of the current
+  pod template vs the target revision. Mirrors `kubectl rollout undo`
+  — strategic-merge-patches `spec.template` and writes the
+  `kubernetes.io/change-cause` annotation. Pre-flight warnings cover
+  the three production footguns: GitOps-managed workloads (ArgoCD /
+  Helm / Flux annotations or labels) get a yellow banner warning that
+  reconcile will revert the rollback; paused Deployments get a
+  "resume rollout" pane instead of the picker; HPA-targeted workloads
+  get an inline note. Optional reason field flows into both the
+  change-cause annotation and the structured audit row. New API
   endpoints `GET /revisions` (history + pre-flight metadata) and
-  `POST /rollback` (the patch); two new audit verbs
-  `rollback_intent` (pre-patch) + `rollback` (post-outcome) so
-  incident review captures attempts that hang or fail mid-flight.
-  See [`docs/setup/workload-rollback.md`](docs/setup/workload-rollback.md).
-  
+  `POST /rollback` (the patch); two new audit verbs `rollback_intent`
+  (pre-patch) + `rollback` (post-outcome) so incident review captures
+  attempts that hang or fail mid-flight. See
+  [`docs/setup/workload-rollback.md`](docs/setup/workload-rollback.md).
+
 - SSE watch streams for ConfigMaps, ResourceQuotas, LimitRanges, and
   ServiceAccounts (#17).
 
 ### Changed
 
+- AWS SDK errors are now classified by `smithy.APIError` code and
+  surfaced with meaningful HTTP statuses + stable error codes
+  (`E_AWS_FORBIDDEN` 403, `E_AWS_NOT_FOUND` 404, `E_AWS_THROTTLED`
+  429) instead of always collapsing to `502 / E_AWS_API`. The SPA's
+  Upgrade Readiness and Node Groups pages branch on these codes and
+  render permission-specific or rate-limit copy. Anything
+  unrecognized still reads as `502 / E_AWS_API` so existing callers
+  stay compatible.
+
 - Helm `values.schema.json` now strictly validates
   `watchStreams.kinds`; deployments with typos that previously
   silently dropped now fail at helm install time.
 
+### Fixed
+
+- NamespacePicker dropdown was anchored to the button's left edge and
+  clipped off the right of the viewport when used in the page
+  header's trailing slot. The picker is also no longer covered by the
+  FilterStrip — `PageHeader` and `FilterStrip` both opened
+  `backdrop-blur` stacking contexts at z-20, so the picker's inner
+  z-30 only applied within the header bottle. Header bumped to z-30;
+  modal/drawer overlays at z-40+ still win. (#111)
+
+- NamespacePicker on clusters with 50+ namespaces was tedious to
+  scan: added a sticky search input (autofocus on open, case-
+  insensitive substring), bumped the panel max height from 320px to
+  `min(70vh, 520px)` so larger lists no longer require dozens of
+  scrolls. (#111)
+
+### Upgrading
+
+If you plan to use the new EKS Upgrade Insights or Node Groups
+features, extend Periscope's AWS role with the following IAM actions
+(scoped as shown):
+
+- `eks:ListInsights`, `eks:DescribeInsight`
+- `eks:ListNodegroups`, `eks:DescribeNodegroup`
+- `ssm:GetParameter` (resource: `arn:aws:ssm:*::parameter/aws/service/eks/*`
+  and `arn:aws:ssm:*::parameter/aws/service/bottlerocket/*`)
+- `ec2:DescribeImages` (resource: `*` — the API has no per-image ARN)
+
+The full IAM policy snippet is in
+[`docs/setup/deploy.md` §4.1](docs/setup/deploy.md). The Helm chart
+itself does not change; non-EKS clusters and existing features
+continue to work without these additions.
 ## [1.0.0]
 
 Initial stable release.

--- a/deploy/helm/periscope-agent/Chart.yaml
+++ b/deploy/helm/periscope-agent/Chart.yaml
@@ -42,12 +42,8 @@ annotations:
   # workflow can sync these from PR titles since the previous tag
   # (matches the server chart's convention).
   artifacthub.io/changes: |
-    - kind: added
-      description: initial agent backend release — per-cluster tunnel client
-    - kind: added
-      description: mTLS-pinned WebSocket dial-out to the central tunnel listener
-    - kind: added
-      description: persisted state Secret (cert + key + server CA) for stable identity across restarts
+    - kind: changed
+      description: "Tracks server v1.0.3 — no agent-side protocol or compatibility changes (server N is compatible with agent N and N-1, unchanged)"
   # Cosign keyless signing (Sigstore). Same signing identity as the
   # server chart — the release workflow signs both in one run. Verify
   # via: cosign verify-blob ... --certificate-oidc-issuer=https://token.actions.githubusercontent.com

--- a/deploy/helm/periscope/Chart.yaml
+++ b/deploy/helm/periscope/Chart.yaml
@@ -44,13 +44,19 @@ annotations:
   # release notes for Artifact Hub's "What changed" panel).
   artifacthub.io/changes: |
     - kind: added
-      description: initial v1.0 stable release
+      description: "Apply YAML dialog — paste / upload multi-doc YAML with dry-run, server-side apply, per-doc RBAC pre-flight, audit per doc"
     - kind: added
-      description: real-time SSE updates for registered resource kinds
+      description: "EKS Upgrade Insights viewer with deep links from affected resources to the YAML editor"
     - kind: added
-      description: searchable SQLite-backed audit log
+      description: "EKS managed node groups view with current AMI release version and days-behind-latest drift detection (SSM primary, EC2 DescribeImages fallback)"
     - kind: added
-      description: read-only Helm release browser with revision diff
+      description: "Workload rollback for Deployment / StatefulSet / DaemonSet with revision diff preview and GitOps / paused / HPA pre-flight warnings"
+    - kind: added
+      description: "SSE watch streams extended to ConfigMaps, ResourceQuotas, LimitRanges, ServiceAccounts"
+    - kind: changed
+      description: "AWS SDK errors mapped to meaningful HTTP statuses (403/404/429) and stable codes (E_AWS_FORBIDDEN, E_AWS_NOT_FOUND, E_AWS_THROTTLED) instead of collapsing every error to 502"
+    - kind: fixed
+      description: "NamespacePicker dropdown no longer clipped at the viewport edge or painted over by the FilterStrip; gained a search input and a taller responsive panel"
   # Cosign signing — Artifact Hub will display a "Signed" badge when
   # the chart is verifiable via cosign. The signKey block teaches it
   # how to verify; for keyless (Sigstore) signatures the URL points


### PR DESCRIPTION
## Summary

Prep for cutting **v1.0.3-rc1** — release-notes housekeeping, no functional changes.

- `CHANGELOG.md`: kept `[Unreleased]` as an empty placeholder, added `[1.0.3-rc1] - 2026-05-06` below it.
  - **Added**: Apply YAML (#53/#54/#55), EKS Upgrade Insights (#103), EKS managed node groups + AMI drift (#103), workload rollback (#71), SSE watch-stream expansion (#17).
  - **Changed**: AWS SDK errors classified by `smithy.APIError` code → meaningful HTTP statuses + stable codes (`E_AWS_FORBIDDEN`, `E_AWS_NOT_FOUND`, `E_AWS_THROTTLED`) instead of always `502 / E_AWS_API`. Helm `values.schema.json` strictly validates `watchStreams.kinds`.
  - **Fixed**: NamespacePicker clipping/overlay/search (#111).
  - **Upgrading**: explicit note that operators using the new EKS surfaces must extend the AWS role with `eks:ListInsights`, `eks:DescribeInsight`, `eks:ListNodegroups`, `eks:DescribeNodegroup`, `ssm:GetParameter` (scoped), `ec2:DescribeImages`. Full snippet in `docs/setup/deploy.md`.
- `deploy/helm/periscope/Chart.yaml`: refreshed `artifacthub.io/changes` from the v1.0.0 initial-release entries to the v1.0.3 shipping content (5 added / 1 changed / 1 fixed). Artifact Hub renders this on the chart's "What changed" panel.
- `deploy/helm/periscope-agent/Chart.yaml`: single tracker entry — no agent-side changes this release; the N / N-1 server-agent compatibility window is unchanged.

## Why now

v1.0.3-rc1 will be the first release with substantive feature additions since v1.0.0 (v1.0.1/v1.0.2 were small fixes that skipped the CHANGELOG). Artifact Hub's per-chart "What changed" panel is currently still pinned to the v1.0.0 bullets, which is misleading for users browsing the chart page.

After this lands, tag `v1.0.3-rc1` to trigger the release workflow (`.github/workflows/release.yaml`) — it builds the multi-arch image, packages + signs both Helm charts, generates the SBOM, and opens the GitHub pre-release with auto-generated PR-title notes.

## Validation

- [x] Both `Chart.yaml` files parse as valid YAML.
- [x] `helm lint deploy/helm/periscope` — clean (`0 chart(s) failed`).
- [x] `helm lint deploy/helm/periscope-agent --set agent.clusterName=test --set agent.serverURL=wss://example.com/api/agents/connect` — clean. (Default-values lint fails on pre-existing required-field schema strictness, unrelated to this PR.)
- [x] CHANGELOG section ordering: `[Unreleased]` → `[1.0.3-rc1]` → `[1.0.0]`.

## Test plan

- [ ] Maintainer review of the CHANGELOG bullets — accuracy, tone, completeness.
- [ ] Spot-check both `artifacthub.io/changes` blocks render correctly on Artifact Hub once published (post-tag).
- [ ] After merge, tag `v1.0.3-rc1` and confirm the release workflow runs green; verify the GitHub pre-release picks up the chart artifacts and the image is signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)