### PR TITLE
chore(theme): tighter dark-mode contrast + JetBrains Mono + theme-token cleanup

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
-        "@fontsource-variable/geist-mono": "^5.2.7",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource/instrument-serif": "^5.2.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -76,6 +76,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -285,27 +286,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -491,10 +471,10 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource-variable/geist-mono": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.7.tgz",
-      "integrity": "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==",
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -1754,6 +1734,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1764,6 +1745,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1774,6 +1756,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1823,6 +1806,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2181,6 +2165,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2292,6 +2277,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2484,6 +2470,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3345,7 +3332,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/monaco-languageserver-types": {
       "version": "0.4.0",
@@ -3563,6 +3551,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3638,6 +3627,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3647,6 +3637,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3984,6 +3975,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4112,6 +4104,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4395,6 +4388,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -286,6 +286,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -619,9 +642,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1114,9 +1137,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1130,9 +1153,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
       "cpu": [
         "arm64"
       ],
@@ -1146,9 +1169,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
       "cpu": [
         "x64"
       ],
@@ -1162,9 +1185,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
       "cpu": [
         "x64"
       ],
@@ -1178,9 +1201,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
       "cpu": [
         "arm"
       ],
@@ -1194,9 +1217,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
       "cpu": [
         "arm64"
       ],
@@ -1210,9 +1233,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
       "cpu": [
         "arm64"
       ],
@@ -1226,9 +1249,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
       "cpu": [
         "ppc64"
       ],
@@ -1242,9 +1265,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
       "cpu": [
         "s390x"
       ],
@@ -1258,9 +1281,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
       "cpu": [
         "x64"
       ],
@@ -1274,9 +1297,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
       "cpu": [
         "x64"
       ],
@@ -1290,9 +1313,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
       "cpu": [
         "arm64"
       ],
@@ -1306,9 +1329,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
       "cpu": [
         "wasm32"
       ],
@@ -1324,9 +1347,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1340,9 +1363,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
       "cpu": [
         "x64"
       ],
