### PR TITLE
fix(auth): background-tab keepalive to prevent idle-session 401

### DIFF
--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -68,6 +68,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     void refresh();
   }, [refresh]);
 
+  // Background-tab keepalive. While the tab is hidden, the list-page
+  // pollers (refetchIntervalInBackground: false) stop firing, so the
+  // server-side session idle timer (default 30m) reaches expiry and
+  // the next foreground action 401s. We send a single lightweight
+  // /api/auth/whoami every 10 min when document.hidden — that hits
+  // the auth middleware and bumps LastActivity, keeping the session
+  // alive without re-enabling expensive background list polling.
+  //
+  // Foreground tabs bump LastActivity organically through the existing
+  // list-endpoint pollers, so we deliberately gate on document.hidden
+  // — no need to double-ping when foreground polling is doing the job.
+  //
+  // 10 min vs 30 min idle window leaves a comfortable safety margin
+  // against browser-side timer throttling (Chrome / Firefox throttle
+  // hidden-tab setInterval to ≤1/min, never below).
+  useEffect(() => {
+    if (!user) return;
+    const id = window.setInterval(() => {
+      if (!document.hidden) return;
+      // Soft-fail: transient network errors here just delay the next
+      // bump. If the session has already expired, the user's next
+      // foreground action will surface that — we don't try to
+      // resurrect from background.
+      fetch("/api/auth/whoami", {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      }).catch(() => {});
+    }, 10 * 60 * 1000);
+    return () => window.clearInterval(id);
+  }, [user]);
+
   const signIn = useCallback(() => {
     window.location.href = "/api/auth/login";
   }, []);


### PR DESCRIPTION
## Summary

Fixes a 401 that operators hit when a Periscope tab is left in the background for 30+ minutes and they then return to the tab. The fleet page's `refetchOnWindowFocus: true` makes the symptom load-bearing — first thing operators see is "couldn't load the fleet."

This is **not** an OIDC refresh-token issue (the refresh flow at `internal/auth/oidc.go:135` works correctly — no `refresh_failed` log entries observed). It's a server-side session **idle timeout** firing because the SPA correctly stops polling when the tab is hidden.

## Related issue / RFC

No tracked issue — surfaced during v1.0.5 demo prep. Repro is below.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs only
- [ ] Refactor / internal cleanup
- [ ] Test or CI only

## Surfaces touched

- [ ] HTTP API
- [ ] Helm values
- [x] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [x] SPA / frontend
- [ ] Documentation

## What's actually happening

Two independent timers run in any OIDC + server-session app:

1. **OIDC token lifecycle** — handled by refresh tokens. Working correctly here.
2. **Server-side session idle timeout** — separate Periscope-side timer at `internal/auth/middleware.go:101`:
   ```go
   if cfg.Session.IdleTimeout > 0 && now.Sub(s.LastActivity) > cfg.Session.IdleTimeout {
       store.Delete(s.ID)
       slog.InfoContext(... "auth.session_expired" ... "kind", "idle")
       unauthorized(w, r)
   }
   ```
   Every authenticated request bumps `LastActivity`. No request → no bump.

The SPA's `web/src/main.tsx:13` sets `refetchIntervalInBackground: false` (correct, set in v1.0.4 to avoid hammering apiserver from hidden tabs). When the tab is backgrounded:
- All list pollers pause
- `LastActivity` stops being bumped
- After `idleTimeout` (default 30m), middleware kills the session
- First foreground action → 401

## Repro

1. Sign in to Periscope, navigate to any cluster page.
2. Switch to another app for ≥30 min (or temporarily set `idleTimeout: 5m` to make repro faster).
3. Switch back to the Periscope tab.
4. Fleet page (or any window-focus refetch) returns 401, banner reads "couldn't load the fleet".

Server log at the moment of failure:
```
{"time":"...","level":"INFO","msg":"auth.session_expired","subject":"auth0|...","kind":"idle"}
```

## Fix

Add a single `useEffect` in `AuthProvider` that runs a 10-min interval calling `/api/auth/whoami` **only when `document.hidden` is true**.

`/api/auth/whoami` was chosen because:
- Already exists and is already used by `AuthProvider` for the initial mount.
- Routed through the auth middleware (not in the `isPublic` allowlist at `internal/auth/middleware.go:43`), so the call bumps `LastActivity` the same way an ordinary list poll would.
- Cheapest auth'd endpoint we have — reads session from store, returns identity JSON, no K8s or AWS calls. ~5ms server-side.

Foreground tabs are deliberately not pinged — existing list pollers bump `LastActivity` organically when the tab is foregrounded.

## Cost analysis

Per backgrounded tab:

| State | Requests/hr | Notes |
|---|---|---|
| Pre-fix (this bug) | 0 | Good for resources, bad UX |
| Post-fix (this PR) | 6 | One per 10 min, only when `document.hidden` |
| Original "always poll" (the v1.0.4 fix's target) | ~1200 | Every list poller every 15-30s |

The keepalive recovers correctness while preserving **99.5% of the v1.0.4 optimization**. Foreground behaviour is unchanged.

## Why not just bump `idleTimeout`?

Considered. One-line config change. Trade-off: erodes the "30m idle = sign back in" security property for everyone, including operators who legitimately walked away from their desk. The keepalive preserves that property — closing the tab still expires the session normally.

## Why not detect SSE activity server-side?

Most "correct" fix (open watch streams should count as activity), but invasive — would require plumbing into every watch-stream handler and a per-stream timer. Deferred to v1.1+ if we want to clean this up further.

## How was this tested?

- ✅ `npx tsc --noEmit` — clean
- ✅ `npx eslint src/auth/AuthProvider.tsx` — clean
- ✅ `npx vitest run` — 263 / 263 pass
- Manual: sign in, hide tab 30+ min, return — fleet page no longer 401s.

To exercise quickly without waiting 30 min: temporarily set `idleTimeout: 5m` via helm upgrade, repro takes ~6 min instead.

## Checklist

- [x] CONTRIBUTING.md re-read.
- [x] Tests pass; no new tests added (the behaviour requires fake timers + `document.visibilityState` mocking which is high cost-to-value for a 30-line change; manual smoke test covers the regression bar).
- [ ] CHANGELOG / docs — happy to amend if v1.0.5 line is being staged.
- [x] No secrets / cluster names / OIDC IDs in committed files.