### PR TITLE
fix(eks): EKS Insights / Node Groups work on any backend with ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ tag.
 
 ## [Unreleased]
 
+### Fixed
+
+- EKS Upgrade Insights and Node Groups surfaces now work on
+  `in-cluster`, `agent`, and `kubeconfig` backends when the cluster
+  entry has both `arn` and `region` set. Before this fix, the
+  surfaces 422'd on any non-`eks` backend regardless of ARN, so an
+  operator running Periscope inside an EKS cluster (`backend:
+  in-cluster`, ARN configured for AWS-side queries) saw "this
+  cluster is not backed by EKS" instead of the actual insights.
+  The K8s-auth backend and the AWS-side EKS metadata are now
+  treated as orthogonal, with the same field validation
+  (`arn` + `region` together, ARN parseable to `:cluster/<name>`)
+  applied uniformly. Surfaced via a new `Cluster.EKSCapable()`
+  method; registry validation rejects mismatched configurations
+  (ARN without region, malformed ARN) at startup.
+
 ## [1.0.3-rc1] - 2026-05-06
 
 ### Added

--- a/cmd/periscope/eks_insights_handler.go
+++ b/cmd/periscope/eks_insights_handler.go
@@ -196,7 +196,7 @@ func eksInsightsListHandler(reg *clusters.Registry, cache *eksInsightsCache, emi
 			http.Error(w, "cluster not found", http.StatusNotFound)
 			return
 		}
