### PR TITLE
fix(docs): IAM snippet — eks:DescribeNodegroup needs nodegroup ARN, not cluster ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ tag.
 
 ### Fixed
 
+- IAM policy snippet in `docs/setup/deploy.md` §4.1 and
+  `docs/setup/eks-upgrade-readiness.md` was incomplete: it grouped
+  `eks:DescribeNodegroup` with the cluster-scoped EKS actions under
+  `Resource: arn:aws:eks:*:<account>:cluster/*`. AWS scopes
+  `eks:DescribeNodegroup` to the **nodegroup** resource
+  (`arn:aws:eks:region:account:nodegroup/cluster-name/nodegroup-name/uuid`),
+  not the cluster — so operators following the doc literally got
+  `AccessDenied` on the nodegroup detail / AMI drift endpoints
+  even though the list endpoint worked. Split the policy into two
+  statements (cluster-scoped and nodegroup-scoped), added a "Resource
+  type" column to the action table, and called out the gotcha
+  inline so future readers do not reintroduce it.
+
 - EKS Upgrade Insights and Node Groups surfaces now work on
   `in-cluster`, `agent`, and `kubeconfig` backends when the cluster
   entry has both `arn` and `region` set. Before this fix, the

--- a/docs/setup/deploy.md
+++ b/docs/setup/deploy.md
@@ -181,13 +181,14 @@ already runs.
 
 The trust policy above only says *who* can assume the role. The *permissions* policy attached to the role is what determines which AWS APIs Periscope can call. Required for every EKS-backed cluster:
 
-| Action | Used by |
-|---|---|
-| `eks:DescribeCluster` | Resolves the apiserver endpoint and CA on every K8s call (auth path). |
-| `eks:ListInsights`, `eks:DescribeInsight` | Upgrade Insights surface (`/api/clusters/{c}/eks/upgrade-insights*`). EKS-only by design; non-EKS clusters return 422. Cached server-side for 1 hour since AWS itself only refreshes daily. |
-| `eks:ListNodegroups`, `eks:DescribeNodegroup` | Managed node group surface (`/api/clusters/{c}/eks/nodegroups*`). |
-| `ssm:GetParameter` (scoped to `arn:aws:ssm:*::parameter/aws/service/eks/*` and `arn:aws:ssm:*::parameter/aws/service/bottlerocket/*`) | AMI drift detection — primary "latest AMI" lookup against AWS public parameters. |
-| `ec2:DescribeImages` | AMI drift detection — fallback used when the SSM lookup fails (denied / not found / throttled). |
+| Action | Resource type | Used by |
+|---|---|---|
+| `eks:DescribeCluster` | cluster | Resolves the apiserver endpoint and CA on every K8s call (auth path). |
+| `eks:ListInsights`, `eks:DescribeInsight` | cluster | Upgrade Insights surface (`/api/clusters/{c}/eks/upgrade-insights*`). EKS-only by design; non-EKS clusters return 422. Cached server-side for 1 hour since AWS itself only refreshes daily. |
+| `eks:ListNodegroups` | cluster | Managed node group list (`GET /api/clusters/{c}/eks/nodegroups`). |
+| `eks:DescribeNodegroup` | **nodegroup** | Managed node group detail + AMI drift (`GET /api/clusters/{c}/eks/nodegroups/{name}`). Per [AWS service authorization](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerserviceforkubernetes.html), this action operates on the **nodegroup** resource (`arn:aws:eks:region:account:nodegroup/cluster-name/nodegroup-name/uuid`), **not** the cluster — scoping it to `cluster/*` yields `AccessDenied` even when the nodegroup is inside a covered cluster. |
+| `ssm:GetParameter` (scoped to `arn:aws:ssm:*::parameter/aws/service/eks/*` and `arn:aws:ssm:*::parameter/aws/service/bottlerocket/*`) | parameter | AMI drift detection — primary "latest AMI" lookup against AWS public parameters. |
+| `ec2:DescribeImages` | * | AMI drift detection — fallback used when the SSM lookup fails (denied / not found / throttled). |
 
 Minimum permissions policy:
 
