### PR TITLE
chore: add Go fuzz tests for OpenSSF Scorecard Fuzzing check

### DIFF
--- a/cmd/periscope/eks_insights_uri.go
+++ b/cmd/periscope/eks_insights_uri.go
@@ -168,7 +168,17 @@ func parseKubernetesResourceURI(cluster, uri string) (parsedResourceURI, bool) {
 		Namespace: ns,
 		Name:      name,
 	}
+	// buildEditorPath returns "" for unmappable shapes (e.g. an
+	// unknown plural without a group+version pair). Promote that
+	// signal into ok=false so callers don't render a struct that
+	// has no actionable EditorPath. Without this, a URI like
+	// "api//0/0" parses to {plural:"0",name:"0"} but produces no
+	// route, and the SPA renders a dead link. Caught by
+	// FuzzParseKubernetesResourceURI.
 	out.EditorPath = buildEditorPath(cluster, group, version, plural, ns, name)
+	if out.EditorPath == "" {
+		return parsedResourceURI{}, false
+	}
 	return out, true
 }
 

--- a/cmd/periscope/eks_insights_uri_test.go
+++ b/cmd/periscope/eks_insights_uri_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestParseKubernetesResourceURI exercises every shape EKS can
 // realistically return: namespaced/cluster-scoped × core/named-group
@@ -201,4 +204,74 @@ func TestParseKubernetesResourceURI_EmptyCluster(t *testing.T) {
 	if _, ok := parseKubernetesResourceURI("", "/api/v1/namespaces/default/pods/nginx"); ok {
 		t.Fatalf("expected ok=false when cluster name is empty")
 	}
+}
+
+// FuzzParseKubernetesResourceURI hunts for panics or
+// pathological-string crashes in the EKS-Insights URI mapper.
+// Inputs come from AWS via DescribeInsight; while the AWS console
+// canonicalises them, we treat the value as untrusted and expect
+// the parser to either return (zero, false) or a fully-formed
+// EditorPath — never panic.
+//
+// Properties asserted per fuzz iteration:
+//
+//  1. No panic for any (cluster, uri) pair.
+//  2. When ok is true, EditorPath must start with "/clusters/" and
+//     contain the cluster name segment, so the SPA router will
+//     handle it cleanly. This catches regressions where a malformed
+//     URI sneaks through the switch and produces a half-built path.
+//  3. Empty cluster name always returns ok=false (existing contract).
+//
+// Run locally with: go test ./cmd/periscope/ -run none -fuzz FuzzParseKubernetesResourceURI -fuzztime 30s
+func FuzzParseKubernetesResourceURI(f *testing.F) {
+	// Seed corpus — real shapes EKS Upgrade Insights returns, plus
+	// a few adversarial cases (empty path, all-slashes, very long
+	// segments, percent-encoded, unicode).
+	type seed struct {
+		cluster, uri string
+	}
+	seeds := []seed{
+		{"prod-eu-west-1", "/api/v1/namespaces/default/pods/nginx"},
+		{"prod-eu-west-1", "/apis/apps/v1/namespaces/kube-system/deployments/coredns"},
+		{"prod-eu-west-1", "/api/v1/nodes/ip-10-0-0-1"},
+		{"prod-eu-west-1", "/apis/policy/v1beta1/namespaces/default/poddisruptionbudgets/my-pdb"},
+		{"prod-eu-west-1", ""},
+		{"prod-eu-west-1", "/"},
+		{"prod-eu-west-1", "//"},
+		{"prod-eu-west-1", "/api"},
+		{"prod-eu-west-1", "/api/v1"},
+		{"prod-eu-west-1", "/api/v1/namespaces"},
+		{"prod-eu-west-1", "/apis///"},
+		{"prod-eu-west-1", "/api/v1/namespaces/default/pods/" + strings.Repeat("a", 1024)},
+		{"prod-eu-west-1", "/apis/example.com/v1alpha1/namespaces/team/awesomethings/foo"},
+		{"prod-eu-west-1", "/api/v1/namespaces/default/pods/nginx?injected=true"},
+		{"", "/api/v1/namespaces/default/pods/nginx"},
+		{"cluster with spaces", "/api/v1/pods/nginx"},
+		{"prod", "/api/v1/namespaces/默认/pods/网站"},
+	}
+	for _, s := range seeds {
+		f.Add(s.cluster, s.uri)
+	}
+
+	f.Fuzz(func(t *testing.T, cluster, uri string) {
+		got, ok := parseKubernetesResourceURI(cluster, uri)
+
+		// Property 1 — no panic, implicit (test runner catches it).
+
+		// Property 2 — when the parser returns a path, the path must
+		// be well-formed enough for the SPA router not to misroute.
+		if ok {
+			if got.EditorPath == "" {
+				t.Fatalf("ok=true but EditorPath is empty for cluster=%q uri=%q", cluster, uri)
+			}
+			if !strings.HasPrefix(got.EditorPath, "/clusters/") {
+				t.Fatalf("EditorPath %q lacks /clusters/ prefix (cluster=%q uri=%q)", got.EditorPath, cluster, uri)
+			}
+		}
+
+		// Property 3 — empty cluster name is a hard reject contract.
+		if cluster == "" && ok {
+			t.Fatalf("empty cluster should always reject; got ok=true for uri=%q", uri)
+		}
+	})
 }