-		if !isEKSBackend(c) {
+		if !c.EKSCapable() {
 			// No audit row here — the backend mismatch is a SPA-side
 			// branch, not a privileged action that needs a forensic
 			// record. The SPA only hits this endpoint speculatively
@@ -258,7 +258,7 @@ func eksInsightsGetHandler(reg *clusters.Registry, cache *eksInsightsCache, emit
 			http.Error(w, "cluster not found", http.StatusNotFound)
 			return
 		}
-		if !isEKSBackend(c) {
+		if !c.EKSCapable() {
 			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
 				errBackendNotEKSCode,
 				"upgrade insights are only available for EKS-backed clusters")
@@ -432,12 +432,6 @@ func mapDeprecationDetail(in *ekstypes.DeprecationDetail) DeprecationDetail {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
-
-func isEKSBackend(c clusters.Cluster) bool {
-	// Empty backend defaults to EKS — same convention as
-	// internal/k8s/client.go's buildRestConfig switch.
-	return c.Backend == clusters.BackendEKS || c.Backend == ""
-}
 
 func insightStatus(s *ekstypes.InsightStatus) string {
 	if s == nil {

--- a/cmd/periscope/eks_insights_handler_test.go
+++ b/cmd/periscope/eks_insights_handler_test.go
@@ -86,6 +86,24 @@ func eksRegistry(t *testing.T, name, backend string) *clusters.Registry {
 		yaml = "clusters:\n" +
 			"  - name: " + name + "\n" +
 			"    backend: agent\n"
+	case "in-cluster+arn":
+		// in-cluster cluster that ALSO supplies the EKS ARN+Region —
+		// the supported pattern when the server runs inside an EKS
+		// cluster and uses its ServiceAccount for K8s auth, but
+		// still wants EKS Insights / Node Groups via Pod Identity.
+		yaml = "clusters:\n" +
+			"  - name: " + name + "\n" +
+			"    backend: in-cluster\n" +
+			"    arn: arn:aws:eks:eu-west-1:111111111111:cluster/" + name + "\n" +
+			"    region: eu-west-1\n"
+	case "agent+arn":
+		// agent-backed cluster with EKS metadata — K8s traffic flows
+		// over the tunnel, AWS API traffic goes server → AWS.
+		yaml = "clusters:\n" +
+			"  - name: " + name + "\n" +
+			"    backend: agent\n" +
+			"    arn: arn:aws:eks:eu-west-1:111111111111:cluster/" + name + "\n" +
+			"    region: eu-west-1\n"
 	default:
 		t.Fatalf("eksRegistry: unhandled backend %q", backend)
 	}
@@ -230,6 +248,45 @@ func TestEKSInsightsList_AgentBackendReturns422(t *testing.T) {
 		map[string]string{"cluster": "edge-1"}, false)
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}
+
+// TestEKSInsightsList_CapableNonEKSBackends asserts the EKS gate
+// reflects ARN+Region capability rather than the K8s-auth backend.
+// in-cluster and agent backends with EKS metadata should bypass the
+// 422 envelope and reach the AWS call (here served by a fake).
+// Regression cover for v1.0.3-rc1 where isEKSBackend rejected any
+// non-eks backend regardless of ARN.
+func TestEKSInsightsList_CapableNonEKSBackends(t *testing.T) {
+	cases := []struct {
+		name    string
+		backend string
+		cluster string
+	}{
+		{"in-cluster + arn", "in-cluster+arn", "self"},
+		{"agent + arn", "agent+arn", "pre-prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := eksRegistry(t, tc.cluster, tc.backend)
+			fake := &fakeEKSInsightsClient{
+				listFn: func(_ context.Context, _ *eks.ListInsightsInput) (*eks.ListInsightsOutput, error) {
+					return &eks.ListInsightsOutput{}, nil
+				},
+			}
+			withFakeEKSClient(t, fake)
+			sink := &recordingSink{}
+			cache := newEKSInsightsCache(time.Hour)
+			rec := invokeInsights(t, reg, cache, sink, http.MethodGet,
+				"/api/clusters/"+tc.cluster+"/eks/upgrade-insights",
+				map[string]string{"cluster": tc.cluster}, false)
+			if rec.Code == http.StatusUnprocessableEntity {
+				t.Fatalf("status = 422 (gate rejected capable cluster); want non-422")
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+		})
 	}
 }
 

--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -178,7 +178,7 @@ func eksNodegroupsListHandler(reg *clusters.Registry, cache *eksNodegroupsCache,
 			http.Error(w, "cluster not found", http.StatusNotFound)
 			return
 		}
-		if !isEKSBackend(c) {
+		if !c.EKSCapable() {
 			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
 				errBackendNotEKSCode,
 				"managed node group introspection is only available for EKS-backed clusters")
@@ -291,7 +291,7 @@ func eksNodegroupsGetHandler(reg *clusters.Registry, cache *eksNodegroupsCache, 
 			http.Error(w, "cluster not found", http.StatusNotFound)
 			return
 		}
-		if !isEKSBackend(c) {
+		if !c.EKSCapable() {
 			writeAPIErrorJSON(w, http.StatusUnprocessableEntity,
 				errBackendNotEKSCode,
 				"managed node group introspection is only available for EKS-backed clusters")

--- a/cmd/periscope/eks_nodegroups_handler_test.go
+++ b/cmd/periscope/eks_nodegroups_handler_test.go
@@ -177,6 +177,44 @@ func TestEKSNodegroupsList_NonEKSReturns422(t *testing.T) {
 	}
 }
 
+// TestEKSNodegroupsList_CapableNonEKSBackends — same regression cover
+// as the insights handler's CapableNonEKSBackends test. Operators
+// running periscope inside an EKS cluster (in-cluster K8s auth) or
+// reaching clusters via the agent tunnel can still query EKS-side
+// node groups as long as ARN + Region are configured.
+func TestEKSNodegroupsList_CapableNonEKSBackends(t *testing.T) {
+	cases := []struct {
+		name    string
+		backend string
+		cluster string
+	}{
+		{"in-cluster + arn", "in-cluster+arn", "self"},
+		{"agent + arn", "agent+arn", "pre-prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := eksRegistry(t, tc.cluster, tc.backend)
+			fake := &fakeEKSNodegroupsClient{
+				listFn: func(_ context.Context, _ *eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+					return &eks.ListNodegroupsOutput{}, nil
+				},
+			}
+			withFakeNodegroupsClient(t, fake)
+			sink := &recordingSink{}
+			cache := newEKSNodegroupsCache(time.Hour)
+			rec := invokeNodegroups(t, reg, cache, sink,
+				"/api/clusters/"+tc.cluster+"/eks/nodegroups",
+				map[string]string{"cluster": tc.cluster}, false)
+			if rec.Code == http.StatusUnprocessableEntity {
+				t.Fatalf("status = 422 (gate rejected capable cluster); want non-422")
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+		})
+	}
+}
+
 func TestEKSNodegroupsList_AWSListErrorEmitsFailureAudit(t *testing.T) {
 	reg := eksRegistry(t, "prod-eu-west-1", clusters.BackendEKS)
 	fake := &fakeEKSNodegroupsClient{

--- a/docs/setup/eks-upgrade-readiness.md
+++ b/docs/setup/eks-upgrade-readiness.md
@@ -7,6 +7,8 @@ Two surfaces, both EKS-only, both pure read-only:
 
 Both surfaces ship as part of issue #103 and are paired in the UI on the cluster overview page so an operator preparing an upgrade can see "are my manifests OK *and* are my node images current?" in one place.
 
+> **Backend-independent.** These features are AWS-side API queries (`eks:*`, `ssm:*`, `ec2:DescribeImages`) — they do **not** touch the cluster's apiserver. They light up on any registered cluster as long as the cluster entry has both `arn` *and* `region` set, regardless of how Periscope authenticates to that cluster's K8s API. A common pattern: Periscope deployed inside an EKS cluster with `backend: in-cluster` (using the pod ServiceAccount for K8s auth) plus `arn` + `region` set so the same cluster also gets EKS Insights / Node Groups via the pod's IAM role. Same applies to `agent`-backed clusters — K8s traffic flows over the tunnel, AWS API traffic goes server→AWS directly.
+
 ---
 
 ## What you see

--- a/internal/clusters/cluster.go
+++ b/internal/clusters/cluster.go
@@ -133,3 +133,26 @@ func (c Cluster) EKSName() string {
 	}
 	return ""
 }
+
+// EKSCapable reports whether the cluster has the AWS-side metadata
+// (ARN + Region + parseable EKS name) needed to call EKS APIs like
+// ListInsights and ListNodegroups.
+//
+// Independent of the K8s-auth backend — an in-cluster, agent, or
+// kubeconfig cluster is just as capable of EKS-side queries as a
+// BackendEKS cluster, as long as the operator wired up the ARN
+// + Region. The two concerns (K8s identity vs AWS identity) are
+// orthogonal: in-cluster authenticates to the apiserver via the
+// pod ServiceAccount, but Periscope can still call AWS EKS APIs
+// for that cluster's ARN using the pod's IAM role (Pod Identity /
+// IRSA). Same for agent-backed clusters: K8s traffic flows over
+// the tunnel, but AWS API traffic goes server → AWS directly.
+//
+// Registry validation guarantees: when ARN is set on any backend,
+// Region is also required and the ARN parses cleanly. So this
+// method's three-way check is defense-in-depth — any single false
+// branch means a misconfiguration that should have failed at load
+// time.
+func (c Cluster) EKSCapable() bool {
+	return c.ARN != "" && c.Region != "" && c.EKSName() != ""
+}

--- a/internal/clusters/registry.go
+++ b/internal/clusters/registry.go
@@ -87,6 +87,25 @@ func LoadFromFile(path string) (*Registry, error) {
 				c.Name, c.Backend, BackendEKS, BackendKubeconfig, BackendInCluster, BackendAgent)
 		}
 
+		// EKS-side metadata (ARN + Region) is orthogonal to the
+		// K8s-auth backend — in-cluster / agent / kubeconfig clusters
+		// can opt in to EKS Upgrade Insights, Node Groups, and AMI
+		// drift by providing the EKS ARN. When they do, the same
+		// validation that BackendEKS enforces applies, so AWS calls
+		// have a real region to dial and a parseable cluster name.
+		// Skipped for BackendEKS because the switch above already
+		// validated. Operators who omit ARN here keep the backend's
+		// no-EKS shape; the EKS handlers then return 422 with
+		// E_BACKEND_NOT_EKS as before.
+		if c.Backend != BackendEKS && c.ARN != "" {
+			if c.Region == "" {
+				return nil, fmt.Errorf("cluster %q (%s): arn is set but region is empty — both are required to enable EKS APIs", c.Name, c.Backend)
+			}
+			if c.EKSName() == "" {
+				return nil, fmt.Errorf("cluster %q (%s): invalid ARN %q (expected ':cluster/<name>')", c.Name, c.Backend, c.ARN)
+			}
+		}
+
 		if _, dup := byName[c.Name]; dup {
 			return nil, fmt.Errorf("duplicate cluster name %q", c.Name)
 		}

--- a/internal/clusters/registry_test.go
+++ b/internal/clusters/registry_test.go
@@ -148,6 +148,13 @@ func TestLoadFromFile_errors(t *testing.T) {
 		{"eks: missing arn", "clusters:\n  - name: a\n    region: us-east-1\n"},
 		{"eks: missing region", "clusters:\n  - name: a\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n"},
 		{"eks: invalid arn", "clusters:\n  - name: a\n    arn: not-an-arn\n    region: us-east-1\n"},
+		// ARN+Region pairing on non-EKS backends — operator opted into
+		// EKS-side metadata but did not supply the matching region or a
+		// parseable ARN. Same enforcement as BackendEKS so AWS calls
+		// have a real region to dial and a parseable cluster name.
+		{"in-cluster: arn without region", "clusters:\n  - name: a\n    backend: in-cluster\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n"},
+		{"agent: malformed arn", "clusters:\n  - name: a\n    backend: agent\n    arn: not-an-arn\n    region: us-east-1\n"},
+		{"kubeconfig: arn without region", "clusters:\n  - name: a\n    backend: kubeconfig\n    kubeconfigPath: /tmp/kc\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n"},
 		{"kubeconfig: missing path", "clusters:\n  - name: a\n    backend: kubeconfig\n"},
 		{"unknown backend", "clusters:\n  - name: a\n    backend: weird\n"},
 		{"duplicate name", `
@@ -284,5 +291,85 @@ func TestLoadFromFile_emptyRegistryReturnsEmpty(t *testing.T) {
 	}
 	if got := len(r.List()); got != 0 {
 		t.Errorf("List() len = %d, want 0", got)
+	}
+}
+
+func TestCluster_EKSCapable(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		want    bool
+		cluster string
+	}{
+		{
+			name: "eks backend (canonical)",
+			yaml: "clusters:\n" +
+				"  - name: prod\n" +
+				"    arn: arn:aws:eks:us-east-1:1:cluster/prod\n" +
+				"    region: us-east-1\n",
+			cluster: "prod",
+			want:    true,
+		},
+		{
+			name: "in-cluster + arn + region",
+			yaml: "clusters:\n" +
+				"  - name: self\n" +
+				"    backend: in-cluster\n" +
+				"    arn: arn:aws:eks:us-west-2:1:cluster/self\n" +
+				"    region: us-west-2\n",
+			cluster: "self",
+			want:    true,
+		},
+		{
+			name: "agent + arn + region",
+			yaml: "clusters:\n" +
+				"  - name: pre-prod\n" +
+				"    backend: agent\n" +
+				"    arn: arn:aws:eks:us-west-2:1:cluster/pre-prod\n" +
+				"    region: us-west-2\n",
+			cluster: "pre-prod",
+			want:    true,
+		},
+		{
+			name: "in-cluster (no arn) — not capable",
+			yaml: "clusters:\n" +
+				"  - name: kind-local\n" +
+				"    backend: in-cluster\n",
+			cluster: "kind-local",
+			want:    false,
+		},
+		{
+			name: "agent (no arn) — not capable",
+			yaml: "clusters:\n" +
+				"  - name: edge-1\n" +
+				"    backend: agent\n",
+			cluster: "edge-1",
+			want:    false,
+		},
+		{
+			name: "kubeconfig (no arn) — not capable",
+			yaml: "clusters:\n" +
+				"  - name: dev\n" +
+				"    backend: kubeconfig\n" +
+				"    kubeconfigPath: /tmp/kc\n",
+			cluster: "dev",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeTempFile(t, tc.yaml)
+			r, err := LoadFromFile(p)
+			if err != nil {
+				t.Fatalf("LoadFromFile: %v", err)
+			}
+			c, ok := r.ByName(tc.cluster)
+			if !ok {
+				t.Fatalf("cluster %q not found in registry", tc.cluster)
+			}
+			if got := c.EKSCapable(); got != tc.want {
+				t.Errorf("EKSCapable() = %v, want %v (cluster=%+v)", got, tc.want, c)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

**v1.0.3-rc1 hotfix candidate.** EKS Upgrade Insights and Node Groups (added in v1.0.3-rc1) only work for clusters with `backend: eks`. The check `isEKSBackend()` was too restrictive — it conflated K8s-auth backend with AWS-side EKS metadata, two orthogonal concerns:

- **K8s-auth backend** (`eks` / `in-cluster` / `agent` / `kubeconfig`) controls how Periscope authenticates to the apiserver.
- **AWS-side EKS metadata** (`arn` + `region`) controls whether Periscope can call EKS APIs (`eks:ListInsights`, `eks:DescribeNodegroup`, etc.) for that cluster — independent of how K8s auth happens.

The most common production deployment shape — Periscope running inside an EKS cluster with `backend: in-cluster` (using the pod ServiceAccount, no IAM Access Entry needed) but with `arn`/`region` set so the same cluster also surfaces EKS Insights via Pod Identity — was broken in rc1: the SPA showed *"Upgrade insights are an EKS feature; this cluster is not backed by EKS"* even though the AWS calls would have succeeded.

## Changes

- `internal/clusters/cluster.go`: new `Cluster.EKSCapable()` method — returns true iff `ARN != "" && Region != "" && EKSName() != ""`. Documents the orthogonality.
- `internal/clusters/registry.go`: validation block after the per-backend switch — when `ARN` is set on any non-`eks` backend, require `Region` and a parseable ARN. Mismatched configs (ARN without region, malformed ARN) fail at startup with a clear error rather than at AWS-call time with a cryptic 502.
- `cmd/periscope/eks_insights_handler.go` + `eks_nodegroups_handler.go`: 4 call sites swapped from `isEKSBackend(c)` → `c.EKSCapable()`. Deleted the now-unused `isEKSBackend` helper.
- Tests:
  - `internal/clusters/registry_test.go`: 3 new error cases + new `TestCluster_EKSCapable` (6 backend × ARN matrix scenarios).
  - `cmd/periscope/eks_insights_handler_test.go`: extended `eksRegistry` helper with `in-cluster+arn` and `agent+arn` modes; added `TestEKSInsightsList_CapableNonEKSBackends`.
  - `cmd/periscope/eks_nodegroups_handler_test.go`: mirror `TestEKSNodegroupsList_CapableNonEKSBackends`.
  - Existing `TestEKSInsightsList_AgentBackendReturns422` and `TestEKSNodegroupsList_NonEKSReturns422` preserved — they now cover the "no ARN" branch of the same gate.
- `docs/setup/eks-upgrade-readiness.md`: blockquote near the top making backend-orthogonality explicit, with the in-cluster + ARN pattern documented as the supported shape.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Behavior matrix

| Backend | ARN set | Region set | Before this PR | After this PR |
|---|---|---|---|---|
| `eks` | ✓ (required) | ✓ (required) | ✅ EKS surfaces work | ✅ EKS surfaces work |
| `in-cluster` | ✗ | — | ❌ 422 (correct) | ❌ 422 (correct) |
| `in-cluster` | ✓ | ✓ | ❌ 422 (bug) | ✅ EKS surfaces work |
| `in-cluster` | ✓ | ✗ | ❌ 422 (bug) + cryptic AWS error if you bypassed | ❌ Registry rejects at startup |
| `agent` | ✗ | — | ❌ 422 (correct) | ❌ 422 (correct) |
| `agent` | ✓ | ✓ | ❌ 422 (bug) | ✅ EKS surfaces work |
| `kubeconfig` | ✓ | ✓ | ❌ 422 (bug) | ✅ EKS surfaces work |

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all green
- [x] `npx tsc --noEmit`, `npm run lint`, `vitest` — 125/125 pass (frontend untouched)
- [ ] Tag `v1.0.3-rc2` from this commit after merge.
- [ ] Smoke `gtm-it-dev-stage-prod` (`backend: in-cluster` + ARN) — should now show Upgrade Insights + Node Groups.
- [ ] Smoke `pre-prod` (`backend: agent` + ARN) — same expectation.
- [ ] Verify a misconfigured cluster (e.g. `backend: in-cluster` + ARN without region) fails at pod startup with a clear error message in the logs.
- [ ] If smoke passes → tag `v1.0.3` from the same SHA as `v1.0.3-rc2`.

## Release context

This is a hotfix for v1.0.3-rc1. Branched off `main` at the rc1 SHA (no helm-write PRs merged into main yet, per the v1.0.3 release-train hold). After merge:

```sh
git fetch origin --tags
git tag -a v1.0.3-rc2 -m "v1.0.3-rc2"
git push origin v1.0.3-rc2
```

Release workflow rebuilds image + chart as `1.0.3-rc2`. Once smoke confirms, tag `v1.0.3` from the same commit.

## Out of scope

- **Hide EKS tab when not capable** in the SPA. Currently the page renders for every cluster and falls back to the empty state on 422. Tracked separately — needs `EKSCapable` shipped on the cluster shape served by the API. Would land in v1.0.4 or v1.1.0.
- **Cross-account ARN handling** in IAM. The role still needs `eks:*` permissions covering the cluster ARN; cross-account requires a role assumption chain, which is operator-managed via IAM trust policies (out of Periscope's scope). Worth a future doc note.
- **Agent disconnect during server restart** — flagged in the bug report as expected behavior; agent reconnects with exponential backoff. No change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)