### PR TITLE
fix(eks): hide upgrade-to on downgrades, seed YAML stub for empty add-on configs

### DIFF
--- a/web/src/components/eks/AddonDetailBody.tsx
+++ b/web/src/components/eks/AddonDetailBody.tsx
@@ -22,6 +22,7 @@
 
 import { useMemo, useState } from "react";
 import { useAddon } from "../../hooks/useAddons";
+import { compareAddonVersions } from "../../lib/addonInstall";
 import { cn } from "../../lib/cn";
 import type { AddonVersionEntry } from "../../lib/types";
 
@@ -227,7 +228,7 @@ function VersionHistory({
                 <VersionRow
                   key={v.version}
                   version={v}
-                  isInstalled={v.version === installedVersion}
+                  installedVersion={installedVersion}
                   onUpgradeToVersion={onUpgradeToVersion}
                 />
               ))}
@@ -241,18 +242,26 @@ function VersionHistory({
 
 function VersionRow({
   version,
-  isInstalled,
+  installedVersion,
   onUpgradeToVersion,
 }: {
   version: AddonVersionEntry;
-  isInstalled: boolean;
+  installedVersion: string | null;
   onUpgradeToVersion: ((version: string) => void) | undefined;
 }) {
-  // Clickable when the operator has an upgrade affordance AND this
-  // row isn't the current install. AWS rejects "upgrade to current",
-  // so we hide the affordance rather than letting the operator hit
-  // the wall in the dialog.
-  const clickable = Boolean(onUpgradeToVersion) && !isInstalled;
+  const isInstalled = version.version === installedVersion;
+  // Clickable when (a) the operator has an upgrade affordance,
+  // (b) this row isn't the current install (AWS rejects upgrade
+  // to current), AND (c) this row's version is strictly newer
+  // than installed. We deliberately don't surface a one-click
+  // affordance for downgrades — that path stays available via the
+  // kebab → Upgrade modal, which forces the operator through a
+  // dialog where the deliberate "older eksbuild" choice is visible.
+  // Downgrades carry CRD/IAM/schema risk that one-click obscures.
+  const isNewer =
+    !!installedVersion &&
+    compareAddonVersions(version.version, installedVersion) > 0;
+  const clickable = Boolean(onUpgradeToVersion) && !isInstalled && isNewer;
   const cta = clickable ? (
     <button
       type="button"

--- a/web/src/components/eks/InstallAddOnDialog.tsx
+++ b/web/src/components/eks/InstallAddOnDialog.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   buildInstallRequest,
   filterCompatibleVersions,
+  generateAddonValuesYamlStub,
   parseSchemaSafe,
   pickDefaultVersion,
 } from "../../lib/addonInstall";
@@ -97,6 +98,20 @@ export function InstallAddOnDialog({
     () => parseSchemaSafe(schemaQuery.data?.configurationSchema),
     [schemaQuery.data?.configurationSchema],
   );
+
+  // Seed the YAML editor with a commented schema reference the
+  // first time the schema arrives for an empty buffer. Without
+  // this, the YAML mode renders as a blank textarea — particularly
+  // jarring for addons whose schema forces YAML as the default
+  // (aws-ebs-csi-driver and other $ref / allOf-heavy schemas) and
+  // the operator never sees the form view to learn what fields
+  // exist. The empty-buffer guard preserves operator edits across
+  // version-change re-renders.
+  useEffect(() => {
+    if (!open || !parsedSchema || valuesYaml !== "") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setValuesYaml(generateAddonValuesYamlStub(parsedSchema));
+  }, [open, parsedSchema, valuesYaml]);
 
   const installMutation = useInstallAddon(cluster);
 

--- a/web/src/components/eks/UpgradeAddOnDialog.tsx
+++ b/web/src/components/eks/UpgradeAddOnDialog.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../lib/addonUpgrade";
 import {
   filterCompatibleVersions,
+  generateAddonValuesYamlStub,
   parseSchemaSafe,
 } from "../../lib/addonInstall";
 import { ApiError } from "../../lib/api";
@@ -119,6 +120,18 @@ export function UpgradeAddOnDialog({
     () => parseSchemaSafe(schemaQuery.data?.configurationSchema),
     [schemaQuery.data?.configurationSchema],
   );
+
+  // Same seed-on-empty pattern as InstallAddOnDialog: when the
+  // operator never set configurationValues for this addon, the
+  // editor would open as a blank textarea even with a fully-formed
+  // schema. Seed a commented schema reference so YAML mode is
+  // discoverable. Skipped when detail.configurationValues is
+  // non-empty — that path keeps the operator's prior overrides.
+  useEffect(() => {
+    if (!open || !parsedSchema || valuesYaml !== "") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setValuesYaml(generateAddonValuesYamlStub(parsedSchema));
+  }, [open, parsedSchema, valuesYaml]);
 
   const upgradeMutation = useUpgradeAddon(cluster);
 

--- a/web/src/lib/addonInstall.test.ts
+++ b/web/src/lib/addonInstall.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   buildInstallRequest,
+  compareAddonVersions,
   filterCompatibleVersions,
+  generateAddonValuesYamlStub,
   parseSchemaSafe,
   pickDefaultVersion,
 } from "./addonInstall";
+import type { JSONSchema } from "./helmSchema";
 import type { CatalogAddon } from "./types";
 
 const vpcCNI: CatalogAddon = {
@@ -113,5 +116,115 @@ describe("buildInstallRequest", () => {
     });
     expect(req.serviceAccountRoleArn).toBe("arn:aws:iam::111:role/x");
     expect(req.resolveConflicts).toBe("NONE");
+  });
+});
+
+describe("compareAddonVersions", () => {
+  it("returns positive when a is newer than b on patch", () => {
+    expect(
+      compareAddonVersions("v1.12.2-eksbuild.2", "v1.12.2-eksbuild.1"),
+    ).toBeGreaterThan(0);
+  });
+
+  it("returns negative when a is older than b on minor", () => {
+    expect(
+      compareAddonVersions("v1.12.1-eksbuild.4", "v1.12.2-eksbuild.2"),
+    ).toBeLessThan(0);
+  });
+
+  it("compares numerically — v1.10.0 is newer than v1.7.1", () => {
+    expect(
+      compareAddonVersions("v1.10.0-eksbuild.1", "v1.7.1-eksbuild.2"),
+    ).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for identical versions", () => {
+    expect(
+      compareAddonVersions("v1.12.2-eksbuild.2", "v1.12.2-eksbuild.2"),
+    ).toBe(0);
+  });
+
+  it("treats absent eksbuild suffix as 0 (older than any eksbuild)", () => {
+    expect(
+      compareAddonVersions("v1.12.2", "v1.12.2-eksbuild.1"),
+    ).toBeLessThan(0);
+  });
+
+  it("returns 0 for unparseable versions (defensive — caller hides affordance)", () => {
+    expect(compareAddonVersions("garbage", "also-garbage")).toBe(0);
+  });
+});
+
+describe("generateAddonValuesYamlStub", () => {
+  const schema: JSONSchema = {
+    type: "object",
+    properties: {
+      enableMetrics: {
+        type: "boolean",
+        description: "Enable metrics collection for the controller pod",
+        default: false,
+      },
+      logLevel: {
+        type: "integer",
+        description: "Set the level of verbosity of the logs",
+        default: 2,
+      },
+      loggingFormat: {
+        type: "string",
+        description: "Log format for the driver container",
+        enum: ["text", "json"],
+      },
+      controller: {
+        type: "object",
+        properties: {
+          replicas: {
+            type: "integer",
+            description: "Number of controller replicas",
+            default: 2,
+          },
+          env: {
+            type: "array",
+            description: "Extra env vars",
+          },
+        },
+      },
+    },
+  };
+
+  it("emits a header explaining the commented-stub convention", () => {
+    const stub = generateAddonValuesYamlStub(schema);
+    expect(stub).toMatch(/^# All fields below are commented for reference/);
+    expect(stub).toContain("Empty config = AWS uses all defaults");
+  });
+
+  it("emits each field as a description comment + key:default line", () => {
+    const stub = generateAddonValuesYamlStub(schema);
+    expect(stub).toContain("# Enable metrics collection for the controller pod");
+    expect(stub).toContain("# enableMetrics: false");
+    expect(stub).toContain("# Set the level of verbosity of the logs");
+    expect(stub).toContain("# logLevel: 2");
+  });
+
+  it("emits enum values as a hint comment", () => {
+    const stub = generateAddonValuesYamlStub(schema);
+    expect(stub).toMatch(/# loggingFormat: "" {2}# one of: "text", "json"/);
+  });
+
+  it("emits nested objects with indented children", () => {
+    const stub = generateAddonValuesYamlStub(schema);
+    // Parent and child both at the # convention; child indented one level
+    expect(stub).toContain("# controller:");
+    expect(stub).toMatch(/ {2}# Number of controller replicas/);
+    expect(stub).toMatch(/ {2}# replicas: 2/);
+  });
+
+  it("emits unsupported leaves with the reason inline", () => {
+    const stub = generateAddonValuesYamlStub(schema);
+    // env is an array without items — descriptor type "unsupported"
+    expect(stub).toMatch(/# env:.*array without items schema/);
+  });
+
+  it("returns empty string for an empty schema", () => {
+    expect(generateAddonValuesYamlStub({ type: "object" })).toBe("");
   });
 });

--- a/web/src/lib/addonInstall.ts
+++ b/web/src/lib/addonInstall.ts
@@ -2,7 +2,12 @@
 // #119, PR-2). Extracted out so the (compat-filter, default-pick,
 // schema-parse) logic is unit-testable without standing up a DOM.
 
-import type { JSONSchema } from "./helmSchema";
+import {
+  buildFieldDescriptors,
+  type FieldDescriptor,
+  type FieldType,
+  type JSONSchema,
+} from "./helmSchema";
 import type { CatalogAddon, CatalogAddonVersion } from "./types";
 
 // filterCompatibleVersions narrows an addon's compatible-versions
@@ -48,6 +53,158 @@ export function parseSchemaSafe(raw: string | undefined): JSONSchema | undefined
   } catch {
     return undefined;
   }
+}
+
+// compareAddonVersions compares two EKS-addon version strings of
+// the form "v<x>.<y>.<z>(-<suffix>.<n>)?" — e.g.
+//   v1.12.2-eksbuild.2  > v1.12.2-eksbuild.1
+//   v1.12.2-eksbuild.2  > v1.12.1-eksbuild.4
+//   v1.7.1-eksbuild.2   < v1.10.0-eksbuild.1   (numeric-aware,
+//                                              not lexicographic)
+// Returns >0 when a > b, <0 when a < b, 0 when equal or
+// unparseable. Defensive fallback to 0 on bad shapes so callers
+// can decide ("treat as equal" → no upgrade affordance).
+export function compareAddonVersions(a: string, b: string): number {
+  const ta = parseAddonVersion(a);
+  const tb = parseAddonVersion(b);
+  for (let i = 0; i < Math.max(ta.length, tb.length); i++) {
+    const da = ta[i] ?? 0;
+    const db = tb[i] ?? 0;
+    if (da !== db) return da - db;
+  }
+  return 0;
+}
+
+function parseAddonVersion(v: string): number[] {
+  const stripped = v.replace(/^v/, "");
+  const [main, suffix] = stripped.split("-");
+  const mainParts = (main ?? "").split(".").map((p) => Number(p));
+  if (mainParts.some((n) => Number.isNaN(n))) return [];
+  if (!suffix) return mainParts;
+  // Suffix shapes vary ("eksbuild.2", "eksbuild.4"); we only care
+  // about the trailing integer for ordering. Anything unparseable
+  // becomes 0, which keeps the comparator total.
+  const m = /\.(\d+)$/.exec(suffix);
+  return [...mainParts, m ? Number(m[1]) : 0];
+}
+
+// generateAddonValuesYamlStub turns an addon's JSON Schema into a
+// fully-commented YAML reference the install dialog seeds into the
+// editor when the operator opens it for an addon they haven't
+// configured yet. Without this, the YAML editor is an empty box —
+// the operator has no way to discover what fields exist short of
+// reading AWS docs in another tab. (For addons whose schema has
+// $ref / allOf / arrays-of-objects, YAML mode is the auto-default
+// per HelmValuesEditor's mode picker, so the discoverability
+// problem matters most precisely where it bites hardest.)
+//
+// Format: every line starts `# ` at its YAML-correct indent. To
+// override a leaf, the operator removes `# ` from the leaf line
+// AND each of its parent (object) lines so the structure validates.
+// Field descriptions are emitted as separate `# <text>` lines above
+// each entry. Empty config still means "AWS uses all defaults" —
+// commented lines are no-ops at the YAML parser.
+export function generateAddonValuesYamlStub(schema: JSONSchema): string {
+  const descriptors = buildFieldDescriptors(schema);
+  if (descriptors.length === 0) return "";
+  const lines: string[] = [
+    "# All fields below are commented for reference. Uncomment and",
+    "# edit only what you want to override; to uncomment a nested",
+    "# key, also uncomment its parent key(s) so the YAML structure",
+    "# validates. Empty config = AWS uses all defaults.",
+    "",
+  ];
+  for (const d of descriptors) {
+    emitStubLines(d, 0, lines);
+  }
+  // trim a trailing blank line if present so the editor doesn't
+  // open with two blank rows at the bottom
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.join("\n") + "\n";
+}
+
+function emitStubLines(d: FieldDescriptor, depth: number, out: string[]) {
+  const indent = "  ".repeat(depth);
+  const key = d.path[d.path.length - 1] ?? "";
+  const requiredHint = d.required ? "  # required" : "";
+
+  if (d.description) {
+    // Description split across lines if very long — keeps editor
+    // line lengths reasonable.
+    for (const line of wrapDescription(d.description, 70)) {
+      out.push(`${indent}# ${line}`);
+    }
+  }
+
+  if (d.type === "object" && d.children && d.children.length > 0) {
+    out.push(`${indent}# ${key}:${requiredHint}`);
+    for (const c of d.children) {
+      emitStubLines(c, depth + 1, out);
+    }
+    if (depth === 0) out.push("");
+    return;
+  }
+
+  if (d.type === "unsupported") {
+    out.push(
+      `${indent}# ${key}:  # ${d.unsupportedReason ?? "edit in YAML"}${requiredHint}`,
+    );
+    if (depth === 0) out.push("");
+    return;
+  }
+
+  const defaultStr = formatDefaultLiteral(d.default, d.type);
+  const enumHint =
+    d.enum && d.enum.length > 0
+      ? `  # one of: ${d.enum.map((v) => formatDefaultLiteral(v, d.type)).join(", ")}`
+      : "";
+  out.push(`${indent}# ${key}: ${defaultStr}${enumHint}${requiredHint}`);
+  if (depth === 0) out.push("");
+}
+
+function formatDefaultLiteral(v: unknown, type: FieldType): string {
+  if (v === undefined) {
+    switch (type) {
+      case "string":
+        return '""';
+      case "number":
+      case "integer":
+        return "0";
+      case "boolean":
+        return "false";
+      case "array-of-primitives":
+        return "[]";
+      default:
+        return "";
+    }
+  }
+  if (v === null) return "null";
+  if (typeof v === "string") return JSON.stringify(v);
+  if (typeof v === "boolean" || typeof v === "number") return String(v);
+  if (Array.isArray(v)) {
+    return `[${v.map((x) => JSON.stringify(x)).join(", ")}]`;
+  }
+  return JSON.stringify(v);
+}
+
+function wrapDescription(text: string, max: number): string[] {
+  const t = text.replace(/\s+/g, " ").trim();
+  if (t.length <= max) return [t];
+  const words = t.split(" ");
+  const lines: string[] = [];
+  let cur = "";
+  for (const w of words) {
+    if (cur.length === 0) {
+      cur = w;
+    } else if (cur.length + 1 + w.length > max) {
+      lines.push(cur);
+      cur = w;
+    } else {
+      cur = `${cur} ${w}`;
+    }
+  }
+  if (cur) lines.push(cur);
+  return lines;
 }
 
 // buildInstallRequest assembles the wire-shape request body from


### PR DESCRIPTION
## Summary

Two follow-ups on the add-ons surface, both surfaced during rc-2 testing.

- **Hide the "upgrade to" CTA on rows older than installed.** Previously every non-installed row in the version-history table got the button, including 18 older eksbuilds for aws-guardduty-agent. Clicking any of them opened the upgrade dialog pre-selected to a downgrade — CRD/IAM/schema risk no operator should hit by reflex. Adds ` compareAddonVersions() ` (numeric-aware parser for ` v<x>.<y>.<z>-eksbuild.<n> ` shapes) and gates the row CTA on ` compareAddonVersions(row, installed) > 0 `. Downgrades stay reachable via the kebab → Upgrade modal, which forces the operator through a dialog where the deliberate "older eksbuild" pick is visible.
- **Seed the install/upgrade dialog YAML editor with a commented schema reference when the buffer is empty.** Without this, the YAML editor opens as a blank textarea — particularly bad for ` aws-ebs-csi-driver ` and other ` $ref ` / ` allOf ` / arrays-of-objects schemas where YAML is the auto-default mode and the operator never sees the form view to discover available fields. New ` generateAddonValuesYamlStub() ` walks the schema descriptor tree and emits a fully-commented YAML reference (` helm show values ` pattern) so every available field is discoverable. Empty config still means "AWS uses all defaults" since commented lines are no-ops at the YAML parser. The seed is gated on empty buffer so version-change re-renders preserve operator edits, and the upgrade dialog naturally skips the seed when the addon already has stored ` configurationValues `.

Closes #126 follow-ups (rc-2 feedback).

## Test plan

- [ ] Open ` /clusters/<c>/addons `, click installed ` aws-guardduty-agent ` (or similar with many older eksbuilds). Confirm ONLY versions newer than installed get the "upgrade to" CTA. Older rows render plain — no button, no row hover-pointer. Click an older row and confirm nothing happens.
- [ ] On the same pane, switch the k8s dropdown to a newer minor, observe rows reflow, confirm the "upgrade to" CTA still respects newer-than-installed (not newer-than-anything-in-the-filtered-set).
- [ ] Kebab → Upgrade on the same row. Confirm the modal still lists older versions in the radio (downgrade path preserved); operator can deliberately pick one and submit.
- [ ] Open the catalog, click ` + Install ` on ` aws-ebs-csi-driver `. Confirm the YAML editor opens populated with a header comment + every schema field as commented ` # key: default ` lines, including ` # controller.env: # array without items schema ` etc. Confirm enum hints render (e.g. ` # loggingFormat: "" # one of: "text", "json" `).
- [ ] Toggle to Form mode and back to YAML — buffer preserved, no re-seed.
- [ ] Pick a different version in the dropdown — buffer still preserved (schema may be the same; if it changes, edits stick because the seed only fires on empty buffer).
- [ ] Uncomment one field, hit Install. Confirm the request body's ` configurationValues ` includes only the uncommented portion (the YAML library strips comments on parse — verify in the audit log or by tail-reading the addon's ` configurationValues ` after install settles).
- [ ] Open the upgrade dialog for an addon that already has ` configurationValues ` set. Confirm the editor shows the operator's prior overrides verbatim (no stub seed).
- [ ] Open the upgrade dialog for an addon that does NOT have ` configurationValues ` set. Confirm the stub seeds.
- [ ] ` npx tsc --noEmit ` and ` npx vitest run ` clean (191 tests including 12 new for ` compareAddonVersions ` and ` generateAddonValuesYamlStub `).

🤖 Generated with [Claude Code](https://claude.com/claude-code)