--- a/cmd/periscope/testdata/fuzz/FuzzParseKubernetesResourceURI/732daf56bc8f2acf
+++ b/cmd/periscope/testdata/fuzz/FuzzParseKubernetesResourceURI/732daf56bc8f2acf
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0")
+string("api//0/0")

--- a/internal/clusters/registry.go
+++ b/internal/clusters/registry.go
@@ -34,10 +34,24 @@ func LoadFromFile(path string) (*Registry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read registry %q: %w", path, err)
 	}
+	r, err := LoadFromBytes(raw)
+	if err != nil {
+		return nil, fmt.Errorf("registry %q: %w", path, err)
+	}
+	return r, nil
+}
 
+// LoadFromBytes parses the registry YAML directly from a byte slice
+// and returns a Registry. Same validation as LoadFromFile minus the
+// I/O wrapper; the path-bearing wrapper adds it via fmt.Errorf so
+// operator-facing errors keep file context.
+//
+// Exposed for tests and fuzzing — production callers should use
+// LoadFromFile.
+func LoadFromBytes(raw []byte) (*Registry, error) {
 	var f registryFile
 	if err := yaml.Unmarshal(raw, &f); err != nil {
-		return nil, fmt.Errorf("parse registry %q: %w", path, err)
+		return nil, fmt.Errorf("parse: %w", err)
 	}
 
 	if len(f.Clusters) == 0 {

--- a/internal/clusters/registry_test.go
+++ b/internal/clusters/registry_test.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -249,7 +250,7 @@ clusters:
 	if dev.Environment != "" {
 		t.Errorf("dev.Environment = %q, want empty", dev.Environment)
 	}
-	if dev.Tags != nil && len(dev.Tags) != 0 {
+	if len(dev.Tags) != 0 {
 		t.Errorf("dev.Tags = %v, want nil/empty", dev.Tags)
 	}
 }
@@ -372,4 +373,94 @@ func TestCluster_EKSCapable(t *testing.T) {
 			}
 		})
 	}