@@ -196,15 +197,24 @@ Minimum permissions policy:
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "EKSClusterScoped",
       "Effect": "Allow",
       "Action": [
         "eks:DescribeCluster",
-        "eks:ListInsights", "eks:DescribeInsight",
-        "eks:ListNodegroups", "eks:DescribeNodegroup"
+        "eks:ListInsights",
+        "eks:DescribeInsight",
+        "eks:ListNodegroups"
       ],
       "Resource": "arn:aws:eks:*:111111111111:cluster/*"
     },
     {
+      "Sid": "EKSNodegroupScoped",
+      "Effect": "Allow",
+      "Action": "eks:DescribeNodegroup",
+      "Resource": "arn:aws:eks:*:111111111111:nodegroup/*/*/*"
+    },
+    {
+      "Sid": "SSMPublicAMIParameters",
       "Effect": "Allow",
       "Action": "ssm:GetParameter",
       "Resource": [
@@ -213,6 +223,7 @@ Minimum permissions policy:
       ]
     },
     {
+      "Sid": "EC2AMILookup",
       "Effect": "Allow",
       "Action": "ec2:DescribeImages",
       "Resource": "*"
@@ -221,7 +232,9 @@ Minimum permissions policy:
 }
 ```
 
-Tighten the EKS resource ARN to specific cluster ARNs once you've decided which clusters Periscope manages. The Insights / node group / SSM-public / `DescribeImages` actions are read-only and produce no mutation surface, so they are safe to grant if your registry is small. `ec2:DescribeImages` only supports `Resource: *` because the API has no resource-level ARN for image lookups.
+`eks:DescribeNodegroup` lives in its own statement because AWS scopes it to the **nodegroup** resource, not the cluster — the wildcard `nodegroup/*/*/*` matches `nodegroup/<cluster>/<nodegroup-name>/<uuid>` for any nodegroup in any cluster Periscope manages. Tighten to specific cluster names (`nodegroup/prod-eu-west-1/*/*`) if you have a small fixed set.
+
+Tighten the cluster-scoped ARN to specific cluster ARNs once you've decided which clusters Periscope manages. The Insights / node group / SSM-public / `DescribeImages` actions are read-only and produce no mutation surface, so they are safe to grant if your registry is small. `ec2:DescribeImages` only supports `Resource: *` because the API has no resource-level ARN for image lookups.
 
 For the full surface map of what each action enables in the UI, see [`eks-upgrade-readiness.md`](./eks-upgrade-readiness.md).
 

--- a/docs/setup/eks-upgrade-readiness.md
+++ b/docs/setup/eks-upgrade-readiness.md
@@ -63,14 +63,23 @@ Minimum policy snippet to add to the existing periscope role (extends the snippe
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "EKSClusterScoped",
       "Effect": "Allow",
       "Action": [
-        "eks:ListInsights", "eks:DescribeInsight",
-        "eks:ListNodegroups", "eks:DescribeNodegroup"
+        "eks:ListInsights",
+        "eks:DescribeInsight",
+        "eks:ListNodegroups"
       ],
       "Resource": "arn:aws:eks:*:111111111111:cluster/*"
     },
     {
+      "Sid": "EKSNodegroupScoped",
+      "Effect": "Allow",
+      "Action": "eks:DescribeNodegroup",
+      "Resource": "arn:aws:eks:*:111111111111:nodegroup/*/*/*"
+    },
+    {
+      "Sid": "SSMPublicAMIParameters",
       "Effect": "Allow",
       "Action": "ssm:GetParameter",
       "Resource": [
@@ -79,6 +88,7 @@ Minimum policy snippet to add to the existing periscope role (extends the snippe
       ]
     },
     {
+      "Sid": "EC2AMILookup",
       "Effect": "Allow",
       "Action": "ec2:DescribeImages",
       "Resource": "*"
@@ -87,7 +97,7 @@ Minimum policy snippet to add to the existing periscope role (extends the snippe
 }
 ```
 
-`ec2:DescribeImages` only supports `Resource: *` because the API doesn't have resource-level ARNs for image lookups. The action is read-only.
+`eks:DescribeNodegroup` is the one action in this set scoped to the **nodegroup** resource rather than the parent cluster — it lives in its own statement so the cluster-scoped wildcard above doesn't try to apply to it (AWS would return `AccessDenied`). The `nodegroup/*/*/*` wildcard matches `nodegroup/<cluster>/<nodegroup-name>/<uuid>`. `ec2:DescribeImages` only supports `Resource: *` because the API doesn't have resource-level ARNs for image lookups. The action is read-only.
 
 > **Diagnosing missing permissions in the SPA.** When the role lacks one of these IAM actions, the upgrade-readiness and node-groups pages render a permission-specific hint (`Periscope's AWS role does not have permission to read…`) instead of a generic red error banner. The backend translates AWS `AccessDeniedException` to HTTP 403 with the stable code `E_AWS_FORBIDDEN`; AWS `ThrottlingException` becomes 429 with `E_AWS_THROTTLED` (transient — refresh after a moment). All other AWS errors keep the legacy 502 / `E_AWS_API` shape.
 


### PR DESCRIPTION
## Summary

**v1.0.3 doc-only fix.** The IAM permissions policy in `docs/setup/deploy.md` §4.1 and `docs/setup/eks-upgrade-readiness.md` grouped `eks:DescribeNodegroup` with the cluster-scoped EKS actions under `Resource: arn:aws:eks:*:<account>:cluster/*`.

Per [AWS service authorization for EKS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerserviceforkubernetes.html), `eks:DescribeNodegroup` operates on the **nodegroup** resource (`arn:aws:eks:region:account:nodegroup/cluster-name/nodegroup-name/uuid`), **not** the cluster. Following the doc literally produced `AccessDenied` on the per-nodegroup detail / AMI drift endpoints — only the nodegroup *list* worked because `ListNodegroups` is correctly scoped to the parent cluster.

Surfaced during v1.0.3-rc smoke; operator had to add the missing statement out-of-band before AMI drift describe started working.

## Changes

- `docs/setup/deploy.md` §4.1 — split the policy into two statements:
  - `EKSClusterScoped` (`DescribeCluster`, `ListInsights`, `DescribeInsight`, `ListNodegroups`) against `cluster/*`
  - `EKSNodegroupScoped` (`DescribeNodegroup`) against `nodegroup/*/*/*`
- `docs/setup/deploy.md` — added a "Resource type" column to the action table so the cluster-vs-nodegroup distinction is visible without leaving the doc.
- `docs/setup/eks-upgrade-readiness.md` — same split applied to the duplicate snippet there.
- Inline note immediately under the JSON block in both docs explaining why `DescribeNodegroup` lives in its own statement, so future readers don't fold it back into the cluster-scoped block.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]` describing the bug + the symptom (list works, describe 403s).

## Behavior matrix

| Action | Resource type | Old doc said | After this PR |
|---|---|---|---|
| `eks:DescribeCluster` | cluster | `cluster/*` ✅ | `cluster/*` ✅ |
| `eks:ListInsights` | cluster | `cluster/*` ✅ | `cluster/*` ✅ |
| `eks:DescribeInsight` | cluster | `cluster/*` ✅ | `cluster/*` ✅ |
| `eks:ListNodegroups` | cluster | `cluster/*` ✅ | `cluster/*` ✅ |
| **`eks:DescribeNodegroup`** | **nodegroup** | `cluster/*` ❌ → `AccessDenied` | `nodegroup/*/*/*` ✅ |
| `ssm:GetParameter` | parameter | scoped to public AMI trees ✅ | unchanged |
| `ec2:DescribeImages` | * | `*` (no resource-level ARN) ✅ | unchanged |

## Verification

- [x] All JSON blocks in both docs parse as valid JSON (sanity-checked locally).
- [ ] After merge, operator deploying v1.0.3 with the fixed snippet should see EKS Insights, nodegroup list, **and** nodegroup detail / AMI drift all populate without further IAM patches.

## Release context

Doc-only; no code changes. Slate this to merge before tagging `v1.0.3` official so the GA release ships a complete IAM snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)