### PR TITLE
Docs/quick local test examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kind create cluster --name periscope-demo
 helm install periscope \
   oci://ghcr.io/gnana997/charts/periscope --version 1.0.5 \
   --namespace periscope --create-namespace \
-  --values https://raw.githubusercontent.com/gnana997/periscope/main/examples/values-kind.yaml
+  --values https://periscopehq.dev/examples/values-kind.yaml
 
 # 3. Wait + open
 kubectl -n periscope wait --for=condition=Available deploy/periscope --timeout=120s

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ Periscope is a self-hosted, multi-cluster Kubernetes console focused on EKS envi
 
 ## Quickstart
 
+### Try locally with kind <span title="60-second evaluation">⚡</span>
+
+The fastest way to see Periscope without touching AWS or an IdP. Runs on any local Kubernetes — kind / k3d / minikube. Sign-in uses an in-process dev fallback so anyone hitting the dashboard becomes `dev@local`.
+
+```sh
+# 1. Create a local cluster
+kind create cluster --name periscope-demo
+
+# 2. Install with the kind-tuned values
+helm install periscope \
+  oci://ghcr.io/gnana997/charts/periscope --version 1.0.5 \
+  --namespace periscope --create-namespace \
+  --values https://raw.githubusercontent.com/gnana997/periscope/main/examples/values-kind.yaml
+
+# 3. Wait + open
+kubectl -n periscope wait --for=condition=Available deploy/periscope --timeout=120s
+kubectl -n periscope port-forward svc/periscope 8080:8080
+
+# 4. Visit http://localhost:8080 in your browser.
+#    Sign-in is automatic — you arrive as "dev@local". No IdP setup.
+```
+
+Cleanup: `kind delete cluster --name periscope-demo`.
+
+> ⚠️  Dev sign-in is for local evaluation only. Don't run this profile against a cluster that holds real workloads — anyone who can reach the SPA becomes the configured `dev` user with `cluster-admin` impersonation.
+
+
 ### Run locally
 
 Prerequisites: Go 1.26, Node 22, and a kubeconfig with access to at least one cluster.

--- a/examples/values-kind.yaml
+++ b/examples/values-kind.yaml
@@ -35,7 +35,14 @@ auth:
     clientID: ""
     clientSecret: ""              # not used in dev mode
   authorization:
-    mode: shared
+    mode: tier
+    groupTiers:
+      # dev@local resolves to admin tier so the impersonation chain
+      # in the chart's cluster-rbac.yaml grants cluster-admin via
+      # the periscope-tier:admin ClusterRoleBinding. Required for the
+      # dev user to actually see resources in the SPA — shared mode
+      # left the SA with no RBAC and every list-call returned 403.
+      periscope-users: admin
   dev:
     subject: dev@local
     email:   dev@local

--- a/examples/values-kind.yaml
+++ b/examples/values-kind.yaml
@@ -1,0 +1,68 @@
+# Periscope on kind (or k3d / minikube) — quickstart values.
+#
+# Goal: a single `helm install` that boots the SPA on any local
+# Kubernetes cluster in ~60s, with zero AWS / OIDC setup. Sign in
+# uses the in-process dev fallback so anyone hitting the dashboard
+# becomes "dev@local" — fine for evaluating the product on your
+# laptop, not for any environment that touches real workloads.
+#
+#   $ kind create cluster --name periscope-demo
+#   $ helm install periscope \
+#       oci://ghcr.io/gnana997/charts/periscope --version 1.0.5 \
+#       --namespace periscope --create-namespace \
+#       --values https://raw.githubusercontent.com/gnana997/periscope/main/examples/values-kind.yaml
+#   $ kubectl -n periscope wait --for=condition=Available deploy/periscope --timeout=120s
+#   $ kubectl -n periscope port-forward svc/periscope 8080:8080
+#   $ open http://localhost:8080
+#
+# What this turns on / off vs. the chart defaults:
+#   - auth.oidc.issuer="" → dev fallback identity ("dev@local").
+#   - secrets.mode=plain with empty client secret → no Secret needed
+#     (chart renders an empty stringData Secret to keep the deployment
+#     happy without an out-of-band create step).
+#   - One cluster: in-cluster backend → Periscope manages the kind
+#     cluster it's running in. No registration token, no agent.
+#   - Conservative resources so it fits comfortably on a single-node
+#     kind/k3d cluster (kind defaults to ~6Gi memory / 4 cores).
+#   - No ingress / no tls — port-forward is the access path.
+
+# ─── Auth ────────────────────────────────────────────────────────────
+# Dev mode: leaving issuer empty triggers the in-process dev fallback.
+# Anyone reaching the dashboard becomes the user defined under auth.dev.
+auth:
+  oidc:
+    issuer: ""                    # ← dev mode trigger
+    clientID: ""
+    clientSecret: ""              # not used in dev mode
+  authorization:
+    mode: shared
+  dev:
+    subject: dev@local
+    email:   dev@local
+    groups:  [periscope-users]    # matches a typical default-tier admin group
+
+# ─── Secret ──────────────────────────────────────────────────────────
+# `plain` mode with empty value → chart renders an empty Secret so the
+# Deployment's envFrom doesn't fail. Periscope ignores the OIDC secret
+# entirely when issuer is empty.
+secrets:
+  mode: plain
+  plain:
+    clientSecret: "dev-mode-placeholder-ignored"
+
+# ─── Cluster registry ────────────────────────────────────────────────
+# Just the local cluster, via in-cluster backend (kubelet-mounted SA).
+# This auto-renders the per-cluster RBAC bindings (templates/cluster-rbac.yaml
+# detects in-cluster mode and emits the impersonation chain).
+clusters:
+  - name: kind-local
+    backend: in-cluster
+
+# ─── Resource limits — sized for a single-node kind/k3d cluster ──────
+resources:
+  requests:
+    cpu: 50m
+    memory: 96Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi


### PR DESCRIPTION
## Summary

Updated Readme and values-kind.yaml for the easy first time setup to smoke test periscope in local clusters

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (user-visible API, config shape, or Helm values)
- [x] Docs only
- [ ] Refactor / internal cleanup
- [ ] Test or CI only

## Surfaces touched

- [ ] HTTP API (`/api/...`) — covered by semver, see `docs/api.md`
- [ ] Helm values — see `deploy/helm/periscope/values.yaml` schema
- [ ] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [ ] SPA / frontend
- [x] Documentation
- [ ] None of the above

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests added or updated where it makes sense.
- [x] Docs updated (`docs/`, `README.md`, or `CHANGELOG.md` under `[Unreleased]`).
- [ ] No secrets, real cluster names, or real OIDC client IDs in committed files.
