### PR TITLE
feat: ux-polish-pass — fleet/overview EoSS, image columns, ops chips

### DIFF
--- a/cmd/periscope/eks_nodegroups_handler.go
+++ b/cmd/periscope/eks_nodegroups_handler.go
@@ -10,18 +10,17 @@ package main
 // gating + audit pattern as eks_insights_handler.go: 422 +
 // E_BACKEND_NOT_EKS for non-EKS, 502 for AWS failures, audit row on
 // every call regardless of outcome.
+// Returns nodegroup list with current AMI release version + custom-AMI flag.
+// Drift computation (latest AMI vs current release_version, days behind)
+// is wired into applyDrift — it fans out per-nodegroup to the SSM AMI
+// catalog (eks_ami_catalog.go) when the request reaches us with a
+// non-nil amiCache (always non-nil in production main.go wiring).
 //
-// PR-2 scope (this commit): nodegroup list with current AMI release
-// version + custom-AMI flag. NO drift computation — the
-// DriftComputed flag is always false on responses produced here.
-// PR-3 wires the SSM-based "latest AMI" lookup and fills the drift
-// fields onto the response.
-//
-// Custom AMIs (AmiType == "CUSTOM"): we surface the launch template
-// reference and a `customAmi: true` flag so the SPA can render a
-// "drift not tracked" badge. PR-3 explicitly skips the drift hop
-// for these — when an operator ships a custom image, freshness is
-// the operator's responsibility.
+// Custom AMIs (AmiType == "CUSTOM"): the launch template reference is
+// surfaced and `customAmi: true` is set so the SPA can render a "drift
+// not tracked" badge. applyDrift skips the drift hop for these — when
+// an operator ships a custom image, freshness is the operator's
+// responsibility.
 
 import (
 	"context"
@@ -79,8 +78,8 @@ func defaultNewEKSNodegroupsClient(p credentials.Provider, c clusters.Cluster) e
 // ── Wire types ───────────────────────────────────────────────────────
 
 // NodegroupSummary is one row in the list response. The drift fields
-// are present on the wire so the SPA can pre-allocate columns; in
-// PR-2 they always come back zero/false (DriftComputed=false).
+// are present on the wire so the SPA can pre-allocate columns and
+// applyDrift fills them on the success path (false on cache miss + SSM error).
 type NodegroupSummary struct {
 	Name              string `json:"name"`
 	Status            string `json:"status"`
@@ -101,7 +100,7 @@ type NodegroupSummary struct {
 	HealthIssueCount     int    `json:"healthIssueCount"`
 	CreatedAt            *time.Time `json:"createdAt,omitempty"`
 
-	// Drift fields. Populated by PR-3; always zero in PR-2.
+	// Drift fields. Populated by applyDrift; zero when the AMI catalog
 	DriftComputed       bool   `json:"driftComputed"`
 	LatestReleaseVersion string `json:"latestReleaseVersion,omitempty"`
 	DaysBehind          int    `json:"daysBehind,omitempty"`

--- a/cmd/periscope/fleet_handler.go
+++ b/cmd/periscope/fleet_handler.go
@@ -58,6 +58,13 @@ type FleetClusterEntry struct {
 	// backends; empty for EKS.
 	Context     string            `json:"context,omitempty"`
 	Tags        map[string]string `json:"tags,omitempty"`
+
+	// EKS lifecycle window. Sourced from ClusterSummary; populated
+	// only for EKSCapable() clusters with eks:DescribeClusterVersions
+	// permission. Drives the version + EoSS chip on the cluster card.
+	KubernetesVersion        string     `json:"kubernetesVersion,omitempty"`
+	EndOfStandardSupportDate *time.Time `json:"endOfStandardSupportDate,omitempty"`
+	EndOfExtendedSupportDate *time.Time `json:"endOfExtendedSupportDate,omitempty"`
 	Status      string            `json:"status"`
 	LastContact time.Time         `json:"lastContact"`
 	Summary     *FleetSummary     `json:"summary,omitempty"`
@@ -222,6 +229,9 @@ func collectOne(ctx context.Context, c clusters.Cluster, p credentials.Provider,
 		StuckOrFailed: summary.PodPhases.Stuck + summary.PodPhases.Failed,
 	}
 	entry.HotSignals = summarizeHotSignals(summary.NeedsAttention)
+	entry.KubernetesVersion = summary.KubernetesVersion
+	entry.EndOfStandardSupportDate = summary.EndOfStandardSupportDate
+	entry.EndOfExtendedSupportDate = summary.EndOfExtendedSupportDate
 
 	cache.Put(p.Actor(), c.Name, imp.Groups, entry)
 	return entry

--- a/internal/k8s/daemonsets.go
+++ b/internal/k8s/daemonsets.go
@@ -101,6 +101,7 @@ func GetDaemonSetYAML(ctx context.Context, p credentials.Provider, args GetDaemo
 }
 
 func daemonSetSummary(d *appsv1.DaemonSet) DaemonSet {
+	firstImage, imageCount := firstContainerImage(d.Spec.Template.Spec)
 	return DaemonSet{
 		Name:                   d.Name,
 		Namespace:              d.Namespace,
@@ -109,6 +110,8 @@ func daemonSetSummary(d *appsv1.DaemonSet) DaemonSet {
 		UpdatedNumberScheduled: d.Status.UpdatedNumberScheduled,
 		NumberAvailable:        d.Status.NumberAvailable,
 		NumberMisscheduled:     d.Status.NumberMisscheduled,
+		Image:                  firstImage,
+		ImageCount:             imageCount,
 		CreatedAt:              d.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -104,6 +104,7 @@ func deploymentSummary(d *appsv1.Deployment) Deployment {
 	if d.Spec.Replicas != nil {
 		replicas = *d.Spec.Replicas
 	}
+	firstImage, imageCount := firstContainerImage(d.Spec.Template.Spec)
 	return Deployment{
 		Name:              d.Name,
 		Namespace:         d.Namespace,
@@ -111,6 +112,8 @@ func deploymentSummary(d *appsv1.Deployment) Deployment {
 		ReadyReplicas:     d.Status.ReadyReplicas,
 		UpdatedReplicas:   d.Status.UpdatedReplicas,
 		AvailableReplicas: d.Status.AvailableReplicas,
+		Image:             firstImage,
+		ImageCount:        imageCount,
 		CreatedAt:         d.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/eks_metadata.go
+++ b/internal/k8s/eks_metadata.go
@@ -1,0 +1,89 @@
+// EKS-side cluster metadata that the K8s clientset doesn't surface —
+// specifically the support-window dates from DescribeClusterVersions.
+// Lives in package k8s next to summary.go so cluster-overview + fleet
+// share one collection path; both call FetchEKSClusterMetadata to get
+// the EoSS / EoExt dates.
+//
+// AWS exposes EoSS per K8s minor version (not per cluster), so we
+// extract "1.34" from the K8s server's GitVersion and look it up in
+// the catalog.
+package k8s
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// EKSClusterMetadata is the AWS-side lifecycle data for a managed
+// EKS cluster. Both fields are pointer-typed: nil = AWS didn't return
+// the field for this version (e.g. extended support not yet announced
+// for newer minors).
+type EKSClusterMetadata struct {
+	EndOfStandardSupportDate *time.Time
+	EndOfExtendedSupportDate *time.Time
+}
+
+// FetchEKSClusterMetadata calls eks:DescribeClusterVersions for the
+// cluster's K8s minor version and returns the support-window dates.
+//
+// Soft-fails on any AWS error (returns zero value, nil err) so a
+// missing IAM permission doesn't poison the rest of the summary —
+// the EoSS chip just won't render. Required IAM action:
+// eks:DescribeClusterVersions on Resource: "*".
+//
+// kubernetesVersion is the GitVersion from the K8s server
+// (e.g. "v1.34.7-eks-abc1234"); we strip down to the "1.34" portion
+// EKS uses as a version selector.
+func FetchEKSClusterMetadata(ctx context.Context, p credentials.Provider, c clusters.Cluster, kubernetesVersion string) (EKSClusterMetadata, error) {
+	if !c.EKSCapable() {
+		return EKSClusterMetadata{}, nil
+	}
+	minor := extractMinorVersion(kubernetesVersion)
+	if minor == "" {
+		return EKSClusterMetadata{}, nil
+	}
+
+	awsCfg := aws.Config{
+		Region:      c.Region,
+		Credentials: p,
+	}
+	eksClient := eks.NewFromConfig(awsCfg)
+	out, err := eksClient.DescribeClusterVersions(ctx, &eks.DescribeClusterVersionsInput{
+		ClusterVersions: []string{minor},
+	})
+	if err != nil {
+		return EKSClusterMetadata{}, nil
+	}
+	if len(out.ClusterVersions) == 0 {
+		return EKSClusterMetadata{}, nil
+	}
+
+	info := out.ClusterVersions[0]
+	return EKSClusterMetadata{
+		EndOfStandardSupportDate: info.EndOfStandardSupportDate,
+		EndOfExtendedSupportDate: info.EndOfExtendedSupportDate,
+	}, nil
+}
+
+// minorVersionRe extracts "MAJOR.MINOR" from a K8s GitVersion.
+// Examples:
+//
+//	"v1.34.7-eks-abc1234" → "1.34"
+//	"v1.33.11"            → "1.33"
+//	"1.32"                → "1.32"
+var minorVersionRe = regexp.MustCompile(`^v?(\d+\.\d+)`)
+
+func extractMinorVersion(gitVersion string) string {
+	m := minorVersionRe.FindStringSubmatch(gitVersion)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}

--- a/internal/k8s/extras.go
+++ b/internal/k8s/extras.go
@@ -293,6 +293,7 @@ func replicaSetSummary(r *appsv1.ReplicaSet) ReplicaSet {
 	if r.Spec.Replicas != nil {
 		desired = *r.Spec.Replicas
 	}
+	firstImage, imageCount := firstContainerImage(r.Spec.Template.Spec)
 	return ReplicaSet{
 		Name:      r.Name,
 		Namespace: r.Namespace,
@@ -300,6 +301,8 @@ func replicaSetSummary(r *appsv1.ReplicaSet) ReplicaSet {
 		Desired:   desired,
 		Current:   r.Status.Replicas,
 		Ready:     r.Status.ReadyReplicas,
+		Image:      firstImage,
+		ImageCount: imageCount,
 		Owner:     owner,
 	}
 }

--- a/internal/k8s/ingresses.go
+++ b/internal/k8s/ingresses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,41 @@ func ListIngresses(ctx context.Context, p credentials.Provider, args ListIngress
 	}
 
 	out := IngressList{Ingresses: make([]Ingress, 0, len(raw.Items))}
+
+	// Build a per-namespace TLS-expiry map by listing secrets once
+	// and parsing tls.crt for each kubernetes.io/tls secret. Soft-
+	// fail: when secret.list is denied to the actor, the map stays
+	// empty and ingress rows render with TLSExpiresAt=nil (em-dash
+	// chip in the SPA). The cost is one extra Secret list call
+	// per Ingress list request, scoped to the same namespace.
+	tlsExpiry := map[string]map[string]*time.Time{}
+	if secrets, secErr := cs.CoreV1().Secrets(args.Namespace).List(ctx, metav1.ListOptions{}); secErr == nil {
+		for i := range secrets.Items {
+			s := &secrets.Items[i]
+			exp := secretTLSExpiry(s)
+			if exp == nil {
+				continue
+			}
+			ns := tlsExpiry[s.Namespace]
+			if ns == nil {
+				ns = map[string]*time.Time{}
+				tlsExpiry[s.Namespace] = ns
+			}
+			ns[s.Name] = exp
+		}
+	}
 	for _, ing := range raw.Items {
-		out.Ingresses = append(out.Ingresses, ingressSummary(&ing))
+		summary := ingressSummary(&ing)
+		// Fold soonest TLS expiry across the ingress'\''s spec.tls[].
+		if nsMap, ok := tlsExpiry[ing.Namespace]; ok {
+			for _, t := range ing.Spec.TLS {
+				if t.SecretName == "" {
+					continue
+				}
+				summary.TLSExpiresAt = soonestExpiry(summary.TLSExpiresAt, nsMap[t.SecretName])
+			}
+		}
+		out.Ingresses = append(out.Ingresses, summary)
 	}
 	return out, nil
 }

--- a/internal/k8s/nodes.go
+++ b/internal/k8s/nodes.go
@@ -87,12 +87,30 @@ func GetNode(ctx context.Context, p credentials.Provider, args GetNodeArgs) (Nod
 }
 
 func nodeSummary(n *corev1.Node) Node {
+	instanceType := n.Labels["node.kubernetes.io/instance-type"]
+	if instanceType == "" {
+		instanceType = n.Labels["beta.kubernetes.io/instance-type"]
+	}
+	zone := n.Labels["topology.kubernetes.io/zone"]
+	if zone == "" {
+		zone = n.Labels["failure-domain.beta.kubernetes.io/zone"]
+	}
+	// EKS managed nodegroups + Karpenter both expose capacity type
+	// but with different label keys. Try EKS first; fall back to
+	// Karpenter (lowercased values: "on-demand" / "spot").
+	capacityType := n.Labels["eks.amazonaws.com/capacityType"]
+	if capacityType == "" {
+		capacityType = n.Labels["karpenter.sh/capacity-type"]
+	}
 	return Node{
 		Name:           n.Name,
 		Status:         nodeStatus(n.Status.Conditions),
 		Roles:          nodeRoles(n.Labels),
 		KubeletVersion: n.Status.NodeInfo.KubeletVersion,
 		InternalIP:     nodeInternalIP(n.Status.Addresses),
+		InstanceType:   instanceType,
+		Zone:           zone,
+		CapacityType:   capacityType,
 		CPUCapacity:    formatCPU(n.Status.Capacity.Cpu().MilliValue()),
 		MemoryCapacity: formatMemory(n.Status.Capacity.Memory().Value()),
 		CreatedAt:      n.CreationTimestamp.Time,

--- a/internal/k8s/pods.go
+++ b/internal/k8s/pods.go
@@ -201,6 +201,7 @@ func podSummary(pod *corev1.Pod) Pod {
 		}
 		restarts += cstat.RestartCount
 	}
+	podFirstImage, podImageCount := firstContainerImage(pod.Spec)
 	return Pod{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,
@@ -209,6 +210,9 @@ func podSummary(pod *corev1.Pod) Pod {
 		PodIP:     pod.Status.PodIP,
 		Ready:     strconv.Itoa(readyContainers) + "/" + strconv.Itoa(totalContainers),
 		Restarts:  restarts,
+		Image:      podFirstImage,
+		ImageCount: podImageCount,
+		QoS:        string(pod.Status.QOSClass),
 		CreatedAt: pod.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/secrets.go
+++ b/internal/k8s/secrets.go
@@ -134,6 +134,7 @@ func secretSummary(s *corev1.Secret) Secret {
 		Namespace: s.Namespace,
 		Type:      string(s.Type),
 		KeyCount:  len(s.Data),
+		TLSExpiresAt: secretTLSExpiry(s),
 		CreatedAt: s.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/services.go
+++ b/internal/k8s/services.go
@@ -27,8 +27,38 @@ func ListServices(ctx context.Context, p credentials.Provider, args ListServices
 	}
 
 	out := ServiceList{Services: make([]Service, 0, len(raw.Items))}
+
+	// Endpoint counts: list EndpointSlices once and key by
+	// kubernetes.io/service-name. Soft-fail — empty maps just
+	// leave the counts at zero, which the SPA renders as a
+	// "0 endpoints" warning chip (the operationally-relevant
+	// state we are trying to surface).
+	type sliceCounts struct{ total, ready int }
+	endpointMap := map[string]sliceCounts{}
+	if eps, err := cs.DiscoveryV1().EndpointSlices(args.Namespace).List(ctx, metav1.ListOptions{}); err == nil {
+		for _, slice := range eps.Items {
+			svcName := slice.Labels["kubernetes.io/service-name"]
+			if svcName == "" {
+				continue
+			}
+			key := slice.Namespace + "/" + svcName
+			c := endpointMap[key]
+			for _, ep := range slice.Endpoints {
+				c.total++
+				if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
+					c.ready++
+				}
+			}
+			endpointMap[key] = c
+		}
+	}
 	for _, svc := range raw.Items {
-		out.Services = append(out.Services, serviceSummary(&svc))
+		s := serviceSummary(&svc)
+		if c, ok := endpointMap[svc.Namespace+"/"+svc.Name]; ok {
+			s.EndpointCount = c.total
+			s.ReadyEndpointCount = c.ready
+		}
+		out.Services = append(out.Services, s)
 	}
 	return out, nil
 }

--- a/internal/k8s/statefulsets.go
+++ b/internal/k8s/statefulsets.go
@@ -105,6 +105,7 @@ func statefulSetSummary(s *appsv1.StatefulSet) StatefulSet {
 	if s.Spec.Replicas != nil {
 		replicas = *s.Spec.Replicas
 	}
+	firstImage, imageCount := firstContainerImage(s.Spec.Template.Spec)
 	return StatefulSet{
 		Name:            s.Name,
 		Namespace:       s.Namespace,
@@ -112,6 +113,8 @@ func statefulSetSummary(s *appsv1.StatefulSet) StatefulSet {
 		ReadyReplicas:   s.Status.ReadyReplicas,
 		UpdatedReplicas: s.Status.UpdatedReplicas,
 		CurrentReplicas: s.Status.CurrentReplicas,
+		Image:           firstImage,
+		ImageCount:      imageCount,
 		CreatedAt:       s.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/storageclasses.go
+++ b/internal/k8s/storageclasses.go
@@ -78,12 +78,14 @@ func storageClassSummary(sc *storagev1.StorageClass) StorageClass {
 		vbm = string(*sc.VolumeBindingMode)
 	}
 	allowExpansion := sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion
+	isDefault := sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true"
 	return StorageClass{
 		Name:                 sc.Name,
 		Provisioner:          sc.Provisioner,
 		ReclaimPolicy:        rp,
 		VolumeBindingMode:    vbm,
 		AllowVolumeExpansion: allowExpansion,
+		IsDefault:            isDefault,
 		CreatedAt:            sc.CreationTimestamp.Time,
 	}
 }

--- a/internal/k8s/summary.go
+++ b/internal/k8s/summary.go
@@ -97,6 +97,20 @@ func GetClusterSummary(ctx context.Context, p credentials.Provider, args GetClus
 	summary.KubernetesVersion = serverVersion.GitVersion
 	summary.Provider = providerLabel(args.Cluster.Backend)
 
+	// --- EKS lifecycle window (EoSS / extended support) ----------------
+	// Soft-fail: missing IAM perm on eks:DescribeClusterVersions or a
+	// non-EKS-capable cluster leaves the fields nil; the SPA renders an
+	// em-dash chip. Other summary panels are unaffected.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		eksMeta, _ := FetchEKSClusterMetadata(ctx, p, args.Cluster, summary.KubernetesVersion)
+		mu.Lock()
+		summary.EndOfStandardSupportDate = eksMeta.EndOfStandardSupportDate
+		summary.EndOfExtendedSupportDate = eksMeta.EndOfExtendedSupportDate
+		mu.Unlock()
+	}()
+
 	// --- Nodes (required-ish — drives the capacity card) ---------------
 	wg.Add(1)
 	go func() {

--- a/internal/k8s/tls_expiry.go
+++ b/internal/k8s/tls_expiry.go
@@ -1,0 +1,71 @@
+// TLS cert expiry helpers. Used by the Secrets list (TLS-typed
+// secrets get an expiry chip directly) and the Ingresses list
+// (joins to TLS-typed Secrets in the same namespace and picks the
+// soonest expiry across an Ingress's spec.tls[]).
+//
+// All helpers soft-fail to nil rather than returning errors — a
+// malformed PEM block in one Secret should not poison the whole
+// list-page render. The SPA renders nil as an em-dash chip.
+package k8s
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// parseFirstTLSCertExpiry parses the PEM-encoded `tls.crt` value of a
+// Secret of type kubernetes.io/tls and returns the NotAfter timestamp
+// of the LEAF certificate (the first PEM block). Soft-fails on:
+//   - missing tls.crt key
+//   - empty value
+//   - non-PEM value
+//   - non-CERTIFICATE PEM block
+//   - x509 parse failure
+//
+// Returns nil in any of those cases.
+func parseFirstTLSCertExpiry(data map[string][]byte) *time.Time {
+	raw, ok := data["tls.crt"]
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil
+	}
+	t := cert.NotAfter
+	return &t
+}
+
+// secretTLSExpiry is a small wrapper that gates parseFirstTLSCertExpiry
+// on the Secret's Type. Non-TLS Secrets always return nil — we don't
+// peek into arbitrary opaque secret payloads.
+func secretTLSExpiry(s *corev1.Secret) *time.Time {
+	if s.Type != corev1.SecretTypeTLS {
+		return nil
+	}
+	return parseFirstTLSCertExpiry(s.Data)
+}
+
+// soonestExpiry returns the earlier of two *time.Time values, treating
+// nil as "no expiry known" — i.e., a known expiry always wins over nil.
+// Used by the Ingress list to fold per-secret expiries into a single
+// per-ingress chip.
+func soonestExpiry(a, b *time.Time) *time.Time {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.Before(*b) {
+		return a
+	}
+	return b
+}

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -15,6 +15,16 @@ type Node struct {
 	Roles          []string  `json:"roles"`
 	KubeletVersion string    `json:"kubeletVersion"`
 	InternalIP     string    `json:"internalIP"`
+	// Cloud-provider metadata derived from node labels. Empty
+	// strings on bare-metal / unlabeled nodes.
+	InstanceType string `json:"instanceType,omitempty"`
+	Zone         string `json:"zone,omitempty"`
+	// CapacityType is "ON_DEMAND" or "SPOT" on EKS managed node
+	// groups (label eks.amazonaws.com/capacityType), or "on-demand"/
+	// "spot" on Karpenter (label karpenter.sh/capacity-type). Empty
+	// for unmanaged nodes; the SPA shows a yellow chip on spot so
+	// "why did my pod die overnight" is visible at scroll glance.
+	CapacityType string `json:"capacityType,omitempty"`
 	CPUCapacity    string    `json:"cpuCapacity"`
 	MemoryCapacity string    `json:"memoryCapacity"`
 	CreatedAt      time.Time `json:"createdAt"`
@@ -89,6 +99,17 @@ type Pod struct {
 	// Ready is the kubectl-style "ready/total" container count, e.g. "2/3".
 	Ready     string    `json:"ready"`
 	Restarts  int32     `json:"restarts"`
+	// Image is the container image of the FIRST container in the pod
+	// (or the empty string when the pod has no containers, which
+	// kubelet rejects but the K8s API briefly accepts during
+	// scheduling). When ImageCount > 1, the SPA renders a small
+	// "+N" suffix to surface multi-container pods at glance.
+	Image      string `json:"image,omitempty"`
+	ImageCount int    `json:"imageCount,omitempty"`
+	// QoS is the kubectl-style QoS class (Guaranteed/Burstable/
+	// BestEffort). Informs eviction-order story during incidents:
+	// BestEffort gets evicted first when the node is under pressure.
+	QoS string `json:"qos,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
@@ -160,6 +181,10 @@ type Deployment struct {
 	ReadyReplicas     int32     `json:"readyReplicas"`
 	UpdatedReplicas   int32     `json:"updatedReplicas"`
 	AvailableReplicas int32     `json:"availableReplicas"`
+	// Image is the container image of the FIRST container in the
+	// pod template. When ImageCount > 1, the SPA renders "+N".
+	Image      string `json:"image,omitempty"`
+	ImageCount int    `json:"imageCount,omitempty"`
 	CreatedAt         time.Time `json:"createdAt"`
 }
 
@@ -199,6 +224,11 @@ type Service struct {
 	ClusterIP  string        `json:"clusterIP,omitempty"`
 	ExternalIP string        `json:"externalIP,omitempty"`
 	Ports      []ServicePort `json:"ports"`
+	// Endpoint counts. Aggregated from all EndpointSlices labeled
+	// kubernetes.io/service-name = <svc> at list time. Calls out the
+	// "Service points at zero pods" failure mode at scroll glance.
+	EndpointCount      int `json:"endpointCount"`
+	ReadyEndpointCount int `json:"readyEndpointCount"`
 	CreatedAt  time.Time     `json:"createdAt"`
 }
 
@@ -275,6 +305,10 @@ type StatefulSet struct {
 	ReadyReplicas   int32     `json:"readyReplicas"`
 	UpdatedReplicas int32     `json:"updatedReplicas"`
 	CurrentReplicas int32     `json:"currentReplicas"`
+	// Image is the container image of the FIRST container in the
+	// pod template. When ImageCount > 1, the SPA renders "+N".
+	Image      string `json:"image,omitempty"`
+	ImageCount int    `json:"imageCount,omitempty"`
 	CreatedAt       time.Time `json:"createdAt"`
 }
 
@@ -304,6 +338,10 @@ type DaemonSet struct {
 	UpdatedNumberScheduled int32     `json:"updatedNumberScheduled"`
 	NumberAvailable        int32     `json:"numberAvailable"`
 	NumberMisscheduled     int32     `json:"numberMisscheduled"`
+	// Image is the container image of the FIRST container in the
+	// pod template. When ImageCount > 1, the SPA renders "+N".
+	Image      string `json:"image,omitempty"`
+	ImageCount int    `json:"imageCount,omitempty"`
 	CreatedAt              time.Time `json:"createdAt"`
 }
 
@@ -336,6 +374,10 @@ type Secret struct {
 	Namespace string    `json:"namespace"`
 	Type      string    `json:"type"`
 	KeyCount  int       `json:"keyCount"`
+	// TLSExpiresAt is the NotAfter of the leaf certificate in
+	// data["tls.crt"], for Secrets of type kubernetes.io/tls. nil
+	// for non-TLS secrets or unparseable certs.
+	TLSExpiresAt *time.Time `json:"tlsExpiresAt,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
@@ -364,6 +406,11 @@ type Ingress struct {
 	Class     string    `json:"class,omitempty"`
 	Hosts     []string  `json:"hosts"`
 	Address   string    `json:"address,omitempty"`
+	// TLSExpiresAt is the soonest NotAfter across all TLS secrets
+	// referenced by spec.tls[]. nil when the ingress has no TLS
+	// section or when secret.list permission is unavailable to
+	// the actor (soft-fail at handler level).
+	TLSExpiresAt *time.Time `json:"tlsExpiresAt,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
@@ -565,6 +612,11 @@ type StorageClass struct {
 	ReclaimPolicy        string    `json:"reclaimPolicy,omitempty"`
 	VolumeBindingMode    string    `json:"volumeBindingMode,omitempty"`
 	AllowVolumeExpansion bool      `json:"allowVolumeExpansion"`
+	// IsDefault mirrors the storageclass.kubernetes.io/is-default-class
+	// annotation. Multiple StorageClasses can carry it (which is a
+	// misconfiguration: the operator should fix the cluster). The SPA
+	// shows a (default) tag next to the matching name.
+	IsDefault bool `json:"isDefault"`
 	CreatedAt            time.Time `json:"createdAt"`
 }
 
@@ -742,6 +794,20 @@ type ServiceAccountDetail struct {
 type ClusterSummary struct {
 	KubernetesVersion string  `json:"kubernetesVersion"`
 	Provider          string  `json:"provider"` // "EKS" | "Kubeconfig"
+
+	// EKS lifecycle window. Populated when the cluster's registry
+	// entry is EKSCapable() (ARN + Region + parseable cluster name)
+	// AND the IAM principal has eks:DescribeClusterVersions; zero
+	// values otherwise. Not fatal — every other summary field is
+	// independent.
+	//
+	// Frontend rule of thumb (matches the SPA's chip):
+	//   now < eos - 180d         → grey   (plenty of runway)
+	//   eos - 180d ≤ now < eos   → yellow (plan upgrade)
+	//   eos ≤ now < eos-extended → red    (extended support — $0.60/hr surcharge)
+	//   now ≥ eos-extended       → red    (no AWS support at all)
+	EndOfStandardSupportDate *time.Time `json:"endOfStandardSupportDate,omitempty"`
+	EndOfExtendedSupportDate *time.Time `json:"endOfExtendedSupportDate,omitempty"`
 	NodeCount         int     `json:"nodeCount"`
 	NodeReadyCount    int     `json:"nodeReadyCount"`
 	PodCount          int     `json:"podCount"`
@@ -902,6 +968,10 @@ type PDBDetail struct {
 type ReplicaSet struct {
 	Name      string    `json:"name"`
 	Namespace string    `json:"namespace"`
+	// Image is the container image of the FIRST container in the
+	// pod template. When ImageCount > 1, the SPA renders "+N".
+	Image      string `json:"image,omitempty"`
+	ImageCount int    `json:"imageCount,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 	Desired   int32     `json:"desired"`
 	Current   int32     `json:"current"`

--- a/internal/k8s/util.go
+++ b/internal/k8s/util.go
@@ -123,3 +123,16 @@ func totalRestarts(pod *corev1.Pod) int32 {
 	}
 	return n
 }
+
+// firstContainerImage extracts the image of the first container in a
+// PodSpec, plus the total container count. Used by the workload-list
+// row constructors (Pod, Deployment, StatefulSet, DaemonSet,
+// ReplicaSet) so the operator can scan "what version is running"
+// without click-through to the detail. Returns ("", 0) for the
+// (briefly accepted) case where the spec has no containers.
+func firstContainerImage(spec corev1.PodSpec) (image string, count int) {
+	if len(spec.Containers) == 0 {
+		return "", 0
+	}
+	return spec.Containers[0].Image, len(spec.Containers)
+}

--- a/web/src/components/fleet/ClusterCard.tsx
+++ b/web/src/components/fleet/ClusterCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { cn } from "../../lib/cn";
 import type { FleetClusterEntry, FleetStatus } from "../../lib/types";
+import { stripGitVersion, supportWindowState } from "../../lib/eosChip";
 
 /**
  * Status glyph + treatment table. Status is encoded dual-channel
@@ -132,6 +133,7 @@ export function ClusterCard({
         {[
           entry.region,
           entry.backend?.toUpperCase(),
+          entry.kubernetesVersion && `k8s ${stripGitVersion(entry.kubernetesVersion)}`,
           entry.accountID && `acct …${entry.accountID.slice(-4)}`,
           entry.context && `ctx ${entry.context}`,
         ]
@@ -145,6 +147,37 @@ export function ClusterCard({
             {entry.environment}
           </span>
         )}
+        {(() => {
+          const state = supportWindowState(entry.endOfStandardSupportDate, entry.endOfExtendedSupportDate);
+          if (state === null || state.tone === "comfortable") return null;
+          const cssClass =
+            state.tone === "warning"
+              ? "border-yellow/40 bg-yellow-soft text-yellow"
+              : "border-red/40 bg-red-soft text-red";
+          const label =
+            state.tone === "warning"
+              ? `EoSS ${state.daysRemaining}d`
+              : state.tone === "past"
+                ? "ext support"
+                : "EoL";
+          const title =
+            state.tone === "warning"
+              ? `End of standard support: ${state.eosDate}`
+              : state.tone === "past"
+                ? `Standard support ended ${state.eosDate} — $0.60/hr surcharge active`
+                : `Extended support ended ${state.eoExtendedDate ?? state.eosDate} — no AWS support`;
+          return (
+            <span
+              className={cn(
+                "ml-2 inline-block rounded border px-1 font-mono text-[10px] uppercase tracking-wide",
+                cssClass,
+              )}
+              title={title}
+            >
+              {label}
+            </span>
+          );
+        })()}
       </div>
 
       {/* body — branches by status */}
@@ -284,3 +317,4 @@ function relativeFromNow(ts: string): string {
   const hr = Math.round(min / 60);
   return `checked ${hr}h ago`;
 }
+

--- a/web/src/components/ui/TLSExpiryChip.tsx
+++ b/web/src/components/ui/TLSExpiryChip.tsx
@@ -1,0 +1,35 @@
+import { cn } from "../../lib/cn";
+import { tlsExpiryState } from "../../lib/tlsExpiry";
+
+/**
+ * Single-row chip rendering for a TLS cert expiry. Calm grey when
+ * comfortable (>30d), yellow at ≤30d, red at ≤7d, red with
+ * "expired" label after the boundary. nil/undefined → em-dash.
+ *
+ * Used on the SecretsPage list (per-Secret expiry) and the
+ * IngressesPage list (soonest expiry across spec.tls[]).
+ */
+export function TLSExpiryChip({ expiresAt }: { expiresAt?: string }) {
+  const state = tlsExpiryState(expiresAt);
+  if (!state) {
+    return <span className="text-ink-faint">—</span>;
+  }
+  const tone =
+    state.tone === "comfortable"
+      ? "text-ink-muted"
+      : state.tone === "warning"
+        ? "text-yellow"
+        : "text-red";
+  const label =
+    state.tone === "expired"
+      ? `expired ${Math.abs(state.daysRemaining)}d ago`
+      : `${state.daysRemaining}d`;
+  return (
+    <span
+      className={cn("font-mono text-[11.5px]", tone)}
+      title={`Expires ${state.isoDate}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web/src/lib/eosChip.ts
+++ b/web/src/lib/eosChip.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared EoSS (End of Standard Support) chip math used by the fleet
+ * card and the cluster identity banner. Both consumers compute the
+ * tone the same way; only the rendering policy differs (fleet card
+ * hides "comfortable" tone by default; overview always shows it).
+ */
+
+export type SupportWindowTone = "comfortable" | "warning" | "past" | "eol";
+
+export interface SupportWindowState {
+  tone: SupportWindowTone;
+  /** Days remaining until standard support ends. Negative when already past. */
+  daysRemaining: number;
+  /** ISO date (yyyy-mm-dd) of the EoSS boundary, useful for tooltips. */
+  eosDate: string;
+  /** ISO date of the extended-support boundary, when known. */
+  eoExtendedDate?: string;
+}
+
+/**
+ * Compute the support-window state for an EKS cluster.
+ *
+ * Returns null when no EoSS data is available (kubeconfig backend,
+ * non-EKS-capable cluster, or missing eks:DescribeClusterVersions
+ * permission). Otherwise returns a tone the renderer maps to a
+ * color treatment:
+ *
+ *   comfortable  — > 180 days remaining
+ *   warning      — ≤ 180 days remaining (still in standard support)
+ *   past         — past EoSS, in extended support ($0.60/hr surcharge)
+ *   eol          — past extended support, no AWS support at all
+ */
+export function supportWindowState(
+  eos?: string,
+  eoExtended?: string,
+): SupportWindowState | null {
+  if (!eos) return null;
+  const eosDate = new Date(eos);
+  if (Number.isNaN(eosDate.getTime())) return null;
+
+  const now = Date.now();
+  const eosMs = eosDate.getTime();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const daysRemaining = Math.ceil((eosMs - now) / dayMs);
+
+  const eosISO = eos.slice(0, 10);
+  const eoExtendedISO = eoExtended ? eoExtended.slice(0, 10) : undefined;
+
+  // Already past standard EoSS.
+  if (now >= eosMs) {
+    if (eoExtended) {
+      const extDate = new Date(eoExtended);
+      if (!Number.isNaN(extDate.getTime()) && now >= extDate.getTime()) {
+        return {
+          tone: "eol",
+          daysRemaining,
+          eosDate: eosISO,
+          eoExtendedDate: eoExtendedISO,
+        };
+      }
+    }
+    return {
+      tone: "past",
+      daysRemaining,
+      eosDate: eosISO,
+      eoExtendedDate: eoExtendedISO,
+    };
+  }
+
+  return {
+    tone: daysRemaining <= 180 ? "warning" : "comfortable",
+    daysRemaining,
+    eosDate: eosISO,
+    eoExtendedDate: eoExtendedISO,
+  };
+}
+
+/**
+ * Strip a K8s GitVersion ("v1.34.7-eks-abc1234") down to the
+ * MAJOR.MINOR portion EKS uses as a version selector. Falls back
+ * to the raw input when parsing fails so callers never show "".
+ */
+export function stripGitVersion(gitVersion: string): string {
+  const m = gitVersion.match(/^v?(\d+\.\d+)/);
+  return m ? m[1] : gitVersion;
+}

--- a/web/src/lib/tlsExpiry.ts
+++ b/web/src/lib/tlsExpiry.ts
@@ -1,0 +1,38 @@
+/**
+ * TLS cert expiry chip math, shared between SecretsPage and
+ * IngressesPage. Mirrors the supportWindowState shape from eosChip.ts
+ * but with TLS-cert-relevant thresholds: red at ≤7d (rotate now),
+ * yellow at ≤30d (rotate soon), muted at > 30d (calm), red+expired
+ * label when past.
+ */
+
+export type TLSExpiryTone = "comfortable" | "warning" | "critical" | "expired";
+
+export interface TLSExpiryState {
+  tone: TLSExpiryTone;
+  daysRemaining: number;
+  isoDate: string;
+}
+
+export function tlsExpiryState(expiresAt?: string): TLSExpiryState | null {
+  if (!expiresAt) return null;
+  const d = new Date(expiresAt);
+  if (Number.isNaN(d.getTime())) return null;
+
+  const now = Date.now();
+  const ms = d.getTime();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const days = Math.ceil((ms - now) / dayMs);
+  const iso = expiresAt.slice(0, 10);
+
+  if (now >= ms) {
+    return { tone: "expired", daysRemaining: days, isoDate: iso };
+  }
+  if (days <= 7) {
+    return { tone: "critical", daysRemaining: days, isoDate: iso };
+  }
+  if (days <= 30) {
+    return { tone: "warning", daysRemaining: days, isoDate: iso };
+  }
+  return { tone: "comfortable", daysRemaining: days, isoDate: iso };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -40,6 +40,12 @@ export interface Node {
   roles: string[];
   kubeletVersion: string;
   internalIP: string;
+  /** From node.kubernetes.io/instance-type label. Empty on bare-metal. */
+  instanceType?: string;
+  /** From topology.kubernetes.io/zone label. */
+  zone?: string;
+  /** EKS "ON_DEMAND"|"SPOT" or Karpenter "on-demand"|"spot". Empty on unmanaged. */
+  capacityType?: string;
   cpuCapacity: string;
   memoryCapacity: string;
   createdAt: string;
@@ -108,6 +114,12 @@ export interface Pod {
   podIP?: string;
   ready: string;
   restarts: number;
+  /** First container's image; "" when the pod has no containers. */
+  image?: string;
+  /** Total container count (only set when > 1; SPA renders "+N" suffix). */
+  imageCount?: number;
+  /** QoS class — Guaranteed | Burstable | BestEffort. Empty during scheduling. */
+  qos?: string;
   createdAt: string;
 }
 
@@ -178,6 +190,9 @@ export interface Deployment {
   readyReplicas: number;
   updatedReplicas: number;
   availableReplicas: number;
+  /** First container's image from the pod template. */
+  image?: string;
+  imageCount?: number;
   createdAt: string;
 }
 
@@ -216,6 +231,9 @@ export interface StatefulSet {
   readyReplicas: number;
   updatedReplicas: number;
   currentReplicas: number;
+  /** First container's image from the pod template. */
+  image?: string;
+  imageCount?: number;
   createdAt: string;
 }
 
@@ -244,6 +262,9 @@ export interface DaemonSet {
   updatedNumberScheduled: number;
   numberAvailable: number;
   numberMisscheduled: number;
+  /** First container's image from the pod template. */
+  image?: string;
+  imageCount?: number;
   createdAt: string;
 }
 
@@ -279,6 +300,11 @@ export interface Service {
   clusterIP?: string;
   externalIP?: string;
   ports: ServicePort[];
+  /** Total endpoints across all EndpointSlices labeled
+   *  kubernetes.io/service-name = <svc>. 0 calls out the
+   *  "selector matches no pods" failure mode. */
+  endpointCount: number;
+  readyEndpointCount: number;
   createdAt: string;
 }
 
@@ -302,6 +328,10 @@ export interface Ingress {
   class?: string;
   hosts: string[];
   address?: string;
+  /** RFC3339. Soonest expiry across all spec.tls[] secrets;
+   *  absent when ingress has no TLS or when the actor lacks
+   *  secret.list permission (handler soft-fails). */
+  tlsExpiresAt?: string;
   createdAt: string;
 }
 
@@ -364,6 +394,9 @@ export interface Secret {
   namespace: string;
   type: string;
   keyCount: number;
+  /** RFC3339. NotAfter of leaf cert in data["tls.crt"] for
+   *  Secrets of type kubernetes.io/tls. Absent for non-TLS. */
+  tlsExpiresAt?: string;
   createdAt: string;
 }
 
@@ -573,6 +606,8 @@ export interface StorageClass {
   reclaimPolicy?: string;
   volumeBindingMode?: string;
   allowVolumeExpansion: boolean;
+  /** Mirrors storageclass.kubernetes.io/is-default-class annotation. */
+  isDefault: boolean;
   createdAt: string;
 }
 
@@ -758,6 +793,12 @@ export interface StorageInfo {
 export interface ClusterSummary {
   kubernetesVersion: string;
   provider: string;
+
+  /** EKS lifecycle window — RFC3339 strings. Populated only for
+   *  EKSCapable clusters with eks:DescribeClusterVersions; absent
+   *  on kubeconfig backends or when the IAM perm is missing. */
+  endOfStandardSupportDate?: string;
+  endOfExtendedSupportDate?: string;
   nodeCount: number;
   nodeReadyCount: number;
   podCount: number;
@@ -1010,6 +1051,9 @@ export interface ReplicaSet {
   desired: number;
   current: number;
   ready: number;
+  /** First container's image from the pod template. */
+  image?: string;
+  imageCount?: number;
   owner: string;
 }
 
@@ -1261,6 +1305,15 @@ export interface FleetClusterEntry {
   /** Kubeconfig context name; only present for kubeconfig backends. */
   context?: string;
   tags?: Record<string, string>;
+
+  /** EKS lifecycle window. Populated only for EKSCapable clusters with
+   *  the eks:DescribeClusterVersions IAM permission. Drives the
+   *  version + EoSS chip on the cluster card. */
+  kubernetesVersion?: string;
+  /** RFC3339. Empty when AWS has not yet announced EoSS for this version. */
+  endOfStandardSupportDate?: string;
+  /** RFC3339. Empty when extended support is not announced. */
+  endOfExtendedSupportDate?: string;
   status: FleetStatus;
   /** RFC3339 timestamp. v1: "now" on every response (no historical ledger). */
   lastContact: string;
@@ -1795,6 +1848,15 @@ export interface NodegroupDetail extends NodegroupSummary {
   diskSize?: number;
   labels?: Record<string, string>;
   tags?: Record<string, string>;
+
+  /** EKS lifecycle window. Populated only for EKSCapable clusters with
+   *  the eks:DescribeClusterVersions IAM permission. Drives the
+   *  version + EoSS chip on the cluster card. */
+  kubernetesVersion?: string;
+  /** RFC3339. Empty when AWS has not yet announced EoSS for this version. */
+  endOfStandardSupportDate?: string;
+  /** RFC3339. Empty when extended support is not announced. */
+  endOfExtendedSupportDate?: string;
   healthIssues?: NodegroupHealthIssue[];
   launchTemplate?: LaunchTemplateRef;
   modifiedAt?: string;

--- a/web/src/pages/DaemonSetsPage.tsx
+++ b/web/src/pages/DaemonSetsPage.tsx
@@ -72,6 +72,23 @@ export function DaemonSetsPage({ cluster }: { cluster: string }) {
     { key: "name", header: "name", weight: 3, cellClassName: "font-mono text-ink", accessor: (d) => d.name },
     { key: "namespace", header: "namespace", weight: 1.4, cellClassName: "font-mono text-ink-muted", accessor: (d) => d.namespace },
     {
+      key: "image",
+      header: "image",
+      weight: 2.4,
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (d) => {
+        if (!d.image) return "—";
+        return (
+          <span className="block truncate" title={d.image}>
+            {d.image}
+            {d.imageCount && d.imageCount > 1 && (
+              <span className="ml-1 text-ink-faint">+{d.imageCount - 1}</span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "ready",
       header: "ready",
       weight: 0.8,

--- a/web/src/pages/DeploymentsPage.tsx
+++ b/web/src/pages/DeploymentsPage.tsx
@@ -72,6 +72,23 @@ export function DeploymentsPage({ cluster }: { cluster: string }) {
     { key: "name", header: "name", weight: 3, cellClassName: "font-mono text-ink", accessor: (d) => d.name },
     { key: "namespace", header: "namespace", weight: 1.4, cellClassName: "font-mono text-ink-muted", accessor: (d) => d.namespace },
     {
+      key: "image",
+      header: "image",
+      weight: 2.4,
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (d) => {
+        if (!d.image) return "—";
+        return (
+          <span className="block truncate" title={d.image}>
+            {d.image}
+            {d.imageCount && d.imageCount > 1 && (
+              <span className="ml-1 text-ink-faint">+{d.imageCount - 1}</span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "ready",
       header: "ready",
       weight: 0.7,

--- a/web/src/pages/IngressesPage.tsx
+++ b/web/src/pages/IngressesPage.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import { type Column } from "../components/table/DataTable";
+import { TLSExpiryChip } from "../components/ui/TLSExpiryChip";
 import { SelectableDataTable } from "../components/table/SelectableDataTable";
 import { api } from "../lib/api";
 import {
@@ -94,6 +95,13 @@ export function IngressesPage({ cluster }: { cluster: string }) {
       weight: 1.4,
       cellClassName: "font-mono text-ink-muted",
       accessor: (i) => i.address || "—",
+    },
+    {
+      key: "tls",
+      header: "tls",
+      weight: 0.9,
+      align: "right",
+      accessor: (i) => <TLSExpiryChip expiresAt={i.tlsExpiresAt} />,
     },
     { key: "age", header: "age", weight: 0.5, align: "right", cellClassName: "font-mono text-ink-muted", accessor: (i) => ageFrom(i.createdAt) },
   ];

--- a/web/src/pages/NodeGroupsPage.tsx
+++ b/web/src/pages/NodeGroupsPage.tsx
@@ -108,6 +108,7 @@ export function NodeGroupsPage({ cluster }: { cluster: string }) {
               <tr>
                 <th className="px-3 py-2 text-left">Name</th>
                 <th className="px-3 py-2 text-left">AMI</th>
+                <th className="px-3 py-2 text-left">Capacity</th>
                 <th className="px-3 py-2 text-left">Release</th>
                 <th className="px-3 py-2 text-left">Status</th>
                 <th className="px-3 py-2 text-left">Scale</th>
@@ -157,6 +158,9 @@ function NodegroupRow({
             <span className="font-mono text-ink-muted">{ng.amiType || "—"}</span>
           )}
         </td>
+        <td className="px-3 py-2">
+          <CapacityCell capacityType={ng.capacityType} />
+        </td>
         <td className="px-3 py-2 font-mono text-ink-muted">
           {ng.releaseVersion || (ng.customAmi ? "—" : "")}
         </td>
@@ -175,7 +179,7 @@ function NodegroupRow({
       </tr>
       {open && (
         <tr>
-          <td colSpan={6} className="border-b border-border bg-surface-2/40 px-6 py-3">
+          <td colSpan={7} className="border-b border-border bg-surface-2/40 px-6 py-3">
             <NodegroupDetailBody cluster={cluster} name={ng.name} />
           </td>
         </tr>
@@ -194,6 +198,26 @@ function StatusBadge({ status }: { status: string }) {
   return (
     <span className={cn("font-mono text-[11px] uppercase tracking-[0.06em]", tone)}>
       {status || "unknown"}
+    </span>
+  );
+}
+
+function CapacityCell({ capacityType }: { capacityType?: string }) {
+  if (!capacityType) {
+    return <span className="text-[11px] text-ink-faint">—</span>;
+  }
+  // SPOT nodes can be reclaimed by AWS at 2-min notice — call out
+  // distinctly from the boring on-demand case so an operator's
+  // "why did my pod die overnight" answer is visible at scroll glance.
+  const isSpot = capacityType === "SPOT";
+  return (
+    <span
+      className={cn(
+        "font-mono text-[11px] uppercase tracking-[0.06em]",
+        isSpot ? "text-yellow" : "text-ink-muted",
+      )}
+    >
+      {capacityType.toLowerCase().replace("_", "-")}
     </span>
   );
 }

--- a/web/src/pages/NodesPage.tsx
+++ b/web/src/pages/NodesPage.tsx
@@ -116,6 +116,29 @@ export function NodesPage({ cluster }: { cluster: string }) {
       accessor: (n) => n.kubeletVersion,
     },
     {
+      key: "instance",
+      header: "instance",
+      weight: 1.8,
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (n) => {
+        if (!n.instanceType && !n.zone) return "—";
+        const isSpot = n.capacityType === "SPOT" || n.capacityType === "spot";
+        return (
+          <span className="flex items-baseline gap-1.5">
+            <span>{n.instanceType || "—"}</span>
+            {n.zone && (
+              <span className="text-ink-faint">·&nbsp;{n.zone}</span>
+            )}
+            {isSpot && (
+              <span className="rounded border border-yellow/40 bg-yellow-soft px-1 py-px text-[9.5px] uppercase tracking-wide text-yellow">
+                spot
+              </span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "ip",
       header: "ip",
       weight: 1.2,

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -8,6 +8,7 @@ import { NodeGroupsCard } from "../components/eks/NodeGroupsCard";
 import { AddOnsCard } from "../components/eks/AddOnsCard";
 import { ageFrom } from "../lib/format";
 import { cn } from "../lib/cn";
+import { supportWindowState } from "../lib/eosChip";
 import type {
   ClusterEvent,
   ClusterSummary,
@@ -237,6 +238,39 @@ function ClusterIdentityBanner({
         </h1>
         <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[12px] text-ink-faint">
           <span>{data.kubernetesVersion}</span>
+          {(() => {
+            const state = supportWindowState(data.endOfStandardSupportDate, data.endOfExtendedSupportDate);
+            if (!state) return null;
+            const cssClass =
+              state.tone === "comfortable"
+                ? "border-border bg-surface-2 text-ink-muted"
+                : state.tone === "warning"
+                  ? "border-yellow/40 bg-yellow-soft text-yellow"
+                  : "border-red/40 bg-red-soft text-red";
+            const label =
+              state.tone === "past"
+                ? "extended support"
+                : state.tone === "eol"
+                  ? "end of life"
+                  : `EoSS in ${state.daysRemaining}d`;
+            const title =
+              state.tone === "past"
+                ? `Standard support ended ${state.eosDate} — $0.60/hr surcharge active`
+                : state.tone === "eol"
+                  ? `Extended support ended ${state.eoExtendedDate ?? state.eosDate} — no AWS support`
+                  : `End of standard support: ${state.eosDate}`;
+            return (
+              <span
+                className={cn(
+                  "ml-1 inline-block rounded border px-1.5 py-px text-[10px] uppercase tracking-wide",
+                  cssClass,
+                )}
+                title={title}
+              >
+                {label}
+              </span>
+            );
+          })()}
           <span>·</span>
           <span>{data.provider}</span>
           <span>·</span>

--- a/web/src/pages/PodsPage.tsx
+++ b/web/src/pages/PodsPage.tsx
@@ -100,6 +100,23 @@ export function PodsPage({ cluster }: { cluster: string }) {
     { key: "namespace", header: "namespace", weight: 1.4, cellClassName: "font-mono text-ink-muted", accessor: (p) => p.namespace },
     { key: "phase", header: "phase", weight: 1.2, accessor: (p) => <PhaseTag phase={p.phase} /> },
     {
+      key: "image",
+      header: "image",
+      weight: 2.2,
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (p) => {
+        if (!p.image) return "—";
+        return (
+          <span className="block truncate" title={p.image}>
+            {p.image}
+            {p.imageCount && p.imageCount > 1 && (
+              <span className="ml-1 text-ink-faint">+{p.imageCount - 1}</span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "ready",
       header: "ready",
       weight: 0.6,
@@ -123,6 +140,22 @@ export function PodsPage({ cluster }: { cluster: string }) {
           {p.restarts}
         </span>
       ),
+    },
+    {
+      key: "qos",
+      header: "qos",
+      weight: 0.8,
+      cellClassName: "font-mono text-[10.5px]",
+      accessor: (p) => {
+        if (!p.qos) return "—";
+        const tone =
+          p.qos === "BestEffort"
+            ? "text-yellow"
+            : p.qos === "Guaranteed"
+              ? "text-green"
+              : "text-ink-muted";
+        return <span className={tone}>{p.qos.toLowerCase()}</span>;
+      },
     },
     { key: "node", header: "node", weight: 1.6, cellClassName: "font-mono text-ink-muted", accessor: (p) => p.nodeName ?? "—" },
     { key: "ip", header: "pod ip", weight: 1.1, cellClassName: "font-mono text-ink-muted", accessor: (p) => p.podIP ?? "—" },

--- a/web/src/pages/ReplicaSetsPage.tsx
+++ b/web/src/pages/ReplicaSetsPage.tsx
@@ -487,6 +487,20 @@ function RSRow({
         </span>
       )}
 
+      {/* Image — truncated; full path in tooltip. Most operationally
+          relevant for ReplicaSets specifically: comparing active vs
+          dormant RS images is the rollback story. */}
+      {rs.image && (
+        <span
+          className="hidden min-w-0 max-w-[260px] shrink truncate font-mono text-[10.5px] text-ink-faint md:block"
+          title={rs.image}
+        >
+          {rs.image}
+          {rs.imageCount && rs.imageCount > 1 && (
+            <span className="ml-1">+{rs.imageCount - 1}</span>
+          )}
+        </span>
+      )}
       {/* Replicas */}
       <div className="w-12 shrink-0 text-right font-mono text-[11.5px] text-ink-muted">
         {isActive ? `${rs.ready}/${rs.desired}` : <span className="text-ink-faint">0/0</span>}

--- a/web/src/pages/SecretsPage.tsx
+++ b/web/src/pages/SecretsPage.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "../components/page/PageHeader";
 import { FilterStrip } from "../components/page/FilterStrip";
 import { SplitPane } from "../components/page/SplitPane";
 import { type Column } from "../components/table/DataTable";
+import { TLSExpiryChip } from "../components/ui/TLSExpiryChip";
 import { SelectableDataTable } from "../components/table/SelectableDataTable";
 import { api } from "../lib/api";
 import {
@@ -79,6 +80,13 @@ export function SecretsPage({ cluster }: { cluster: string }) {
       accessor: (s) => <span title={s.type}>{shortType(s.type)}</span>,
     },
     { key: "keys", header: "keys", weight: 0.5, align: "right", cellClassName: "font-mono text-ink-muted", accessor: (s) => s.keyCount },
+    {
+      key: "expires",
+      header: "expires",
+      weight: 0.9,
+      align: "right",
+      accessor: (s) => <TLSExpiryChip expiresAt={s.tlsExpiresAt} />,
+    },
     { key: "age", header: "age", weight: 0.5, align: "right", cellClassName: "font-mono text-ink-muted", accessor: (s) => ageFrom(s.createdAt) },
   ];
 

--- a/web/src/pages/ServicesPage.tsx
+++ b/web/src/pages/ServicesPage.tsx
@@ -70,6 +70,30 @@ export function ServicesPage({ cluster }: { cluster: string }) {
     { key: "clusterip", header: "cluster-ip", weight: 1.1, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.clusterIP || "—" },
     { key: "external", header: "external", weight: 1.4, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.externalIP || "—" },
     { key: "ports", header: "ports", weight: 2, cellClassName: "font-mono text-ink-muted", accessor: (s) => formatPorts(s.ports) },
+    {
+      key: "endpoints",
+      header: "endpoints",
+      weight: 0.9,
+      align: "right",
+      cellClassName: "font-mono",
+      accessor: (s) => {
+        if (s.endpointCount === 0) {
+          return (
+            <span className="text-yellow" title="No backing endpoints — selector matches no pods">
+              0
+            </span>
+          );
+        }
+        if (s.readyEndpointCount < s.endpointCount) {
+          return (
+            <span className="text-yellow" title={`${s.endpointCount - s.readyEndpointCount} not ready`}>
+              {s.readyEndpointCount}/{s.endpointCount}
+            </span>
+          );
+        }
+        return <span className="text-ink-muted">{s.endpointCount}</span>;
+      },
+    },
     { key: "age", header: "age", weight: 0.5, align: "right", cellClassName: "font-mono text-ink-muted", accessor: (s) => ageFrom(s.createdAt) },
   ];
 

--- a/web/src/pages/StatefulSetsPage.tsx
+++ b/web/src/pages/StatefulSetsPage.tsx
@@ -72,6 +72,23 @@ export function StatefulSetsPage({ cluster }: { cluster: string }) {
     { key: "name", header: "name", weight: 3, cellClassName: "font-mono text-ink", accessor: (s) => s.name },
     { key: "namespace", header: "namespace", weight: 1.4, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.namespace },
     {
+      key: "image",
+      header: "image",
+      weight: 2.4,
+      cellClassName: "font-mono text-ink-muted",
+      accessor: (s) => {
+        if (!s.image) return "—";
+        return (
+          <span className="block truncate" title={s.image}>
+            {s.image}
+            {s.imageCount && s.imageCount > 1 && (
+              <span className="ml-1 text-ink-faint">+{s.imageCount - 1}</span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "ready",
       header: "ready",
       weight: 0.7,

--- a/web/src/pages/StorageClassesPage.tsx
+++ b/web/src/pages/StorageClassesPage.tsx
@@ -50,7 +50,22 @@ export function StorageClassesPage({ cluster }: { cluster: string }) {
   );
 
   const columns: Column<StorageClass>[] = [
-    { key: "name", header: "name", weight: 2.5, cellClassName: "font-mono text-ink", accessor: (s) => s.name },
+    {
+      key: "name",
+      header: "name",
+      weight: 2.5,
+      cellClassName: "font-mono text-ink",
+      accessor: (s) => (
+        <span>
+          {s.name}
+          {s.isDefault && (
+            <span className="ml-2 rounded border border-border bg-surface-2 px-1 py-px font-mono text-[9.5px] uppercase tracking-wide text-ink-muted">
+              default
+            </span>
+          )}
+        </span>
+      ),
+    },
     { key: "provisioner", header: "provisioner", weight: 2, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.provisioner },
     { key: "reclaim", header: "reclaim", weight: 0.8, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.reclaimPolicy ?? "—" },
     { key: "binding", header: "binding mode", weight: 1.2, cellClassName: "font-mono text-ink-muted", accessor: (s) => s.volumeBindingMode ?? "—" },


### PR DESCRIPTION
## Summary

UX polish pass landing eight features that share one design pattern: data Periscope already collects (or is one cheap call away) but currently drops at the wire. Originated from an audit of every list/detail handler vs. its rendered columns, benchmarked against Lens / Headlamp / k9s / Rancher / ArgoCD. Net **+874 / -18 lines across 34 files**.

## Related issue / RFC

No tracked issue — UX polish pass scoped from an internal audit. Happy to file an issue retroactively if helpful for changelog grouping.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs only
- [ ] Refactor / internal cleanup
- [ ] Test or CI only

## Surfaces touched

- [ ] HTTP API
- [ ] Helm values
- [ ] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [x] SPA / frontend
- [ ] Documentation
- [x] Other — Go API response structs gained additive fields (no removals); IAM policy guidance updated in commit body

## What changed (by surface)

- **Fleet card** — k8s version inline + EoSS countdown chip when standard support is approaching (yellow ≤180d) or past (red). Backend was already collecting `KubernetesVersion` on `ClusterSummary` but the fleet handler dropped it; this commit plumbs it through and adds `EndOfStandardSupportDate` / `EndOfExtendedSupportDate` via a new `FetchEKSClusterMetadata` helper that calls `eks:DescribeClusterVersions`. Soft-fails on missing IAM perm.
- **Cluster overview** — same EoSS chip in the identity banner, always visible with verbose copy. `supportWindowState` extracted into a shared helper at `web/src/lib/eosChip.ts`.
- **Workloads (Pods + Deployments + StatefulSets + DaemonSets + ReplicaSets)** — image column on every list (operator's most-asked question is "what version is running"). Pods also gains a QoS chip. Single shared `firstContainerImage` helper, no new K8s API calls.
- **Nodes** — combined "instance" column showing instance-type · zone with a yellow SPOT chip. Read from existing node labels (EKS or Karpenter).
- **StorageClasses** — `(default)` tag inline with name when the `is-default-class` annotation is true.
- **NodeGroups** — capacity-type column promoted from detail to list.
- **Ingresses + Secrets** — TLS cert expiry chip. Helper parses leaf cert NotAfter from `data["tls.crt"]`. Ingress soonest-expiry across `spec.tls[]` via one extra Secrets list call per request, soft-failing on `secret.list` deny. Bands: comfortable >30d / warning ≤30d / critical ≤7d / expired.
- **Services** — endpoint count column with explicit "0 endpoints" warning state for the "selector matches no pods" failure mode. Counts via `DiscoveryV1.EndpointSlices.List` keyed by `kubernetes.io/service-name`.
- **NodeGroups handler comments** — stale "PR-2/PR-3 work, drift always zero" docstrings cleaned up; `applyDrift` has been wired since some later PR.

## IAM impact

`eks:DescribeClusterVersions` is now required for the EoSS chip to render. Without it the chip silently no-renders (soft-fail by design); fleet + overview pages render cleanly otherwise. Add to the Periscope SA's IAM policy when upgrading.

No new K8s RBAC requirements. Service endpoint counts and Ingress TLS expiry both use existing list permissions and soft-fail on deny.

## How was this tested?

- ✅ `go test ./...` — all packages green (`internal/k8s`, `cmd/periscope`, `cmd/periscope-agent`, `internal/audit`, `internal/auth`, `internal/authz`, `internal/clusters`, `internal/sse`, `internal/tunnel`)
- ✅ `npx vitest run` — 263 / 263 tests pass
- ✅ `npx tsc --noEmit` — clean
- ✅ `npx eslint` — clean on touched files
- ✅ Visual smoke: peri-server fleet card shows `k8s 1.34`, peri-agent shows `k8s 1.33` + yellow EoSS chip; workload list pages all show image column; Pods page renders QoS chip; Secrets list shows TLS expiry where applicable; Services list shows endpoint count.

## Checklist

- [x] CONTRIBUTING.md re-read.
- [x] Existing tests pass; no new tests needed (additive fields, soft-fail paths covered by handler-level error classification).
- [ ] CHANGELOG / docs — **deferred to a follow-up commit on this branch if the v1.0.5 line is being staged**, or merge as-is if CHANGELOG bump happens elsewhere.
- [x] No secrets, cluster names, or OIDC IDs in committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)