@@ -1715,9 +1738,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1729,9 +1752,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.1.tgz",
+      "integrity": "sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -2293,9 +2316,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -2415,16 +2438,16 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.350",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.350.tgz",
-      "integrity": "sha512-/KWD4qK8nMqIoJh35Rpc37fiVyOe80mcUQKpfje0Dp9uot2ROuipsh+EriCdfInxjleD5v1S4OlIn41I0LXP0g==",
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.1.tgz",
+      "integrity": "sha512-8p7DUVq6XJnZEz9W4oSwiwycxBIjHjRzYb3Je3zVN+geKTRQKzAkR/K4PBExlS0090d9nshak6phMUxr3PDjmQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3623,9 +3646,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3633,16 +3656,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-remove-scroll": {
@@ -3762,13 +3785,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3777,27 +3800,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -4100,16 +4123,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -4126,7 +4149,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
-    "@fontsource-variable/geist-mono": "^5.2.7",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource/instrument-serif": "^5.2.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/web/src/components/apply/ApplyYamlInput.tsx
+++ b/web/src/components/apply/ApplyYamlInput.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import * as monaco from "monaco-editor";
 import { cn } from "../../lib/cn";
 import {
+  MONACO_FONT_FAMILY,
   ensureMonacoConfigured,
   useMonacoTheme,
   currentMonacoTheme,
@@ -41,8 +42,7 @@ export function ApplyYamlInput({ value, onChange }: ApplyYamlInputProps) {
       theme: currentMonacoTheme(),
       readOnly: false,
       automaticLayout: true,
-      fontFamily:
-        '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       lineHeight: 19,
       minimap: { enabled: false },

--- a/web/src/components/detail/YamlReadView.tsx
+++ b/web/src/components/detail/YamlReadView.tsx
@@ -17,6 +17,7 @@ import { useEditorYaml } from "../../hooks/useResource";
 import type { EditorSource } from "../../lib/customResources";
 import { cn } from "../../lib/cn";
 import {
+  MONACO_FONT_FAMILY,
   ensureMonacoConfigured,
   useMonacoTheme,
   currentMonacoTheme,
@@ -75,7 +76,7 @@ function MonacoReadEditor({ value }: MonacoReadEditorProps) {
       // for copy still works.
       cursorStyle: "line-thin",
       cursorBlinking: "solid",
-      fontFamily: '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       fontLigatures: true,
       lineHeight: 19,

--- a/web/src/components/detail/yaml/DriftBanner.tsx
+++ b/web/src/components/detail/yaml/DriftBanner.tsx
@@ -60,7 +60,7 @@ export function DriftBanner({
         <div
           className={cn(
             "font-mono text-[11px] font-medium",
-            isUrgent ? "text-red" : "text-yellow-700 dark:text-yellow-300",
+            isUrgent ? "text-red" : "text-yellow",
           )}
         >
           {isUrgent ? "cluster modified by another operator" : "cluster modified by a controller"}

--- a/web/src/components/detail/yaml/DriftDiffOverlay.tsx
+++ b/web/src/components/detail/yaml/DriftDiffOverlay.tsx
@@ -83,7 +83,7 @@ export function DriftDiffOverlay({
       <>
         {/* Header */}
         <header className="shrink-0 border-b border-border bg-surface px-5 py-3">
-          <div className="font-mono text-[10px] uppercase tracking-[0.10em] text-yellow-700 dark:text-yellow-300">
+          <div className="font-mono text-[10px] uppercase tracking-[0.10em] text-yellow">
             cluster diff · viewing
           </div>
           <h2

--- a/web/src/components/detail/yaml/InlineDiff.tsx
+++ b/web/src/components/detail/yaml/InlineDiff.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef } from "react";
 import * as monaco from "monaco-editor";
 
 import {
+  MONACO_FONT_FAMILY,
   currentMonacoTheme,
   ensureMonacoConfigured,
   useMonacoTheme,
@@ -35,7 +36,7 @@ export function InlineDiff({ original, proposed }: InlineDiffProps) {
       readOnly: true,
       automaticLayout: true,
       renderSideBySide: false,
-      fontFamily: '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       lineHeight: 19,
       minimap: { enabled: false },

--- a/web/src/components/detail/yaml/SchemaMissingBanner.tsx
+++ b/web/src/components/detail/yaml/SchemaMissingBanner.tsx
@@ -28,7 +28,7 @@ export function SchemaMissingBanner({ kindLabel }: SchemaMissingBannerProps) {
     >
       <span aria-hidden className="mt-1 size-2 shrink-0 rounded-sm bg-yellow" />
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[11px] font-medium text-yellow-700 dark:text-yellow-300">
+        <div className="font-mono text-[11px] font-medium text-yellow">
           schema unavailable — validation off
         </div>
         <div className="mt-0.5 font-mono text-[11.5px] text-ink-muted">

--- a/web/src/components/detail/yaml/YamlEditor.tsx
+++ b/web/src/components/detail/yaml/YamlEditor.tsx
@@ -55,6 +55,7 @@ import {
 } from "../../../lib/managedFields";
 import { pathForLine } from "../../../lib/yamlPath";
 import {
+  MONACO_FONT_FAMILY,
   currentMonacoTheme,
   ensureMonacoConfigured,
   ensureMonacoYamlConfigured,
@@ -446,7 +447,7 @@ function Editor({ cluster, source, resource, pristine }: EditorProps) {
       theme: currentMonacoTheme(),
       readOnly: false,
       automaticLayout: true,
-      fontFamily: '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       fontLigatures: true,
       lineHeight: 19,

--- a/web/src/components/helm/HelmValuesYaml.tsx
+++ b/web/src/components/helm/HelmValuesYaml.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useRef } from "react";
 import * as monaco from "monaco-editor";
 import {
+  MONACO_FONT_FAMILY,
   ensureMonacoConfigured,
   useMonacoTheme,
   currentMonacoTheme,
@@ -38,7 +39,7 @@ export function HelmValuesYaml({ value, onChange }: HelmValuesYamlProps) {
       theme: currentMonacoTheme(),
       readOnly: false,
       automaticLayout: true,
-      fontFamily: '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       lineHeight: 19,
       minimap: { enabled: false },

--- a/web/src/components/helm/MonacoYAML.tsx
+++ b/web/src/components/helm/MonacoYAML.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import * as monaco from "monaco-editor";
 import { cn } from "../../lib/cn";
 import {
+  MONACO_FONT_FAMILY,
   ensureMonacoConfigured,
   useMonacoTheme,
   currentMonacoTheme,
@@ -36,7 +37,7 @@ export function MonacoYAML({ value, emptyLabel }: MonacoYAMLProps) {
       theme: currentMonacoTheme(),
       readOnly: true,
       automaticLayout: true,
-      fontFamily: '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace',
+      fontFamily: MONACO_FONT_FAMILY,
       fontSize: 12.5,
       lineHeight: 19,
       minimap: { enabled: false },

--- a/web/src/exec/Terminal.tsx
+++ b/web/src/exec/Terminal.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { bindTerminal } from "./term-bus";
+import { MONACO_FONT_FAMILY } from "../lib/monacoSetup";
 import type { ExecClient } from "./ExecClient";
 
 /**
@@ -20,8 +21,9 @@ interface TerminalProps {
   active: boolean;
 }
 
-const FONT_FAMILY =
-  '"Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace';
+// Reuse the Monaco font stack for xterm so the in-browser shell looks
+// consistent with the YAML editor + every other code surface.
+const FONT_FAMILY = MONACO_FONT_FAMILY;
 
 /**
  * Read the live CSS custom properties so the xterm theme tracks Periscope's

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @import "@fontsource-variable/geist";
-@import "@fontsource-variable/geist-mono";
+@import "@fontsource-variable/jetbrains-mono";
 @import "@fontsource/instrument-serif/400.css";
 @import "@fontsource/instrument-serif/400-italic.css";
 
@@ -11,7 +11,7 @@
   --font-sans: "Geist Variable", ui-sans-serif, system-ui, -apple-system,
     "Segoe UI", sans-serif;
   --font-display: "Instrument Serif", Georgia, "Times New Roman", serif;
-  --font-mono: "Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-mono: "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;
 
   --color-bg: var(--bg);
   --color-surface: var(--surface);
@@ -29,6 +29,13 @@
   --color-yellow-soft: var(--yellow-soft);
   --color-red: var(--red);
   --color-red-soft: var(--red-soft);
+  /* Categorical tokens used by lib/managers.ts to badge SSA field
+   * managers in the conflict view. These don't carry a semantic
+   * meaning beyond "differentiate the N categories visually" so
+   * they live alongside the named semantic colors above. */
+  --color-blue: var(--blue);
+  --color-violet: var(--violet);
+  --color-teal: var(--teal);
 }
 
 :root {
@@ -37,7 +44,12 @@
   --surface-2: #ebe6db;
   --ink: #1a1815;
   --ink-muted: #6b665c;
-  --ink-faint: #a39d8f;
+  /* Lifted from #a39d8f (2.65:1 against --surface — failed even
+   * AA large/UI 3.0 minimum) to #777267 (4.50:1 — passes AA body
+   * 4.5 threshold). Affects every faint-tier label site app-wide
+   * (breadcrumbs, hint text, "ago" timestamps, path fragments
+   * next to form labels). */
+  --ink-faint: #777267;
   --border: rgba(26, 24, 21, 0.1);
   --border-strong: rgba(26, 24, 21, 0.2);
   --accent: #c2410c;
@@ -48,17 +60,32 @@
   --yellow-soft: rgba(161, 98, 7, 0.14);
   --red: #b91c1c;
   --red-soft: rgba(185, 28, 28, 0.1);
+  /* Categorical (manager-class) colors. Picked from Tailwind's
+   * 600 stops for solid AA contrast against --surface light. */
+  --blue: #2563eb;
+  --violet: #7c3aed;
+  --teal: #0d9488;
 
   color-scheme: light;
 }
 
 .dark {
-  --bg: #16140f;
-  --surface: #1f1c16;
-  --surface-2: #100e0a;
+  /* Backgrounds darkened a notch (was #16140f / #1f1c16 / #100e0a)
+   * for two reasons: operators reported the previous shade felt
+   * "washed out" against monospace UI density, AND the deeper bg
+   * lifts existing text contrast a touch without changing token
+   * values. Still warm-tone (preserves Periscope's aesthetic vs
+   * the cold black of generic devtools). */
+  --bg: #0d0c08;
+  --surface: #15130e;
+  --surface-2: #080704;
   --ink: #ece7d9;
   --ink-muted: #9b948a;
-  --ink-faint: #615b50;
+  /* Lifted from #615b50 (2.52:1 against --surface — failed even
+   * AA large/UI 3.0 minimum) to #8a8378 (~4.95:1 against the new
+   * --surface — passes AA body). Same root-cause fix as light
+   * mode above: faint-tier text was silently below WCAG. */
+  --ink-faint: #8a8378;
   --border: rgba(255, 250, 235, 0.08);
   --border-strong: rgba(255, 250, 235, 0.16);
   --accent: #fb923c;
@@ -69,6 +96,11 @@
   --yellow-soft: rgba(251, 191, 36, 0.14);
   --red: #f87171;
   --red-soft: rgba(248, 113, 113, 0.14);
+  /* Categorical (manager-class) colors. Tailwind 400 stops for
+   * AA contrast against --surface dark. */
+  --blue: #60a5fa;
+  --violet: #a78bfa;
+  --teal: #2dd4bf;
 
   color-scheme: dark;
 }

--- a/web/src/lib/managers.ts
+++ b/web/src/lib/managers.ts
@@ -339,11 +339,11 @@ export function managerColorClass(category: ManagerCategory): {
     case "GITOPS":
       return { text: "text-violet", bg: "bg-violet/10", border: "border-violet/40", glyph: "bg-violet" };
     case "CONTROLLER":
-      return { text: "text-blue-500", bg: "bg-blue-500/10", border: "border-blue-500/40", glyph: "bg-blue-500" };
+      return { text: "text-blue", bg: "bg-blue/10", border: "border-blue/40", glyph: "bg-blue" };
     case "HUMAN":
       return { text: "text-green", bg: "bg-green-soft", border: "border-green/40", glyph: "bg-green" };
     case "HELM":
-      return { text: "text-teal-500", bg: "bg-teal-500/10", border: "border-teal-500/40", glyph: "bg-teal-500" };
+      return { text: "text-teal", bg: "bg-teal/10", border: "border-teal/40", glyph: "bg-teal" };
     case "PERISCOPE":
       return { text: "text-accent", bg: "bg-accent-soft", border: "border-accent/40", glyph: "bg-accent" };
     case "UNKNOWN":

--- a/web/src/lib/monacoSetup.ts
+++ b/web/src/lib/monacoSetup.ts
@@ -40,6 +40,17 @@ import { useEffect } from "react";
   },
 };
 
+/**
+ * Font stack for every Monaco editor instance app-wide. Mirrors the
+ * `--font-mono` CSS variable defined in `src/index.css` — Monaco
+ * doesn't read CSS variables directly (it owns its own canvas-style
+ * rendering pipeline), so we maintain a small parallel constant here
+ * that callers import. Update both sites together when the mono font
+ * changes (e.g. Geist Mono → JetBrains Mono in #N).
+ */
+export const MONACO_FONT_FAMILY =
+  '"JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, monospace';
+
 let configured = false;
 
 export function ensureMonacoConfigured(): void {


### PR DESCRIPTION
Three coupled changes from operator feedback. No behavior change, no new tests (theme-only).

## Why

Team flagged two issues:
1. Dark mode "light grey on dark panel" causing eye strain
2. The mono font (Geist Mono) feels cramped at small sizes for the dense terminal-style UI

Ran a WCAG contrast script against the current dark mode tokens and found the **real** root cause: `--ink-faint` was at **2.52:1** against `--surface` — failing even the AA large/UI 3.0 minimum, never mind the 4.5 body threshold. Light mode had the same bug (`#a39d8f` on `#fffdf7` = 2.65:1) but office lighting was masking it.

## What changed

### 1. Dark mode contrast (`web/src/index.css`)
- Backgrounds darkened a notch — still warm-tone, not OLED-cold:
  - ` --bg `: ` #16140f ` → ` #0d0c08 `
  - ` --surface `: ` #1f1c16 ` → ` #15130e `
  - ` --surface-2 `: ` #100e0a ` → ` #080704 `
- ` --ink-faint ` lifted ` #615b50 ` → ` #8a8378 ` (~5:1 against new ` --surface `, AA body ✓)
- ` --ink ` and ` --ink-muted ` unchanged — they were already AAA / AA

### 2. Light mode contrast (`web/src/index.css`)
- ` --ink-faint ` lifted ` #a39d8f ` → ` #777267 ` (4.5:1, AA body ✓). No one had complained yet but it was the same latent failure.

### 3. JetBrains Mono swap (`package.json`, `web/src/index.css`)
- Replaced ` @fontsource-variable/geist-mono ` with ` @fontsource-variable/jetbrains-mono `
- ` --font-mono ` value updated
- Sans (Geist) and display (Instrument Serif) untouched

### 4. Monaco font centralization (` web/src/lib/monacoSetup.ts ` + 7 editor files)
- New ` MONACO_FONT_FAMILY ` constant — Monaco doesn't read CSS variables (own canvas-style render pipeline) so we maintain a small parallel constant
- Replaced 7 hardcoded font strings: ` InlineDiff `, ` YamlEditor `, ` MonacoYAML `, ` YamlReadView `, ` HelmValuesYaml `, ` ApplyYamlInput `, ` Terminal ` (xterm.js)
- Future font swap is now 1 line

### 5. Theme-token cleanup (4 files audit findings)
- ` lib/managers.ts:342 ` — ` text-blue-500 ` / ` bg-blue-500/10 ` etc. were Tailwind defaults, bypassing theme. Added ` --color-blue ` / ` --color-violet ` / ` --color-teal ` theme tokens (light + dark) so manager-color badges in the SSA conflict view stay semantically distinct AND theme-controlled. Side-effect: ` text-violet ` (which had no token defined) now actually renders.
- ` DriftBanner ` / ` DriftDiffOverlay ` / ` SchemaMissingBanner ` — three ` text-yellow-700 dark:text-yellow-300 ` instances replaced with the project's ` text-yellow ` token (which already swaps light/dark via CSS variables).

## Verification

- ` npx tsc --noEmit ` clean
- ` npx eslint ` clean (touched files)
- ` npx vitest run ` — **191 tests pass**
- WCAG contrast script run against new values:
  - Dark ` --ink ` on ` --surface `: 15.02:1 (AAA)
  - Dark ` --ink-muted ` on ` --surface `: 6.18:1 (AA body)
  - Dark ` --ink-faint ` on ` --surface `: ~5:1 (AA body) — was 2.52:1, FAIL
  - Light ` --ink-faint ` on ` --surface `: 4.5:1 (AA body) — was 2.65:1, FAIL
  - All semantic colors (accent / yellow / red / green): AA / AAA in both modes

## What you'll see visually

- **Dark mode background**: deeper warm black, more contrast against the surface cards
- **Faint text** (breadcrumbs, "X ago" timestamps, hint text under labels): noticeably more readable in both modes
- **JetBrains Mono**: wider letterforms in every code surface — YAML editors, helm values, exec terminal, addon configs, manager badges
- **Manager badges** in the SSA conflict view: GITOPS (violet) actually colors now (was rendering as no-color before)

## Test plan

- [ ] Toggle the app between light and dark mode (` html.dark ` class or system pref). All text remains readable; no jarring contrast jumps.
- [ ] Dark mode: hover the breadcrumb path on a resource detail page — the faint path is readable, not washed out.
- [ ] Edit a YAML resource — Monaco shows JetBrains Mono. Type some code; cursor shape / line numbers / fold gutter all visible.
- [ ] Open in-browser pod exec — xterm shows JetBrains Mono.
- [ ] Open the SSA conflict view (force apply on a controller-owned field). Manager badges show distinct colors per category — GITOPS violet, CONTROLLER blue, HUMAN green, HELM teal, PERISCOPE accent.
- [ ] Open a CRD without a registered OpenAPI v3 schema. SchemaMissingBanner shows the yellow heading text in both modes.
- [ ] Trigger a drift event (edit a resource externally while open in editor). DriftBanner yellow heading text reads cleanly in both modes.

## Out of scope

- Reverting / changing the sans font (Geist Variable). Team's complaint was specifically about the mono font, which is what most of Periscope renders in.
- Theming overhaul (e.g. user-pickable themes). Tokens are now centralized enough to make this easy whenever it becomes a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)