+}
+
+// FuzzLoadRegistryBytes hammers the registry YAML loader with
+// arbitrary byte sequences. Operator-supplied input — a pod that
+// panics on a typo'd config is worse than one that errors cleanly,
+// so the contract under fuzz is "either a valid Registry or a
+// non-nil error, never a panic".
+//
+// We additionally check that any cluster present in a successfully-
+// loaded registry passes the same invariants the loader enforces:
+// non-empty name, recognized backend, and (when ARN is set on any
+// backend) a parseable EKSName + non-empty Region. This catches
+// regressions where new validation paths leak through.
+//
+// Run locally with:
+//
+//	go test ./internal/clusters/ -run none -fuzz FuzzLoadRegistryBytes -fuzztime 30s
+func FuzzLoadRegistryBytes(f *testing.F) {
+	// Seed corpus — happy paths plus the kinds of malformed YAML an
+	// operator could realistically paste in (anchors, merge keys,
+	// numeric vs string scalar coercion, deeply nested aliases).
+	seeds := []string{
+		``,
+		`clusters: []`,
+		"clusters:\n  - name: a\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n    region: us-east-1\n",
+		"clusters:\n  - name: a\n    backend: in-cluster\n",
+		"clusters:\n  - name: a\n    backend: agent\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n    region: us-east-1\n",
+		"clusters:\n  - name: a\n    backend: kubeconfig\n    kubeconfigPath: /tmp/kc\n",
+		"clusters:\n  - name: a\n    backend: weird\n",
+		"clusters:\n  - name: a\n    arn: not-an-arn\n    region: us-east-1\n",
+		"clusters:\n  - {}\n",
+		"clusters: 42",
+		"clusters:\n  - &x\n    name: a\n    arn: arn:aws:eks:us-east-1:1:cluster/a\n    region: us-east-1\n  - <<: *x\n    name: b\n",
+		"clusters:\n  - name: \"\\x00\"\n    backend: in-cluster\n",
+		strings.Repeat("a: b\n", 1000),
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		// 64 KiB is well above any realistic cluster registry; cap
+		// here so the fuzzer doesn't burn cycles on multi-MB inputs
+		// that don't materially expand coverage. Real-world the file
+		// is read from disk so size is operator-bounded anyway.
+		if len(raw) > 64*1024 {
+			t.Skip("oversized input — out of realistic config-file range")
+		}
+
+		reg, err := LoadFromBytes(raw)
+
+		// Property 1 — exactly one of (reg, err) is non-nil.
+		switch {
+		case reg == nil && err == nil:
+			t.Fatalf("both reg and err are nil")
+		case reg != nil && err != nil:
+			t.Fatalf("both reg and err are non-nil: reg=%+v err=%v", reg, err)
+		}
+
+		if reg == nil {
+			return
+		}
+
+		// Property 2 — every loaded cluster satisfies invariants.
+		for _, c := range reg.List() {
+			if c.Name == "" {
+				t.Fatalf("loaded cluster has empty Name: %+v", c)
+			}
+			switch c.Backend {
+			case BackendEKS, BackendKubeconfig, BackendInCluster, BackendAgent:
+				// recognized
+			default:
+				t.Fatalf("loaded cluster has unrecognized Backend %q: %+v", c.Backend, c)
+			}
+			// When ARN is set on any backend, the loader must have
+			// validated Region presence + ARN parseability. The
+			// EKSCapable invariant should hold uniformly.
+			if c.ARN != "" {
+				if c.Region == "" {
+					t.Fatalf("loaded cluster %q has ARN but empty Region", c.Name)
+				}
+				if c.EKSName() == "" {
+					t.Fatalf("loaded cluster %q has unparseable ARN %q", c.Name, c.ARN)
+				}
+				if !c.EKSCapable() {
+					t.Fatalf("loaded cluster %q has ARN+Region but EKSCapable=false: %+v", c.Name, c)
+				}
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Add native Go fuzzing for two parser surfaces — the EKS Insights URI mapper and the cluster-registry YAML loader. Both run as part of the normal `go test` pipeline (seed corpus mode) and can be fuzzed continuously with `-fuzz=FuzzName -fuzztime=...`.

**Lights up [OpenSSF Scorecard's Fuzzing check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing): 0 → 10**, and gives defense-in-depth against parser regressions on operator- and AWS-supplied inputs.

## Changes

- `internal/clusters/registry.go`: extract `LoadFromBytes(raw []byte)` from `LoadFromFile` so the fuzz target avoids per-iteration tempfile IO. Non-breaking — `LoadFromFile` now wraps `LoadFromBytes` and adds the path to error messages.
- `internal/clusters/registry_test.go`: `FuzzLoadRegistryBytes` with 13 seed inputs (happy paths + adversarial YAML — anchors, merge keys, null bytes, large repetitions). Asserts:
  - exactly one of `(reg, err)` is non-nil
  - every loaded cluster satisfies post-load invariants (Name non-empty, Backend recognized, ARN ⇒ Region+EKSName+EKSCapable)
- `internal/clusters/registry_test.go`: drive-by lint fix on `TestLoadFromFile_environmentAndTags` — drop the redundant `dev.Tags != nil &&` (len of nil map is 0).
- `cmd/periscope/eks_insights_uri_test.go`: `FuzzParseKubernetesResourceURI` with 17 seed inputs (real AWS shapes + adversarial: empty, all-slashes, very long segments, query strings, unicode). Asserts:
  - no panic
  - `ok=true` ⇒ `EditorPath` has `/clusters/` prefix
  - empty cluster always rejects
- **`cmd/periscope/eks_insights_uri.go`: bug fix surfaced by the URI fuzzer in <1 second.**
- `cmd/periscope/testdata/fuzz/FuzzParseKubernetesResourceURI/732daf56bc8f2acf`: recorded crash input — becomes permanent regression corpus.

## Bug found by the fuzzer

Input: `cluster="0", uri="api//0/0"`. Trace:

- `strings.TrimPrefix(uri, "/")` leaves `"api//0/0"` unchanged (no leading slash).
- `strings.Split` → `["api", "", "0", "0"]` — note the empty `version` segment from the `//`.
- The `api` branch sets `version=""`, `rest=["0","0"]`.
- Treated as cluster-scoped: `plural="0"`, `name="0"`.
- `buildEditorPath` returned `""` (plural unknown + group/version empty).
- **Parser returned `ok=true` with `EditorPath=""`** → the SPA would render a dead link.

**Fix:** when `buildEditorPath` returns `""`, promote that to `ok=false` so callers don't get a parsed struct with no actionable path. The recorded crash input is now permanent corpus — `go test ./cmd/periscope/` automatically replays it as a regression test.

## Verification

- [x] `go build`, `go vet`, `go test ./...` — all green.
- [x] `FuzzParseKubernetesResourceURI -fuzztime 10s` — 45k execs, 30 interesting paths, no failures (post-fix).
- [x] `FuzzLoadRegistryBytes -fuzztime 10s` — 266k execs, 324 interesting paths, no failures.
- [x] `npx tsc --noEmit`, `eslint`, `vitest` — frontend untouched, all green.

## Why these two targets

Pure parser/validator surfaces with attacker-influenced or operator-supplied inputs. Both already had unit tests so the fuzz target rides on existing imports:

- `parseKubernetesResourceURI` — input from AWS DescribeInsight; a panic crashes a request.
- `LoadFromBytes` — input from operator config file; a panic kills pod startup.

The `helm_chart_unpack` tarball unpacker (mentioned in the original triage as a candidate) lives on the unmerged `feat/helm-chart-fetch` branch — can be fuzzed in a follow-up once that PR lands.

## CI

No CI changes needed. OpenSSF Scorecard reads source for `Fuzz*(*testing.F)` functions; the existing `.github/workflows/scorecard.yml` will pick this up on its next run. Fuzz targets aren't run continuously in CI here — they're available for ad-hoc deep fuzzing via the commands in the function docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)