### PR TITLE
fix(eks): right-edge detail pane, form/yaml toggle, clickable version history for add-ons

### DIFF
--- a/web/src/components/eks/AddonDetailBody.tsx
+++ b/web/src/components/eks/AddonDetailBody.tsx
@@ -1,24 +1,52 @@
-import { useAddon } from "../../hooks/useAddons";
-import { cn } from "../../lib/cn";
-
 // AddonDetailBody — body of the installed-add-on detail surface.
 // Rendered inside AddonDetailPane (right-edge SplitPane). Held in
 // its own file so the next EKS surface that wants the same
 // "Field / Section" atoms can import them from one place rather
 // than re-deriving the layout.
 //
-// The Field / FieldGrid / Section primitives below are also exported
-// because they're the SPA's house style for "row of label+value
-// boxes" and the next EKS detail surface (e.g. addon-policy review)
-// will want them.
+// The version-history block deserves its own note:
+//
+//   - Rows are CLICKABLE — clicking one opens the upgrade dialog
+//     with that version pre-selected, so the operator can pick a
+//     specific target (including a downgrade or pinning to an
+//     older "eksbuild.N" of the same minor) without a second
+//     pass through the dialog's radio list.
+//   - The "compatible with k8s [X ▼]" dropdown above the table
+//     filters rows by which k8s version they support. Default is
+//     the cluster's current k8s. Switching to the next minor lets
+//     the operator answer the question raised by the row's
+//     "blocks next k8s minor" warning chip — IS there a newer
+//     addon version that would unblock the cluster upgrade?
+//   - The currently-installed row never gets the click affordance
+//     (upgrading "to current" is a noop and AWS rejects it).
+
+import { useMemo, useState } from "react";
+import { useAddon } from "../../hooks/useAddons";
+import { cn } from "../../lib/cn";
+import type { AddonVersionEntry } from "../../lib/types";
+
+const ANY_K8S = "__any__";
+
+interface AddonDetailBodyProps {
+  cluster: string;
+  name: string;
+  /** Cluster's current K8s version. Sets the initial dropdown
+   *  selection so "compatible with k8s [today's version]" is the
+   *  default view. */
+  clusterK8sVersion?: string;
+  /** Click handler for version-history rows. Pane wires this to
+   *  open the upgrade dialog with the chosen version. When omitted
+   *  rows render as plain (read-only) — useful for surfaces that
+   *  surface this body without an upgrade affordance. */
+  onUpgradeToVersion?: (version: string) => void;
+}
 
 export function AddonDetailBody({
   cluster,
   name,
-}: {
-  cluster: string;
-  name: string;
-}) {
+  clusterK8sVersion,
+  onUpgradeToVersion,
+}: AddonDetailBodyProps) {
   const { data, isLoading, isError, error } = useAddon(cluster, name);
   if (isLoading) {
     return <p className="text-[12px] italic text-ink-faint">Loading…</p>;
@@ -70,48 +98,12 @@ export function AddonDetailBody({
       )}
 
       {data.availableVersions && data.availableVersions.length > 0 && (
-        <Section label="Version history">
-          <div className="overflow-hidden rounded-sm border border-border">
-            <table className="w-full text-[11.5px]">
-              <thead className="border-b border-border bg-surface text-[10px] uppercase tracking-[0.06em] text-ink-faint">
-                <tr>
-                  <th className="px-2 py-1 text-left">Version</th>
-                  <th className="px-2 py-1 text-left">Compatible k8s</th>
-                  <th className="px-2 py-1 text-left">Default</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.availableVersions.map((v) => {
-                  const isInstalled = v.version === data.version;
-                  return (
-                    <tr
-                      key={v.version}
-                      className={cn(
-                        "border-b border-border last:border-0",
-                        isInstalled && "bg-accent-soft/30",
-                      )}
-                    >
-                      <td className="px-2 py-1 font-mono">
-                        {v.version}
-                        {isInstalled && (
-                          <span className="ml-2 text-[10px] uppercase tracking-[0.06em] text-accent">
-                            installed
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-2 py-1 font-mono text-ink-muted">
-                        {v.compatibleK8sVersions.join(", ") || "—"}
-                      </td>
-                      <td className="px-2 py-1 text-ink-muted">
-                        {v.defaultVersion ? "yes" : ""}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </Section>
+        <VersionHistory
+          versions={data.availableVersions}
+          installedVersion={data.version ?? null}
+          clusterK8sVersion={clusterK8sVersion}
+          onUpgradeToVersion={onUpgradeToVersion}
+        />
       )}
 
       {(data.owner || data.publisher) && (
@@ -132,6 +124,188 @@ export function AddonDetailBody({
       )}
     </div>
   );
+}
+
+// ── Version-history block ─────────────────────────────────────────
+
+function VersionHistory({
+  versions,
+  installedVersion,
+  clusterK8sVersion,
+  onUpgradeToVersion,
+}: {
+  versions: AddonVersionEntry[];
+  installedVersion: string | null;
+  clusterK8sVersion: string | undefined;
+  onUpgradeToVersion: ((version: string) => void) | undefined;
+}) {
+  // Build the dropdown options: every k8s version that appears in
+  // any row's compatibleK8sVersions. Sorted descending so the
+  // newest minor is at the top.
+  const k8sOptions = useMemo(() => {
+    const s = new Set<string>();
+    for (const v of versions) {
+      for (const k of v.compatibleK8sVersions) s.add(k);
+    }
+    return Array.from(s).sort(compareK8sDesc);
+  }, [versions]);
+
+  // Default selection: cluster k8s if it's in the option list,
+  // otherwise the newest k8s the addon supports. ANY_K8S is the
+  // explicit "show all" escape hatch.
+  const [selectedK8s, setSelectedK8s] = useState<string>(() => {
+    if (clusterK8sVersion && k8sOptions.includes(clusterK8sVersion)) {
+      return clusterK8sVersion;
+    }
+    return k8sOptions[0] ?? ANY_K8S;
+  });
+
+  const filtered = useMemo(() => {
+    if (selectedK8s === ANY_K8S) return versions;
+    return versions.filter((v) =>
+      v.compatibleK8sVersions.includes(selectedK8s),
+    );
+  }, [versions, selectedK8s]);
+
+  const isClusterK8s = selectedK8s === clusterK8sVersion;
+
+  return (
+    <Section label="Version history">
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-[11.5px]">
+        <label className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+          compatible with k8s
+        </label>
+        <select
+          value={selectedK8s}
+          onChange={(e) => setSelectedK8s(e.target.value)}
+          className="rounded-sm border border-border bg-bg px-1.5 py-0.5 font-mono text-[11.5px]"
+        >
+          {k8sOptions.map((k) => (
+            <option key={k} value={k}>
+              {k}
+              {k === clusterK8sVersion ? "  (current)" : ""}
+            </option>
+          ))}
+          <option value={ANY_K8S}>any</option>
+        </select>
+        {!isClusterK8s && selectedK8s !== ANY_K8S && clusterK8sVersion && (
+          <button
+            type="button"
+            onClick={() => setSelectedK8s(clusterK8sVersion)}
+            className="font-mono text-[10.5px] uppercase tracking-[0.06em] text-accent hover:underline"
+          >
+            reset to {clusterK8sVersion}
+          </button>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-sm border border-border bg-surface px-3 py-2.5 text-[11.5px] text-ink-muted">
+          No add-on versions are compatible with k8s {selectedK8s}.
+          {clusterK8sVersion && selectedK8s !== clusterK8sVersion && (
+            <>
+              {" "}
+              This is what the &quot;blocks next k8s minor&quot; warning
+              flags — track AWS release notes for a future eksbuild
+              that adds {selectedK8s} compatibility.
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-sm border border-border">
+          <table className="w-full text-[11.5px]">
+            <thead className="border-b border-border bg-surface text-[10px] uppercase tracking-[0.06em] text-ink-faint">
+              <tr>
+                <th className="px-2 py-1 text-left">Version</th>
+                <th className="px-2 py-1 text-left">Compatible k8s</th>
+                <th className="px-2 py-1 text-left">Default</th>
+                <th className="px-2 py-1 text-right" />
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((v) => (
+                <VersionRow
+                  key={v.version}
+                  version={v}
+                  isInstalled={v.version === installedVersion}
+                  onUpgradeToVersion={onUpgradeToVersion}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  );
+}
+
+function VersionRow({
+  version,
+  isInstalled,
+  onUpgradeToVersion,
+}: {
+  version: AddonVersionEntry;
+  isInstalled: boolean;
+  onUpgradeToVersion: ((version: string) => void) | undefined;
+}) {
+  // Clickable when the operator has an upgrade affordance AND this
+  // row isn't the current install. AWS rejects "upgrade to current",
+  // so we hide the affordance rather than letting the operator hit
+  // the wall in the dialog.
+  const clickable = Boolean(onUpgradeToVersion) && !isInstalled;
+  const cta = clickable ? (
+    <button
+      type="button"
+      onClick={() => onUpgradeToVersion?.(version.version)}
+      className="rounded-sm border border-accent bg-accent-soft px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.06em] text-accent hover:bg-accent/10"
+    >
+      upgrade to
+    </button>
+  ) : null;
+
+  const onRowClick = clickable
+    ? () => onUpgradeToVersion?.(version.version)
+    : undefined;
+
+  return (
+    <tr
+      className={cn(
+        "border-b border-border last:border-0",
+        isInstalled && "bg-accent-soft/30",
+        clickable && "cursor-pointer transition-colors hover:bg-surface-2",
+      )}
+      onClick={onRowClick}
+    >
+      <td className="px-2 py-1 font-mono">
+        {version.version}
+        {isInstalled && (
+          <span className="ml-2 text-[10px] uppercase tracking-[0.06em] text-accent">
+            installed
+          </span>
+        )}
+      </td>
+      <td className="px-2 py-1 font-mono text-ink-muted">
+        {version.compatibleK8sVersions.join(", ") || "—"}
+      </td>
+      <td className="px-2 py-1 text-ink-muted">
+        {version.defaultVersion ? "yes" : ""}
+      </td>
+      <td className="px-2 py-1 text-right">{cta}</td>
+    </tr>
+  );
+}
+
+// Sort k8s minor versions in descending order. Strings like "1.31"
+// vs "1.7" need numeric-aware compare.
+function compareK8sDesc(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return db - da;
+  }
+  return 0;
 }
 
 // ── Layout primitives ──────────────────────────────────────────────

--- a/web/src/components/eks/AddonDetailBody.tsx
+++ b/web/src/components/eks/AddonDetailBody.tsx
@@ -1,9 +1,9 @@
 import { useAddon } from "../../hooks/useAddons";
 import { cn } from "../../lib/cn";
 
-// AddonDetailBody — body rendered when an AddOnsPage row is
-// expanded. Lives outside AddOnsPage.tsx so the row table stays
-// readable, and so the next EKS surface that wants the same
+// AddonDetailBody — body of the installed-add-on detail surface.
+// Rendered inside AddonDetailPane (right-edge SplitPane). Held in
+// its own file so the next EKS surface that wants the same
 // "Field / Section" atoms can import them from one place rather
 // than re-deriving the layout.
 //

--- a/web/src/components/eks/AddonDetailPane.tsx
+++ b/web/src/components/eks/AddonDetailPane.tsx
@@ -31,6 +31,11 @@ interface AddonDetailPaneProps {
   onInstall?: () => void;
   onUpgrade?: () => void;
   onDelete?: () => void;
+  /** Variant of onUpgrade triggered from a clickable version-history
+   *  row — opens the upgrade dialog with the chosen version
+   *  pre-selected. Same modal, just bypasses the AWS-default
+   *  selection. Wired only when onUpgrade is also wired. */
+  onUpgradeToVersion?: (version: string) => void;
   /** True while AWS is mid-transition (CREATING/UPDATING/DELETING).
    *  Disables Upgrade/Delete; matches the kebab-disabled rule. */
   actionsDisabled?: boolean;
@@ -44,6 +49,7 @@ export function AddonDetailPane({
   onInstall,
   onUpgrade,
   onDelete,
+  onUpgradeToVersion,
   actionsDisabled,
 }: AddonDetailPaneProps) {
   const name =
@@ -85,7 +91,14 @@ export function AddonDetailPane({
 
       <div className="flex-1 overflow-y-auto px-4 py-3">
         {selection.kind === "installed" ? (
-          <AddonDetailBody cluster={cluster} name={selection.name} />
+          <AddonDetailBody
+            cluster={cluster}
+            name={selection.name}
+            clusterK8sVersion={kubernetesVersion}
+            onUpgradeToVersion={
+              actionsDisabled ? undefined : onUpgradeToVersion
+            }
+          />
         ) : (
           <AvailableBody
             catalog={selection.catalog}

--- a/web/src/components/eks/AddonDetailPane.tsx
+++ b/web/src/components/eks/AddonDetailPane.tsx
@@ -1,0 +1,265 @@
+// AddonDetailPane — right-edge detail pane for the EKS add-ons
+// surface. Lives inside SplitPane on both AddOnsPage and the catalog
+// page; replaces the old inline-row-expand which couldn't scroll
+// independently of the page (#117 follow-up).
+//
+// Two modes:
+//   - "installed"  — fetched detail (version history, IAM SA role,
+//                    health issues, ARN). Footer: Upgrade / Delete.
+//   - "available"  — catalog metadata only (publisher, type, compat
+//                    range, version list, marketplace warning). No
+//                    /addons/{name} call (would 404). Footer: Install.
+
+import { compatRangeOf, pickLatestForK8s } from "../../lib/addonCatalog";
+import { cn } from "../../lib/cn";
+import type { CatalogAddon } from "../../lib/types";
+import { AddonDetailBody } from "./AddonDetailBody";
+
+export type AddonPaneSelection =
+  | { kind: "installed"; name: string; catalog?: CatalogAddon }
+  | { kind: "available"; catalog: CatalogAddon };
+
+interface AddonDetailPaneProps {
+  cluster: string;
+  selection: AddonPaneSelection;
+  /** Cluster's K8s version — drives compat range display in
+   *  available mode. */
+  kubernetesVersion?: string;
+  onClose: () => void;
+  /** Action handlers: each is wired by the page. The pane just
+   *  triggers; modal management lives in the page. */
+  onInstall?: () => void;
+  onUpgrade?: () => void;
+  onDelete?: () => void;
+  /** True while AWS is mid-transition (CREATING/UPDATING/DELETING).
+   *  Disables Upgrade/Delete; matches the kebab-disabled rule. */
+  actionsDisabled?: boolean;
+}
+
+export function AddonDetailPane({
+  cluster,
+  selection,
+  kubernetesVersion,
+  onClose,
+  onInstall,
+  onUpgrade,
+  onDelete,
+  actionsDisabled,
+}: AddonDetailPaneProps) {
+  const name =
+    selection.kind === "installed" ? selection.name : selection.catalog.name;
+  const catalog =
+    selection.kind === "installed" ? selection.catalog : selection.catalog;
+  const subtitle = subtitleFor(catalog);
+
+  return (
+    // min-w-0 mirrors DetailPane — the SplitPane right pane is
+    // fixed-width and min-w-0; nested flex containers must opt-in
+    // for `truncate` and overflow-hidden to actually clip.
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-surface">
+      <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <div className="truncate font-mono text-[13.5px] text-ink">
+            {name}
+          </div>
+          {subtitle && (
+            <div className="mt-0.5 truncate text-[11.5px] text-ink-faint">
+              {subtitle}
+            </div>
+          )}
+          {catalog?.marketplaceProduct && (
+            <div className="mt-1 text-[11px] text-yellow">
+              marketplace · accept EULA outside Periscope
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close detail pane"
+          className="shrink-0 rounded-sm border border-border bg-bg px-2 py-0.5 font-mono text-[11px] text-ink-muted hover:bg-surface-2"
+        >
+          ✕
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {selection.kind === "installed" ? (
+          <AddonDetailBody cluster={cluster} name={selection.name} />
+        ) : (
+          <AvailableBody
+            catalog={selection.catalog}
+            kubernetesVersion={kubernetesVersion}
+          />
+        )}
+      </div>
+
+      <footer className="flex shrink-0 items-center justify-end gap-2 border-t border-border bg-surface-2/30 px-4 py-2.5">
+        {selection.kind === "installed" ? (
+          <>
+            {onDelete && (
+              <ActionButton
+                tone="danger"
+                disabled={actionsDisabled}
+                onClick={onDelete}
+              >
+                Delete…
+              </ActionButton>
+            )}
+            {onUpgrade && (
+              <ActionButton
+                tone="primary"
+                disabled={actionsDisabled}
+                onClick={onUpgrade}
+              >
+                Upgrade…
+              </ActionButton>
+            )}
+          </>
+        ) : (
+          onInstall && (
+            <ActionButton tone="primary" onClick={onInstall}>
+              + Install
+            </ActionButton>
+          )
+        )}
+      </footer>
+    </div>
+  );
+}
+
+function subtitleFor(catalog: CatalogAddon | undefined): string {
+  if (!catalog) return "";
+  const parts: string[] = [];
+  if (catalog.publisher) parts.push(`Published by ${catalog.publisher}`);
+  if (catalog.owner) parts.push(`owner: ${catalog.owner}`);
+  if (catalog.type) parts.push(catalog.type);
+  return parts.join(" · ");
+}
+
+function ActionButton({
+  tone,
+  disabled,
+  onClick,
+  children,
+}: {
+  tone: "primary" | "danger";
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "rounded-sm border px-3 py-1 font-mono text-[11.5px] transition-colors disabled:opacity-50",
+        tone === "primary" &&
+          "border-accent bg-accent-soft text-accent hover:bg-accent/10",
+        tone === "danger" &&
+          "border-red/40 bg-red/5 text-red hover:bg-red/10",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Available-mode body ──────────────────────────────────────────
+//
+// Renders catalog metadata + a versions table. We deliberately don't
+// call useAddon() here — the addon isn't installed, the endpoint
+// would 404, and the SAR cost is wasted.
+
+function AvailableBody({
+  catalog,
+  kubernetesVersion,
+}: {
+  catalog: CatalogAddon;
+  kubernetesVersion?: string;
+}) {
+  const latest = pickLatestForK8s(catalog.compatibleVersions, kubernetesVersion);
+  const compatRange = compatRangeOf(latest?.kubernetesVersions ?? []);
+
+  return (
+    <div className="space-y-3">
+      <PaneFieldGrid>
+        <PaneField label="Latest version">{latest?.version ?? "—"}</PaneField>
+        <PaneField label="Compatible k8s">{compatRange ?? "—"}</PaneField>
+        <PaneField label="Owner">{catalog.owner ?? "—"}</PaneField>
+        <PaneField label="Type">{catalog.type ?? "—"}</PaneField>
+      </PaneFieldGrid>
+
+      {catalog.compatibleVersions.length > 0 && (
+        <PaneSection label="Available versions">
+          <div className="overflow-hidden rounded-sm border border-border">
+            <table className="w-full text-[11.5px]">
+              <thead className="border-b border-border bg-surface text-[10px] uppercase tracking-[0.06em] text-ink-faint">
+                <tr>
+                  <th className="px-2 py-1 text-left">Version</th>
+                  <th className="px-2 py-1 text-left">Compatible k8s</th>
+                  <th className="px-2 py-1 text-left">Default</th>
+                </tr>
+              </thead>
+              <tbody>
+                {catalog.compatibleVersions.map((v) => (
+                  <tr
+                    key={v.version}
+                    className="border-b border-border last:border-0"
+                  >
+                    <td className="px-2 py-1 font-mono">{v.version}</td>
+                    <td className="px-2 py-1 font-mono text-ink-muted">
+                      {v.kubernetesVersions.join(", ") || "—"}
+                    </td>
+                    <td className="px-2 py-1 text-ink-muted">
+                      {v.default ? "yes" : ""}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </PaneSection>
+      )}
+    </div>
+  );
+}
+
+function PaneSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function PaneFieldGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-2 gap-x-6 gap-y-2">{children}</div>;
+}
+
+function PaneField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        {label}
+      </div>
+      <div className="mt-0.5 font-mono text-[12px]">{children}</div>
+    </div>
+  );
+}

--- a/web/src/components/eks/UpgradeAddOnDialog.tsx
+++ b/web/src/components/eks/UpgradeAddOnDialog.tsx
@@ -53,6 +53,13 @@ interface UpgradeAddOnDialogProps {
   /** Cluster's current K8s version. Filters version list to
    *  compatible entries. */
   kubernetesVersion?: string;
+  /** When set, the dialog opens with this version pre-selected
+   *  instead of the AWS-recommended default. Wired by the
+   *  detail-pane's clickable version-history rows so an operator
+   *  can pick a specific target without a second pass through the
+   *  dropdown. Falls back to pickUpgradeDefault when the requested
+   *  version isn't actually a valid upgrade target. */
+  initialVersion?: string;
 }
 
 type ResolveConflicts = "NONE" | "OVERWRITE" | "PRESERVE";
@@ -64,6 +71,7 @@ export function UpgradeAddOnDialog({
   catalogAddon,
   detail,
   kubernetesVersion,
+  initialVersion,
 }: UpgradeAddOnDialogProps) {
   const labelId = "upgrade-addon-dialog-title";
 
@@ -87,12 +95,20 @@ export function UpgradeAddOnDialog({
 
   useEffect(() => {
     if (!open || !catalogAddon || !detail) return;
+    // Honor initialVersion if it's actually one of the valid upgrade
+    // targets — otherwise fall back to the AWS-recommended default.
+    // The pane only proposes versions from the same list, so the
+    // fallback path is mostly a guard against stale clicks.
+    const requested =
+      initialVersion && targets.some((t) => t.version === initialVersion)
+        ? initialVersion
+        : pickUpgradeDefault(targets);
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setVersion(pickUpgradeDefault(targets));
+    setVersion(requested);
     setValuesYaml(detail.configurationValues ?? "");
     setServiceAccountRoleArn(detail.serviceAccountRoleArn ?? "");
     setResolveConflicts("PRESERVE");
-  }, [open, catalogAddon, detail, targets]);
+  }, [open, catalogAddon, detail, targets, initialVersion]);
 
   const schemaQuery = useAddonConfigurationSchema(
     cluster,

--- a/web/src/components/helm/HelmValuesEditor.tsx
+++ b/web/src/components/helm/HelmValuesEditor.tsx
@@ -1,33 +1,46 @@
 // HelmValuesEditor — top-level switch between form (when chart
-// ships values.schema.json) and Monaco YAML (when it doesn't).
-//
-// Why not a toggle in v1.1: a Form↔YAML toggle would need
-// round-trip serialization that loses YAML comments and reformat
-// hints. Operators editing schemaless charts edit YAML directly;
-// operators editing schema'd charts use the form. Cleaner v1
-// invariant; toggle is a follow-up polish item.
+// ships values.schema.json) and Monaco YAML.
 //
 // State contract:
 //   - The CALLER owns `valuesYaml` (raw YAML string).
-//   - When schema is present, this component parses the YAML once
-//     into a JS object, hands it to HelmValuesForm, and on every
-//     form mutation re-serializes to YAML and bubbles back through
-//     `onValuesYamlChange`.
-//   - When schema is absent, it bypasses parse/serialize and hands
-//     the string straight to HelmValuesYaml.
+//   - When schema is present and the operator chose form mode, this
+//     component parses the YAML once into a JS object, hands it to
+//     HelmValuesForm, and on every form mutation re-serializes to
+//     YAML and bubbles back through `onValuesYamlChange`.
+//   - When schema is absent OR the operator toggled to YAML mode,
+//     it bypasses parse/serialize and hands the string straight to
+//     HelmValuesYaml.
+//
+// Form↔YAML toggle:
+//   - Visible only when a schema is present (no toggle when there's
+//     no schema — YAML is the only option).
+//   - Default mode is `form` unless the schema has a required field
+//     the form can't render ($ref / allOf / arrays of objects / etc.),
+//     in which case we default to `yaml` so the operator isn't stuck.
+//   - Switching either way is free: the parent owns valuesYaml and
+//     SchemaFormBridge re-parses on remount, so the toggle is just
+//     "which child to render."
+//   - YAML→Form may lose comments (yaml.parse → yaml.stringify drops
+//     them); the warning above the form fires once after such a flip.
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { HelmValuesForm } from "./HelmValuesForm";
 import { HelmValuesYaml } from "./HelmValuesYaml";
-import type { JSONSchema } from "../../lib/helmSchema";
+import {
+  hasRequiredUnsupportedField,
+  type JSONSchema,
+} from "../../lib/helmSchema";
+import { cn } from "../../lib/cn";
+
+type Mode = "form" | "yaml";
 
 interface HelmValuesEditorProps {
   /** values.yaml as a raw string — what the chart shipped, what
    *  eventually goes back to helm. */
   valuesYaml: string;
   /** values.schema.json from the chart (decoded). When absent,
-   *  the editor renders the Monaco YAML fallback. */
+   *  the editor renders the Monaco YAML fallback with no toggle. */
   schema?: JSONSchema;
   onValuesYamlChange: (next: string) => void;
 }
@@ -45,7 +58,7 @@ export function HelmValuesEditor({
     );
   }
   return (
-    <SchemaFormBridge
+    <SchemaEditor
       valuesYaml={valuesYaml}
       schema={schema}
       onValuesYamlChange={onValuesYamlChange}
@@ -53,13 +66,7 @@ export function HelmValuesEditor({
   );
 }
 
-// SchemaFormBridge translates between the YAML string the parent
-// owns and the JS-object world HelmValuesForm operates in. One
-// parse on mount + one parse on external valuesYaml change; one
-// stringify per form mutation. Yaml-package preserves key order
-// across the round-trip but DOES NOT preserve comments — known
-// limitation in v1.1 (operators see the warning banner above).
-function SchemaFormBridge({
+function SchemaEditor({
   valuesYaml,
   schema,
   onValuesYamlChange,
@@ -68,14 +75,120 @@ function SchemaFormBridge({
   schema: JSONSchema;
   onValuesYamlChange: (next: string) => void;
 }) {
+  // Auto-default to YAML if any required field is unrenderable in
+  // form mode — otherwise the operator hits a wall.
+  const [mode, setMode] = useState<Mode>(() =>
+    hasRequiredUnsupportedField(schema) ? "yaml" : "form",
+  );
+  // Recompute the suggested default when the chart version (and so
+  // the schema) changes. Only override the current mode when the new
+  // schema would force a different default; preserve an explicit user
+  // toggle within the same schema.
+  const lastSchemaRef = useRef<JSONSchema>(schema);
+  useEffect(() => {
+    if (lastSchemaRef.current === schema) return;
+    lastSchemaRef.current = schema;
+    setMode(hasRequiredUnsupportedField(schema) ? "yaml" : "form");
+  }, [schema]);
+
+  // Track whether we've ever round-tripped through the form. If so,
+  // comments in the original YAML have already been dropped on the
+  // first stringify; flag it so the operator knows.
+  const [commentsLost, setCommentsLost] = useState(false);
+
+  return (
+    <div className="flex min-h-[460px] flex-1 flex-col gap-2">
+      <ModeToggle mode={mode} onChange={setMode} />
+      {mode === "yaml" ? (
+        <div className="flex min-h-[420px] flex-1 flex-col overflow-hidden rounded-sm border border-border bg-bg">
+          <HelmValuesYaml value={valuesYaml} onChange={onValuesYamlChange} />
+        </div>
+      ) : (
+        <SchemaFormBridge
+          valuesYaml={valuesYaml}
+          schema={schema}
+          onValuesYamlChange={(next) => {
+            setCommentsLost(true);
+            onValuesYamlChange(next);
+          }}
+          commentsLost={commentsLost}
+        />
+      )}
+    </div>
+  );
+}
+
+function ModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: Mode;
+  onChange: (next: Mode) => void;
+}) {
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <span className="mr-1 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        edit as
+      </span>
+      <ModeButton active={mode === "form"} onClick={() => onChange("form")}>
+        form
+      </ModeButton>
+      <ModeButton active={mode === "yaml"} onClick={() => onChange("yaml")}>
+        yaml
+      </ModeButton>
+    </div>
+  );
+}
+
+function ModeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-sm border px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.08em] transition-colors",
+        active
+          ? "border-accent bg-accent-soft text-accent"
+          : "border-border text-ink-muted hover:bg-surface-2",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// SchemaFormBridge translates between the YAML string the parent
+// owns and the JS-object world HelmValuesForm operates in. One
+// parse on mount + one parse on external valuesYaml change; one
+// stringify per form mutation. yaml-package preserves key order
+// across the round-trip but DOES NOT preserve comments.
+function SchemaFormBridge({
+  valuesYaml,
+  schema,
+  onValuesYamlChange,
+  commentsLost,
+}: {
+  valuesYaml: string;
+  schema: JSONSchema;
+  onValuesYamlChange: (next: string) => void;
+  commentsLost: boolean;
+}) {
   const [obj, setObj] = useState<Record<string, unknown>>(() => parseSafe(valuesYaml));
 
   // External reset (parent supplied new YAML — e.g. operator picked
-  // a different chart version) — re-parse. The setState-in-effect
-  // is intentional: this is the "external state changed, sync our
-  // mirror" pattern, which the rule legitimately allows but flags
-  // anyway. The structural-equality guard makes it a no-op when the
-  // parent re-renders without changing valuesYaml.
+  // a different chart version, or flipped from YAML mode back to
+  // Form mode after editing) — re-parse. The setState-in-effect is
+  // the "external state changed, sync our mirror" pattern; the
+  // structural-equality guard makes it a no-op when the parent
+  // re-renders without changing valuesYaml.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setObj((prev) => {
@@ -89,18 +202,21 @@ function SchemaFormBridge({
     });
   }, [valuesYaml]);
 
+  const sourceHasComments = useMemo(() => yamlHasComments(valuesYaml), [valuesYaml]);
+
   return (
     <div className="space-y-3">
-      <div className="rounded-sm border border-yellow/40 bg-yellow/5 px-3 py-2 text-[12px] text-ink-muted">
-        <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-yellow">
-          form mode
-        </span>
-        <span className="ml-2">
-          chart ships a values schema; rendering as a structured form.
-          comments in values.yaml will be stripped on save — switch to
-          YAML mode (planned in a follow-up) to preserve them.
-        </span>
-      </div>
+      {(commentsLost || sourceHasComments) && (
+        <div className="rounded-sm border border-yellow/40 bg-yellow/5 px-3 py-2 text-[12px] text-ink-muted">
+          <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-yellow">
+            form mode
+          </span>
+          <span className="ml-2">
+            comments in values.yaml are stripped on save — switch to
+            YAML mode to preserve them.
+          </span>
+        </div>
+      )}
       <HelmValuesForm
         schema={schema}
         values={obj}
@@ -133,4 +249,18 @@ function parseSafe(yaml: string): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function yamlHasComments(yaml: string): boolean {
+  // Cheap line scan — we don't need perfect YAML lexing here, just
+  // "is there a # somewhere that isn't inside a string." Good enough
+  // to decide whether to show the comment-loss banner.
+  for (const line of yaml.split("\n")) {
+    const t = line.trimStart();
+    if (t.startsWith("#")) return true;
+    // crude inline check: " # " outside of quotes
+    const idx = t.indexOf(" #");
+    if (idx >= 0) return true;
+  }
+  return false;
 }

--- a/web/src/components/helm/HelmValuesForm.tsx
+++ b/web/src/components/helm/HelmValuesForm.tsx
@@ -108,18 +108,18 @@ function FieldRow({ descriptor, values, issues, onChange }: FieldRowProps) {
 
   if (descriptor.type === "unsupported") {
     return (
-      <div className="rounded-sm border border-yellow/40 bg-yellow/5 px-3 py-2">
+      <div className="rounded-sm border border-border bg-surface px-3 py-2">
         <div className="flex items-baseline justify-between gap-3">
           <span className="font-mono text-[12px] text-ink">
             {descriptor.path.join(".")}
-            {descriptor.required ? " *" : ""}
+            {descriptor.required ? <span className="text-red"> *</span> : null}
           </span>
-          <span className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-yellow">
-            yaml only
+          <span className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-faint">
+            edit in yaml mode
           </span>
         </div>
         <p className="mt-1 text-[12px] text-ink-muted">
-          {descriptor.unsupportedReason}
+          {descriptor.unsupportedReason} — toggle to YAML above to set this field.
         </p>
       </div>
     );

--- a/web/src/lib/helmSchema.ts
+++ b/web/src/lib/helmSchema.ts
@@ -106,6 +106,29 @@ export function buildFieldDescriptors(schema: JSONSchema): FieldDescriptor[] {
   return walkObject(schema, []);
 }
 
+/**
+ * True when the schema contains at least one required field that the
+ * form can't render (array of objects, $ref, allOf/anyOf/oneOf,
+ * patternProperties — anything that ends up as `type: "unsupported"`).
+ *
+ * The editor uses this to pick the initial mode: if there's a
+ * required-but-unrenderable field, defaulting to form mode would
+ * prevent the operator from filling in a value the install will
+ * reject. Default to YAML mode in that case so they can edit
+ * everything in one place.
+ */
+export function hasRequiredUnsupportedField(schema: JSONSchema): boolean {
+  return buildFieldDescriptors(schema).some(walkRequiredUnsupported);
+}
+
+function walkRequiredUnsupported(d: FieldDescriptor): boolean {
+  if (d.type === "unsupported" && d.required) return true;
+  if (d.type === "object" && d.children) {
+    return d.children.some(walkRequiredUnsupported);
+  }
+  return false;
+}
+
 function walkObject(schema: JSONSchema, path: string[]): FieldDescriptor[] {
   const props = schema.properties ?? {};
   const required = new Set(schema.required ?? []);

--- a/web/src/pages/AddOnsPage.tsx
+++ b/web/src/pages/AddOnsPage.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
-import { AddonDetailBody } from "../components/eks/AddonDetailBody";
+import { AddonDetailPane } from "../components/eks/AddonDetailPane";
 import { DeleteAddOnModal } from "../components/eks/DeleteAddOnModal";
 import { UpgradeAddOnDialog } from "../components/eks/UpgradeAddOnDialog";
 import { KebabMenu } from "../components/ui/KebabMenu";
+import { SplitPane } from "../components/page/SplitPane";
 import { useAddon, useAddons } from "../hooks/useAddons";
 import { useAddonCatalog } from "../hooks/useAddonCatalog";
 import { isAWSForbidden, isAWSThrottled, isBackendNotEKS } from "../lib/api";
@@ -11,12 +12,12 @@ import type { AddonHealthGlyph, AddonSummary, CatalogAddon } from "../lib/types"
 
 // AddOnsPage — dedicated /clusters/{c}/addons view (issue #117).
 //
-// Layout: a table of installed add-ons; click a row to expand the
-// detail panel (version history, compat matrix, IAM service-account
-// ARN, health issues). Three glyphs (●/▲/✕) match the issue mockup.
-// Pairs with Upgrade Insights — the operator can see "what's
-// installed" alongside the AWS-side "what should change before next
-// minor".
+// Layout: SplitPane with the installed-add-ons table on the left and
+// AddonDetailPane on the right. Row click opens the pane (replaces
+// the original inline-row-expand which couldn't scroll independently
+// of the page). Pane width persists under the shared
+// `periscope.detailWidth.v4` storage key, so an operator's chosen
+// pane width travels across every resource page.
 
 export function AddOnsPage({ cluster }: { cluster: string }) {
   const { data, isLoading, isError, error } = useAddons(cluster);
@@ -37,6 +38,8 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
   // delete needs only the name.
   const [upgradeTarget, setUpgradeTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  // Selected row for the detail pane. null = pane closed.
+  const [selected, setSelected] = useState<string | null>(null);
   // Detail blob for the upgrade dialog. Lazy fetch — only fires
   // when an upgrade target is set, since useAddon respects the
   // enabled flag inside the hook (Boolean(cluster && name)).
@@ -108,10 +111,34 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
 
   if (!data) return null;
   const rows = data.addons;
+  const selectedRow = selected ? rows.find((r) => r.name === selected) : null;
+  const selectedTransient =
+    selectedRow != null &&
+    (selectedRow.status === "CREATING" ||
+      selectedRow.status === "UPDATING" ||
+      selectedRow.status === "DELETING");
+
+  const detail = selected ? (
+    <AddonDetailPane
+      cluster={cluster}
+      selection={{
+        kind: "installed",
+        name: selected,
+        catalog: catalogByName.get(selected),
+      }}
+      kubernetesVersion={
+        catalog.data?.kubernetesVersion ?? data?.clusterKubernetesVersion
+      }
+      onClose={() => setSelected(null)}
+      onUpgrade={() => setUpgradeTarget(selected)}
+      onDelete={() => setDeleteTarget(selected)}
+      actionsDisabled={selectedTransient}
+    />
+  ) : null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto px-6 py-5">
-      <header className="mb-4">
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="shrink-0 px-6 pt-5 pb-3">
         <h1 className="text-[16px] font-medium">
           EKS add-ons{" "}
           {data.clusterKubernetesVersion && (
@@ -131,40 +158,53 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
         </p>
       </header>
 
-      {rows.length === 0 ? (
-        <p className="text-[13px] text-ink-faint">
-          This cluster has no managed add-ons. Self-managed add-ons
-          (operator-deployed coredns/kube-proxy via Helm) are not
-          surfaced here — EKS does not track them.
-        </p>
-      ) : (
-        <div className="overflow-hidden rounded-md border border-border bg-surface">
-          <table className="w-full text-[12.5px]">
-            <thead className="border-b border-border bg-surface-2/40 text-[10px] uppercase tracking-[0.08em] text-ink-faint">
-              <tr>
-                <th className="px-3 py-2 text-left">Health</th>
-                <th className="px-3 py-2 text-left">Name</th>
-                <th className="px-3 py-2 text-left">Installed</th>
-                <th className="px-3 py-2 text-left">Latest</th>
-                <th className="px-3 py-2 text-left">Compat (k8s)</th>
-                <th className="px-3 py-2 text-left">Status</th>
-                <th className="px-3 py-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <AddonRow
-                  key={row.name}
-                  cluster={cluster}
-                  addon={row}
-                  onUpgrade={() => setUpgradeTarget(row.name)}
-                  onDelete={() => setDeleteTarget(row.name)}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <SplitPane
+        storageKey="periscope.detailWidth.v4"
+        left={
+          rows.length === 0 ? (
+            <p className="px-6 py-4 text-[13px] text-ink-faint">
+              This cluster has no managed add-ons. Self-managed add-ons
+              (operator-deployed coredns/kube-proxy via Helm) are not
+              surfaced here — EKS does not track them.
+            </p>
+          ) : (
+            <div className="flex h-full min-h-0 flex-col px-6 pb-5">
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-surface">
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <table className="w-full text-[12.5px]">
+                    <thead className="sticky top-0 z-[1] border-b border-border bg-surface-2/90 text-[10px] uppercase tracking-[0.08em] text-ink-faint backdrop-blur-sm">
+                      <tr>
+                        <th className="px-3 py-2 text-left">Health</th>
+                        <th className="px-3 py-2 text-left">Name</th>
+                        <th className="px-3 py-2 text-left">Installed</th>
+                        <th className="px-3 py-2 text-left">Latest</th>
+                        <th className="hidden px-3 py-2 text-left lg:table-cell">
+                          Compat (k8s)
+                        </th>
+                        <th className="px-3 py-2 text-left">Status</th>
+                        <th className="px-3 py-2 text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row) => (
+                        <AddonRow
+                          key={row.name}
+                          addon={row}
+                          selected={selected === row.name}
+                          onSelect={() => setSelected(row.name)}
+                          onUpgrade={() => setUpgradeTarget(row.name)}
+                          onDelete={() => setDeleteTarget(row.name)}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          )
+        }
+        right={detail}
+      />
 
       <UpgradeAddOnDialog
         open={upgradeTarget !== null}
@@ -189,17 +229,18 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
 }
 
 function AddonRow({
-  cluster,
   addon,
+  selected,
+  onSelect,
   onUpgrade,
   onDelete,
 }: {
-  cluster: string;
   addon: AddonSummary;
+  selected: boolean;
+  onSelect: () => void;
   onUpgrade: () => void;
   onDelete: () => void;
 }) {
-  const [open, setOpen] = useState(false);
   // Disable Upgrade / Delete kebab items while AWS is mid-transition —
   // sending another mutation while CREATING/UPDATING/DELETING is in
   // flight produces opaque AWS errors. The status flips back via
@@ -209,75 +250,66 @@ function AddonRow({
     addon.status === "UPDATING" ||
     addon.status === "DELETING";
   return (
-    <>
-      <tr
-        className={cn(
-          "cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-surface-2",
-          open && "bg-surface-2",
-        )}
-        onClick={() => setOpen((v) => !v)}
-      >
-        <td className="px-3 py-2">
-          <Glyph glyph={addon.healthGlyph} />
-        </td>
-        <td className="px-3 py-2 font-mono">
-          {addon.name}
-          {addon.blocksNextMinor && (
-            <div className="text-[10.5px] text-yellow">
-              blocks next k8s minor
-            </div>
-          )}
-        </td>
-        <td className="px-3 py-2 font-mono text-ink-muted">
-          {addon.version || "—"}
-        </td>
-        <td className="px-3 py-2 font-mono text-ink-muted">
-          {addon.updateAvailable ? (
-            <span className="text-yellow">{addon.latestVersion ?? "—"}</span>
-          ) : addon.latestVersion ? (
-            <span>{addon.latestVersion}</span>
-          ) : (
-            "—"
-          )}
-        </td>
-        <td className="px-3 py-2 font-mono text-[11.5px] text-ink-muted">
-          {addon.compatMinK8s && addon.compatMaxK8s
-            ? `${addon.compatMinK8s} – ${addon.compatMaxK8s}`
-            : "—"}
-        </td>
-        <td className="px-3 py-2">
-          <StatusBadge status={addon.status} />
-        </td>
-        <td className="px-3 py-2 text-right">
-          <KebabMenu
-            label={`actions for ${addon.name}`}
-            items={[
-              {
-                label: "Upgrade…",
-                onSelect: onUpgrade,
-                disabled: transient,
-              },
-              {
-                label: "Delete…",
-                onSelect: onDelete,
-                variant: "danger",
-                disabled: transient,
-              },
-            ]}
-          />
-        </td>
-      </tr>
-      {open && (
-        <tr>
-          <td
-            colSpan={7}
-            className="border-b border-border bg-surface-2/40 px-6 py-3"
-          >
-            <AddonDetailBody cluster={cluster} name={addon.name} />
-          </td>
-        </tr>
+    <tr
+      className={cn(
+        "cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-surface-2",
+        selected && "bg-accent-soft/40",
       )}
-    </>
+      onClick={onSelect}
+    >
+      <td className="px-3 py-2">
+        <Glyph glyph={addon.healthGlyph} />
+      </td>
+      <td className="px-3 py-2 font-mono">
+        {addon.name}
+        {addon.blocksNextMinor && (
+          <div className="text-[10.5px] text-yellow">
+            blocks next k8s minor
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-2 font-mono text-ink-muted">
+        {addon.version || "—"}
+      </td>
+      <td className="px-3 py-2 font-mono text-ink-muted">
+        {addon.updateAvailable ? (
+          <span className="text-yellow">{addon.latestVersion ?? "—"}</span>
+        ) : addon.latestVersion ? (
+          <span>{addon.latestVersion}</span>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td className="hidden px-3 py-2 font-mono text-[11.5px] text-ink-muted lg:table-cell">
+        {addon.compatMinK8s && addon.compatMaxK8s
+          ? `${addon.compatMinK8s} – ${addon.compatMaxK8s}`
+          : "—"}
+      </td>
+      <td className="px-3 py-2">
+        <StatusBadge status={addon.status} />
+      </td>
+      <td
+        className="px-3 py-2 text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <KebabMenu
+          label={`actions for ${addon.name}`}
+          items={[
+            {
+              label: "Upgrade…",
+              onSelect: onUpgrade,
+              disabled: transient,
+            },
+            {
+              label: "Delete…",
+              onSelect: onDelete,
+              variant: "danger",
+              disabled: transient,
+            },
+          ]}
+        />
+      </td>
+    </tr>
   );
 }
 
@@ -329,4 +361,3 @@ function StatusBadge({ status }: { status: string }) {
     </span>
   );
 }
-

--- a/web/src/pages/AddOnsPage.tsx
+++ b/web/src/pages/AddOnsPage.tsx
@@ -37,6 +37,13 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
   // null = no dialog open. Upgrade needs (catalogAddon + detail);
   // delete needs only the name.
   const [upgradeTarget, setUpgradeTarget] = useState<string | null>(null);
+  // Optional pre-selected upgrade version, set when the operator
+  // clicks a row in the detail-pane's version-history table.
+  // Cleared when the upgrade dialog closes so subsequent kebab
+  // opens fall back to the AWS-default selection.
+  const [upgradeInitialVersion, setUpgradeInitialVersion] = useState<
+    string | null
+  >(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   // Selected row for the detail pane. null = pane closed.
   const [selected, setSelected] = useState<string | null>(null);
@@ -130,7 +137,14 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
         catalog.data?.kubernetesVersion ?? data?.clusterKubernetesVersion
       }
       onClose={() => setSelected(null)}
-      onUpgrade={() => setUpgradeTarget(selected)}
+      onUpgrade={() => {
+        setUpgradeInitialVersion(null);
+        setUpgradeTarget(selected);
+      }}
+      onUpgradeToVersion={(v) => {
+        setUpgradeInitialVersion(v);
+        setUpgradeTarget(selected);
+      }}
       onDelete={() => setDeleteTarget(selected)}
       actionsDisabled={selectedTransient}
     />
@@ -208,7 +222,10 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
 
       <UpgradeAddOnDialog
         open={upgradeTarget !== null}
-        onClose={() => setUpgradeTarget(null)}
+        onClose={() => {
+          setUpgradeTarget(null);
+          setUpgradeInitialVersion(null);
+        }}
         cluster={cluster}
         catalogAddon={
           upgradeTarget ? catalogByName.get(upgradeTarget) ?? null : null
@@ -217,6 +234,7 @@ export function AddOnsPage({ cluster }: { cluster: string }) {
         kubernetesVersion={
           catalog.data?.kubernetesVersion ?? data?.clusterKubernetesVersion
         }
+        initialVersion={upgradeInitialVersion ?? undefined}
       />
       <DeleteAddOnModal
         open={deleteTarget !== null}

--- a/web/src/pages/EKSAddOnsCatalogPage.tsx
+++ b/web/src/pages/EKSAddOnsCatalogPage.tsx
@@ -7,16 +7,19 @@
 // Filter chips narrow by ownership (AWS vs third-party) and by
 // type (networking / storage / observability / security).
 //
-// Install action is wired in PR-2: clicking "+ Install" on a row
-// opens InstallAddOnDialog. Upgrade / Delete from installed rows
-// land in PR-3 (kebab menu); for now installed rows still link
-// over to AddOnsPage for the existing detail surface.
+// Layout: SplitPane with the catalog table on the left and
+// AddonDetailPane on the right. Both installed and available rows
+// open the pane on click; the row's primary action (Install / kebab)
+// stops propagation so the operator can still skip to the modal
+// without going through the pane first.
 
 import { useMemo, useState } from "react";
+import { AddonDetailPane } from "../components/eks/AddonDetailPane";
 import { DeleteAddOnModal } from "../components/eks/DeleteAddOnModal";
 import { InstallAddOnDialog } from "../components/eks/InstallAddOnDialog";
 import { UpgradeAddOnDialog } from "../components/eks/UpgradeAddOnDialog";
 import { KebabMenu } from "../components/ui/KebabMenu";
+import { SplitPane } from "../components/page/SplitPane";
 import { useAddonCatalog } from "../hooks/useAddonCatalog";
 import { useAddon, useAddons } from "../hooks/useAddons";
 import {
@@ -49,6 +52,10 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
   // across both surfaces.
   const [upgradeTarget, setUpgradeTarget] = useState<CatalogAddon | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  // Selected row for the detail pane. Stores the addon name; the
+  // pane resolves it back to a CatalogAddon at render time so we
+  // don't keep a stale snapshot if the catalog refetches.
+  const [selectedName, setSelectedName] = useState<string | null>(null);
   const upgradeDetail = useAddon(cluster, upgradeTarget?.name ?? "");
 
   const rows = useMemo(() => {
@@ -139,9 +146,38 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
   const totalCount = rows.length;
   const installedCount = rows.filter((r) => r.installed).length;
 
+  const selectedRow = selectedName
+    ? rows.find((r) => r.name === selectedName) ?? null
+    : null;
+  const selectedTransient =
+    selectedRow?.installed?.status === "CREATING" ||
+    selectedRow?.installed?.status === "UPDATING" ||
+    selectedRow?.installed?.status === "DELETING";
+
+  const detail = selectedRow ? (
+    <AddonDetailPane
+      cluster={cluster}
+      selection={
+        selectedRow.installed
+          ? {
+              kind: "installed",
+              name: selectedRow.name,
+              catalog: selectedRow,
+            }
+          : { kind: "available", catalog: selectedRow }
+      }
+      kubernetesVersion={catalog.data?.kubernetesVersion}
+      onClose={() => setSelectedName(null)}
+      onInstall={() => setInstallTarget(selectedRow)}
+      onUpgrade={() => setUpgradeTarget(selectedRow)}
+      onDelete={() => setDeleteTarget(selectedRow.name)}
+      actionsDisabled={selectedTransient}
+    />
+  ) : null;
+
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto px-6 py-5">
-      <header className="mb-4">
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="shrink-0 px-6 pt-5 pb-3">
         <h1 className="text-[16px] font-medium">
           EKS add-on catalog
           {catalog.data.kubernetesVersion && (
@@ -155,73 +191,89 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
         </p>
       </header>
 
-      <div className="mb-3 flex flex-wrap items-center gap-2">
-        <FilterChip
-          active={ownerFilter === "all"}
-          onClick={() => setOwnerFilter("all")}
-          label="All"
-        />
-        <FilterChip
-          active={ownerFilter === "aws"}
-          onClick={() => setOwnerFilter("aws")}
-          label="AWS"
-        />
-        <FilterChip
-          active={ownerFilter === "third-party"}
-          onClick={() => setOwnerFilter("third-party")}
-          label="Third-party"
-        />
-        <span className="mx-2 text-ink-faint">·</span>
-        <FilterChip
-          active={typeFilter === "all"}
-          onClick={() => setTypeFilter("all")}
-          label="Any type"
-        />
-        {types.map((t) => (
+      <div className="shrink-0 px-6 pb-3">
+        <div className="flex flex-wrap items-center gap-2">
           <FilterChip
-            key={t}
-            active={typeFilter === t}
-            onClick={() => setTypeFilter(t)}
-            label={t}
+            active={ownerFilter === "all"}
+            onClick={() => setOwnerFilter("all")}
+            label="All"
           />
-        ))}
+          <FilterChip
+            active={ownerFilter === "aws"}
+            onClick={() => setOwnerFilter("aws")}
+            label="AWS"
+          />
+          <FilterChip
+            active={ownerFilter === "third-party"}
+            onClick={() => setOwnerFilter("third-party")}
+            label="Third-party"
+          />
+          <span className="mx-2 text-ink-faint">·</span>
+          <FilterChip
+            active={typeFilter === "all"}
+            onClick={() => setTypeFilter("all")}
+            label="Any type"
+          />
+          {types.map((t) => (
+            <FilterChip
+              key={t}
+              active={typeFilter === t}
+              onClick={() => setTypeFilter(t)}
+              label={t}
+            />
+          ))}
+        </div>
       </div>
 
-      {filtered.length === 0 ? (
-        <p className="text-[13px] text-ink-faint">
-          {totalCount === 0
-            ? "AWS returned no add-on catalog for this k8s version."
-            : "No add-ons match the current filters."}
-        </p>
-      ) : (
-        <div className="overflow-hidden rounded-md border border-border bg-surface">
-          <table className="w-full text-[12.5px]">
-            <thead className="border-b border-border bg-surface-2/40 text-[10px] uppercase tracking-[0.08em] text-ink-faint">
-              <tr>
-                <th className="px-3 py-2 text-left">Name</th>
-                <th className="px-3 py-2 text-left">Owner</th>
-                <th className="px-3 py-2 text-left">Type</th>
-                <th className="px-3 py-2 text-left">Latest</th>
-                <th className="px-3 py-2 text-left">Compatible k8s</th>
-                <th className="px-3 py-2 text-left">Status</th>
-                <th className="px-3 py-2 text-right">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((row) => (
-                <CatalogRow
-                  key={row.name}
-                  row={row}
-                  k8sVersion={catalog.data?.kubernetesVersion}
-                  onInstall={() => setInstallTarget(row)}
-                  onUpgrade={() => setUpgradeTarget(row)}
-                  onDelete={() => setDeleteTarget(row.name)}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <SplitPane
+        storageKey="periscope.detailWidth.v4"
+        left={
+          filtered.length === 0 ? (
+            <p className="px-6 py-4 text-[13px] text-ink-faint">
+              {totalCount === 0
+                ? "AWS returned no add-on catalog for this k8s version."
+                : "No add-ons match the current filters."}
+            </p>
+          ) : (
+            <div className="flex h-full min-h-0 flex-col px-6 pb-5">
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-surface">
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <table className="w-full text-[12.5px]">
+                    <thead className="sticky top-0 z-[1] border-b border-border bg-surface-2/90 text-[10px] uppercase tracking-[0.08em] text-ink-faint backdrop-blur-sm">
+                      <tr>
+                        <th className="px-3 py-2 text-left">Name</th>
+                        <th className="px-3 py-2 text-left">Owner</th>
+                        <th className="px-3 py-2 text-left">Type</th>
+                        <th className="px-3 py-2 text-left">Latest</th>
+                        <th className="hidden px-3 py-2 text-left lg:table-cell">
+                          Compatible k8s
+                        </th>
+                        <th className="px-3 py-2 text-left">Status</th>
+                        <th className="px-3 py-2 text-right">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filtered.map((row) => (
+                        <CatalogRow
+                          key={row.name}
+                          row={row}
+                          k8sVersion={catalog.data?.kubernetesVersion}
+                          selected={selectedName === row.name}
+                          onSelect={() => setSelectedName(row.name)}
+                          onInstall={() => setInstallTarget(row)}
+                          onUpgrade={() => setUpgradeTarget(row)}
+                          onDelete={() => setDeleteTarget(row.name)}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          )
+        }
+        right={detail}
+      />
 
       <InstallAddOnDialog
         open={installTarget !== null}
@@ -276,12 +328,16 @@ function FilterChip({
 function CatalogRow({
   row,
   k8sVersion,
+  selected,
+  onSelect,
   onInstall,
   onUpgrade,
   onDelete,
 }: {
   row: CatalogAddon;
   k8sVersion?: string;
+  selected: boolean;
+  onSelect: () => void;
   onInstall: () => void;
   onUpgrade: () => void;
   onDelete: () => void;
@@ -294,7 +350,13 @@ function CatalogRow({
     row.installed?.status === "DELETING";
 
   return (
-    <tr className="border-b border-border last:border-0 transition-colors hover:bg-surface-2">
+    <tr
+      className={cn(
+        "cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-surface-2",
+        selected && "bg-accent-soft/40",
+      )}
+      onClick={onSelect}
+    >
       <td className="px-3 py-2 font-mono">
         {row.name}
         {row.marketplaceProduct && (
@@ -310,7 +372,7 @@ function CatalogRow({
       <td className="px-3 py-2 font-mono text-ink-muted">
         {latest?.version ?? "—"}
       </td>
-      <td className="px-3 py-2 font-mono text-[11.5px] text-ink-muted">
+      <td className="hidden px-3 py-2 font-mono text-[11.5px] text-ink-muted lg:table-cell">
         {compatRange ?? "—"}
       </td>
       <td className="px-3 py-2">
@@ -325,7 +387,10 @@ function CatalogRow({
           </span>
         )}
       </td>
-      <td className="px-3 py-2 text-right">
+      <td
+        className="px-3 py-2 text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
         {row.installed ? (
           <KebabMenu
             label={`actions for ${row.name}`}
@@ -356,4 +421,3 @@ function CatalogRow({
     </tr>
   );
 }
-

--- a/web/src/pages/EKSAddOnsCatalogPage.tsx
+++ b/web/src/pages/EKSAddOnsCatalogPage.tsx
@@ -51,6 +51,12 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
   // rows. Same dialogs as AddOnsPage so the action UX is identical
   // across both surfaces.
   const [upgradeTarget, setUpgradeTarget] = useState<CatalogAddon | null>(null);
+  // Set when the operator clicks a row in the detail-pane's
+  // version-history table; threads the chosen version to
+  // UpgradeAddOnDialog as the initial selection.
+  const [upgradeInitialVersion, setUpgradeInitialVersion] = useState<
+    string | null
+  >(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   // Selected row for the detail pane. Stores the addon name; the
   // pane resolves it back to a CatalogAddon at render time so we
@@ -169,7 +175,14 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
       kubernetesVersion={catalog.data?.kubernetesVersion}
       onClose={() => setSelectedName(null)}
       onInstall={() => setInstallTarget(selectedRow)}
-      onUpgrade={() => setUpgradeTarget(selectedRow)}
+      onUpgrade={() => {
+        setUpgradeInitialVersion(null);
+        setUpgradeTarget(selectedRow);
+      }}
+      onUpgradeToVersion={(v) => {
+        setUpgradeInitialVersion(v);
+        setUpgradeTarget(selectedRow);
+      }}
       onDelete={() => setDeleteTarget(selectedRow.name)}
       actionsDisabled={selectedTransient}
     />
@@ -284,11 +297,15 @@ export function EKSAddOnsCatalogPage({ cluster }: { cluster: string }) {
       />
       <UpgradeAddOnDialog
         open={upgradeTarget !== null}
-        onClose={() => setUpgradeTarget(null)}
+        onClose={() => {
+          setUpgradeTarget(null);
+          setUpgradeInitialVersion(null);
+        }}
         cluster={cluster}
         catalogAddon={upgradeTarget}
         detail={upgradeDetail.data ?? null}
         kubernetesVersion={catalog.data?.kubernetesVersion}
+        initialVersion={upgradeInitialVersion ?? undefined}
       />
       <DeleteAddOnModal
         open={deleteTarget !== null}


### PR DESCRIPTION
## Summary

Five add-ons polish fixes bundled — all surfaced after #122 merge.

- **Right-edge detail pane.** Replaces inline-row-expand on `AddOnsPage` and `EKSAddOnsCatalogPage` with a `SplitPane` + new `AddonDetailPane`, matching every other resource page (pods/deps/configmaps/secrets/RBAC). Pane scrolls independently of the page, so the version-history table no longer pushes the ARN below the fold. Pane width persists under the shared ` periscope.detailWidth.v4 ` storage key, so an operator's chosen width travels across every page in the app. Both installed rows (Upgrade/Delete) and available catalog rows (Install) open the pane on click; the row's primary action button stops propagation so the modal-direct path still works.
- **Form↔YAML toggle in `HelmValuesEditor`.** When a chart's `values.schema.json` contains `$ref` / `allOf` / `anyOf` / arrays-of-objects, the form rendered yellow "yaml only" cards with no escape — operators editing aws-ebs-csi-driver hit a wall. Adds a binary toggle in the editor header so they can flip to raw YAML. Auto-defaults to YAML when the schema has any required-but-unrenderable field. Single change, four dialogs benefit (Helm install/upgrade + EKS add-on install/upgrade).
- **Sticky table headers + internal scroll** on both add-ons tables. Compat-(k8s) column drops below the ` lg ` breakpoint to keep the primary signal columns readable when the pane is open on smaller viewports — same info is in the side pane anyway.
- **Clickable version-history rows** in `AddonDetailBody`. Click a row → upgrade dialog opens with that version pre-selected. The currently-installed row is rendered without the click affordance (AWS rejects upgrade-to-current; better to hide the trap than let the operator hit it). Threads through a new ` initialVersion ` prop on `UpgradeAddOnDialog` that overrides ` pickUpgradeDefault() ` when set.
- **K8s-compatibility dropdown** above the version-history table. Defaults to the cluster's current k8s; switch to the next minor to answer the question raised by the "blocks next k8s minor" warning chip — IS there a newer add-on version that would unblock the cluster upgrade? When none match the selected k8s, the empty state ties back to the warning explicitly.

## Test plan

- [ ] Open an EKS cluster with at least one installed add-on. Click an installed row in `/clusters/<c>/addons`; pane opens on the right. Verify version-history table scrolls inside the pane (not the page). Click "upgrade to" on a non-installed version; upgrade dialog opens with that version pre-selected.
- [ ] On the version-history table, switch the k8s dropdown to a newer minor than the cluster (or a minor with no compatible versions). Confirm the empty state references the "blocks next k8s minor" warning. Click "reset to <current>"; selection snaps back.
- [ ] Open `/clusters/<c>/eks/addons/catalog`. Click an available (non-installed) row; pane opens with catalog metadata + version table + Install button. Click Install; modal opens. Click an installed row; pane opens with detail body + Upgrade/Delete buttons. Verify clicking the inline `+ Install` / kebab on a row does NOT open the pane (event stops propagation).
- [ ] Open the install dialog for `aws-ebs-csi-driver` (it ships a $ref-heavy schema). Confirm the editor defaults to YAML mode; toggle to Form; toggle back. Edit a value in YAML mode; toggle to Form; verify the value is reflected in the form.
- [ ] Drag the SplitPane divider in `/addons` to ~800px. Open `/pods` (or any other resource page); confirm the pane width is ~800px there too — shared storage key.
- [ ] Resize browser to a `< lg ` width with the pane open; confirm Compat-(k8s) column is hidden in both tables.
- [ ] Sticky table header: scroll the table body in both pages; column header stays pinned.
- [ ] ` npx tsc --noEmit ` and ` npx vitest run ` clean (179 tests).