### PR TITLE
feat(schema): section-grouped form editor for K8s kinds

### DIFF
--- a/web/src/components/edit/K8sSchemaForm.tsx
+++ b/web/src/components/edit/K8sSchemaForm.tsx
@@ -16,6 +16,8 @@ import { SchemaFormBridge } from "../../lib/schemaForm/SchemaFormBridge";
 import { buildRefResolver, findSchemaByGVK } from "../../lib/schemaForm/refResolver";
 import {
   filterSchemaForKind,
+  getSectionLabels,
+  getSectionResolver,
   getCreateOnlyPaths,
   getKindGVK,
   type SupportedKind,
@@ -66,6 +68,7 @@ export function K8sSchemaForm({
       // surfaces as the YAML-mode hint.
       allowOneOfDiscriminator: true,
       createOnlyPaths: getCreateOnlyPaths(kind),
+      sectionResolver: getSectionResolver(kind),
     };
     return { rootSchema: filtered, walkOptions: opts };
   }, [schemaQuery.data, gvk.group, gvk.version, gvk.kind, kind]);
@@ -95,6 +98,7 @@ export function K8sSchemaForm({
       valuesYaml={valuesYaml}
       schema={rootSchema}
       walkOptions={walkOptions}
+      sectionLabels={getSectionLabels(kind)}
       mode={mode}
       onValuesYamlChange={onValuesYamlChange}
       banner={banner}

--- a/web/src/lib/schemaForm/SchemaForm.test.ts
+++ b/web/src/lib/schemaForm/SchemaForm.test.ts
@@ -1,0 +1,126 @@
+// schemaForm/SchemaForm.test.ts — pure-logic tests for the
+// section-grouping helpers. The DOM render path (primary visible /
+// metadata collapsed / advanced count) is verified manually since
+// this app's vitest runs in a node environment without
+// @testing-library/react. The data flow that decides which
+// descriptor lands in which bucket is fully testable here.
+
+import { describe, it, expect } from "vitest";
+import { collectSectioned, descendantHasSection } from "./SchemaForm";
+import type { FieldDescriptor } from "./types";
+
+const stringField = (
+  path: string[],
+  extras: Partial<FieldDescriptor> = {},
+): FieldDescriptor => ({
+  type: "string",
+  path,
+  label: path[path.length - 1] ?? "",
+  required: false,
+  ...extras,
+});
+
+const objectField = (
+  path: string[],
+  children: FieldDescriptor[],
+  extras: Partial<FieldDescriptor> = {},
+): FieldDescriptor => ({
+  type: "object",
+  path,
+  label: path[path.length - 1] ?? "",
+  required: false,
+  children,
+  ...extras,
+});
+
+describe("collectSectioned", () => {
+  it("buckets top-level descriptors by their stamped section", () => {
+    const ds: FieldDescriptor[] = [
+      stringField(["data"], { section: "primary", displayOrder: 0 }),
+      stringField(["binaryData"], { section: "primary", displayOrder: 1 }),
+      stringField(["immutable"], { section: "advanced", displayOrder: 0 }),
+    ];
+    const out = collectSectioned(ds);
+    expect(out.total).toBe(3);
+    expect(out.primary.map((d) => d.path.join("."))).toEqual([
+      "data",
+      "binaryData",
+    ]);
+    expect(out.advanced.map((d) => d.path.join("."))).toEqual(["immutable"]);
+    expect(out.metadata).toEqual([]);
+  });
+
+  it("promotes nested children of an unsectioned parent into their section bucket", () => {
+    // metadata container has no section; its children have section="metadata".
+    const ds: FieldDescriptor[] = [
+      objectField(["metadata"], [
+        stringField(["metadata", "name"], { section: "metadata", displayOrder: 0 }),
+        stringField(["metadata", "namespace"], { section: "metadata", displayOrder: 1 }),
+        stringField(["metadata", "annotations"], { section: "metadata", displayOrder: 3 }),
+        stringField(["metadata", "labels"], { section: "metadata", displayOrder: 2 }),
+      ]),
+      stringField(["data"], { section: "primary", displayOrder: 0 }),
+    ];
+    const out = collectSectioned(ds);
+    expect(out.total).toBe(5);
+    // Sorted by displayOrder regardless of the source-tree order.
+    expect(out.metadata.map((d) => d.path.join("."))).toEqual([
+      "metadata.name",
+      "metadata.namespace",
+      "metadata.labels",
+      "metadata.annotations",
+    ]);
+  });
+
+  it("returns total=0 for fully unsectioned descriptors (Helm path)", () => {
+    const ds: FieldDescriptor[] = [
+      stringField(["replicas"]),
+      objectField(["image"], [stringField(["image", "tag"])]),
+    ];
+    const out = collectSectioned(ds);
+    expect(out.total).toBe(0);
+    expect(out.primary).toEqual([]);
+    expect(out.metadata).toEqual([]);
+    expect(out.advanced).toEqual([]);
+  });
+
+  it("descriptors without displayOrder sort to the end of their bucket", () => {
+    const ds: FieldDescriptor[] = [
+      stringField(["a"], { section: "primary" }),
+      stringField(["b"], { section: "primary", displayOrder: 0 }),
+      stringField(["c"], { section: "primary", displayOrder: 1 }),
+    ];
+    const out = collectSectioned(ds);
+    expect(out.primary.map((d) => d.path.join("."))).toEqual(["b", "c", "a"]);
+  });
+});
+
+describe("descendantHasSection", () => {
+  it("true when a child has a section", () => {
+    const d = objectField(["spec"], [
+      stringField(["spec", "type"], { section: "primary" }),
+    ]);
+    expect(descendantHasSection(d)).toBe(true);
+  });
+
+  it("false when neither the descriptor nor any descendant has a section", () => {
+    const d = objectField(["spec"], [
+      objectField(["spec", "nested"], [stringField(["spec", "nested", "leaf"])]),
+    ]);
+    expect(descendantHasSection(d)).toBe(false);
+  });
+
+  it("recurses past unsectioned intermediate containers", () => {
+    const d = objectField(["spec"], [
+      objectField(["spec", "nested"], [
+        stringField(["spec", "nested", "leaf"], { section: "advanced" }),
+      ]),
+    ]);
+    expect(descendantHasSection(d)).toBe(true);
+  });
+
+  it("false for a leaf descriptor", () => {
+    const d = stringField(["replicas"]);
+    expect(descendantHasSection(d)).toBe(false);
+  });
+});

--- a/web/src/lib/schemaForm/SchemaForm.test.ts
+++ b/web/src/lib/schemaForm/SchemaForm.test.ts
@@ -6,7 +6,7 @@
 // descriptor lands in which bucket is fully testable here.
 
 import { describe, it, expect } from "vitest";
-import { collectSectioned, descendantHasSection } from "./SchemaForm";
+import { collectSectioned, descendantHasSection } from "./sections";
 import type { FieldDescriptor } from "./types";
 
 const stringField = (

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
 import { buildFieldDescriptors, type WalkOptions } from "./walker";
 import { validateValues } from "./validate";
+import { collectSectioned, descendantHasSection } from "./sections";
 import { cn } from "../cn";
 import { getAtPath, setAtPath } from "./pathOps";
 import type { FieldDescriptor, JSONSchema, ValidationIssue } from "./types";
@@ -75,55 +76,6 @@ export interface SchemaFormProps {
    *  keep the legacy flat layout. */
   sectionLabels?: SchemaFormSectionLabels;
 }
-
-interface SectionedBuckets {
-  primary: FieldDescriptor[];
-  metadata: FieldDescriptor[];
-  advanced: FieldDescriptor[];
-  total: number;
-}
-
-// Walk the descriptor tree and collect every descriptor whose walker
-// stamped a section. Descriptors land in the bucket directly, even if
-// they are nested children of an unsectioned object container (e.g.
-// `metadata.name` is collected under "metadata" while its parent
-// `metadata` descriptor itself is unsectioned and gets dropped from
-// the layout).
-export function collectSectioned(
-  descriptors: FieldDescriptor[],
-): SectionedBuckets {
-  const buckets: SectionedBuckets = {
-    primary: [],
-    metadata: [],
-    advanced: [],
-    total: 0,
-  };
-  const visit = (d: FieldDescriptor) => {
-    if (d.section) {
-      buckets[d.section].push(d);
-      buckets.total += 1;
-    }
-    if (d.children) {
-      for (const c of d.children) visit(c);
-    }
-  };
-  for (const d of descriptors) visit(d);
-  const byOrder = (a: FieldDescriptor, b: FieldDescriptor) =>
-    (a.displayOrder ?? Number.MAX_SAFE_INTEGER) -
-    (b.displayOrder ?? Number.MAX_SAFE_INTEGER);
-  buckets.primary.sort(byOrder);
-  buckets.metadata.sort(byOrder);
-  buckets.advanced.sort(byOrder);
-  return buckets;
-}
-
-export function descendantHasSection(d: FieldDescriptor): boolean {
-  if (!d.children) return false;
-  return d.children.some(
-    (c) => c.section !== undefined || descendantHasSection(c),
-  );
-}
-
 export function SchemaForm({
   schema,
   values,

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -43,6 +43,18 @@ function InfoTip({ text }: { text: string | undefined }) {
 
 export type SchemaFormMode = "create" | "edit";
 
+export interface SchemaFormSectionLabels {
+  /** Required header for the always-open primary section. Kind-specific
+   *  to give the operator clear intent ("Data" for ConfigMap, "Networking"
+   *  for Service, etc.). */
+  primary: string;
+  /** Header for the collapsed metadata section. Defaults to "Metadata". */
+  metadata?: string;
+  /** Header for the collapsed advanced section. Defaults to "Advanced".
+   *  The renderer appends a `(N)` field count automatically. */
+  advanced?: string;
+}
+
 export interface SchemaFormProps {
   schema: JSONSchema;
   /** Current values. The form treats this as immutable; onChange
@@ -57,6 +69,59 @@ export interface SchemaFormProps {
   mode?: SchemaFormMode;
   /** Rendered when the schema produces zero descriptors. */
   emptyMessage?: ReactNode;
+  /** When set, descriptors are grouped into primary / metadata /
+   *  advanced sections according to `descriptor.section` stamped by the
+   *  walker. K8sSchemaForm passes this; Helm leaves it undefined to
+   *  keep the legacy flat layout. */
+  sectionLabels?: SchemaFormSectionLabels;
+}
+
+interface SectionedBuckets {
+  primary: FieldDescriptor[];
+  metadata: FieldDescriptor[];
+  advanced: FieldDescriptor[];
+  total: number;
+}
+
+// Walk the descriptor tree and collect every descriptor whose walker
+// stamped a section. Descriptors land in the bucket directly, even if
+// they are nested children of an unsectioned object container (e.g.
+// `metadata.name` is collected under "metadata" while its parent
+// `metadata` descriptor itself is unsectioned and gets dropped from
+// the layout).
+export function collectSectioned(
+  descriptors: FieldDescriptor[],
+): SectionedBuckets {
+  const buckets: SectionedBuckets = {
+    primary: [],
+    metadata: [],
+    advanced: [],
+    total: 0,
+  };
+  const visit = (d: FieldDescriptor) => {
+    if (d.section) {
+      buckets[d.section].push(d);
+      buckets.total += 1;
+    }
+    if (d.children) {
+      for (const c of d.children) visit(c);
+    }
+  };
+  for (const d of descriptors) visit(d);
+  const byOrder = (a: FieldDescriptor, b: FieldDescriptor) =>
+    (a.displayOrder ?? Number.MAX_SAFE_INTEGER) -
+    (b.displayOrder ?? Number.MAX_SAFE_INTEGER);
+  buckets.primary.sort(byOrder);
+  buckets.metadata.sort(byOrder);
+  buckets.advanced.sort(byOrder);
+  return buckets;
+}
+
+export function descendantHasSection(d: FieldDescriptor): boolean {
+  if (!d.children) return false;
+  return d.children.some(
+    (c) => c.section !== undefined || descendantHasSection(c),
+  );
 }
 
 export function SchemaForm({
@@ -66,12 +131,14 @@ export function SchemaForm({
   walkOptions,
   mode = "edit",
   emptyMessage,
+  sectionLabels,
 }: SchemaFormProps) {
   const descriptors = useMemo(
     () => buildFieldDescriptors(schema, walkOptions),
     [schema, walkOptions],
   );
   const issues = useMemo(() => validateValues(schema, values), [schema, values]);
+  const sectioned = useMemo(() => collectSectioned(descriptors), [descriptors]);
 
   if (descriptors.length === 0) {
     return (
@@ -81,18 +148,76 @@ export function SchemaForm({
     );
   }
 
+  const renderRow = (d: FieldDescriptor) => (
+    <FieldRow
+      key={d.path.join(".")}
+      descriptor={d}
+      values={values}
+      issues={issues}
+      mode={mode}
+      onChange={onChange}
+    />
+  );
+
+  // Back-compat fallback: when the caller hasn't asked for sections,
+  // OR no descriptor has a section stamp (Helm path), render the flat
+  // ordered list exactly like the pre-#142 layout.
+  if (!sectionLabels || sectioned.total === 0) {
+    return (
+      <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
+        {descriptors.map(renderRow)}
+      </form>
+    );
+  }
+
+  // "Other" catches top-level descriptors that aren't sectioned and
+  // whose children also aren't — typically forward-compatible cases
+  // where a future K8s field for a supported kind hasn't been added
+  // to the per-kind allowlist yet. Render at the bottom so they're
+  // discoverable rather than silently dropped.
+  const others = descriptors.filter(
+    (d) => d.section === undefined && !descendantHasSection(d),
+  );
+
   return (
     <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
-      {descriptors.map((d) => (
-        <FieldRow
-          key={d.path.join(".")}
-          descriptor={d}
-          values={values}
-          issues={issues}
-          mode={mode}
-          onChange={onChange}
-        />
-      ))}
+      <section className="space-y-3">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
+          {sectionLabels.primary}
+        </h3>
+        <div className="space-y-3">{sectioned.primary.map(renderRow)}</div>
+      </section>
+
+      {sectioned.metadata.length > 0 && (
+        <details className="group rounded-sm border border-border">
+          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
+            {sectionLabels.metadata ?? "Metadata"}
+          </summary>
+          <div className="space-y-3 px-3 pb-3 pt-1">
+            {sectioned.metadata.map(renderRow)}
+          </div>
+        </details>
+      )}
+
+      {sectioned.advanced.length > 0 && (
+        <details className="group rounded-sm border border-border">
+          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
+            {sectionLabels.advanced ?? "Advanced"} ({sectioned.advanced.length})
+          </summary>
+          <div className="space-y-3 px-3 pb-3 pt-1">
+            {sectioned.advanced.map(renderRow)}
+          </div>
+        </details>
+      )}
+
+      {others.length > 0 && (
+        <details className="group rounded-sm border border-border">
+          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
+            Other ({others.length})
+          </summary>
+          <div className="space-y-3 px-3 pb-3 pt-1">{others.map(renderRow)}</div>
+        </details>
+      )}
     </form>
   );
 }

--- a/web/src/lib/schemaForm/SchemaFormBridge.tsx
+++ b/web/src/lib/schemaForm/SchemaFormBridge.tsx
@@ -9,7 +9,11 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { SchemaForm, type SchemaFormMode } from "./SchemaForm";
+import {
+  SchemaForm,
+  type SchemaFormMode,
+  type SchemaFormSectionLabels,
+} from "./SchemaForm";
 import type { JSONSchema } from "./types";
 import type { WalkOptions } from "./walker";
 
@@ -29,6 +33,10 @@ export interface SchemaFormBridgeProps {
    *  consumers that want to switch the user back to YAML mode use
    *  this signal. */
   onParseError?: (raw: string) => void;
+  /** When provided, SchemaForm renders descriptors grouped into
+   *  primary / metadata / advanced sections. K8sSchemaForm sets this;
+   *  Helm leaves it undefined to keep the legacy flat layout. */
+  sectionLabels?: SchemaFormSectionLabels;
 }
 
 export function SchemaFormBridge({
@@ -40,6 +48,7 @@ export function SchemaFormBridge({
   emptyMessage,
   banner,
   onParseError,
+  sectionLabels,
 }: SchemaFormBridgeProps) {
   const [obj, setObj] = useState<Record<string, unknown>>(() => parseSafe(valuesYaml, onParseError));
 
@@ -70,6 +79,7 @@ export function SchemaFormBridge({
         walkOptions={walkOptions}
         mode={mode}
         emptyMessage={emptyMessage}
+        sectionLabels={sectionLabels}
         onChange={(next) => {
           setObj(next);
           // Re-serialize and bubble. Default key order — sortKeys

--- a/web/src/lib/schemaForm/k8sAllowlist.ts
+++ b/web/src/lib/schemaForm/k8sAllowlist.ts
@@ -7,21 +7,42 @@
 // Allowlist (not deny-list) per design call-out — predictable and
 // auditable; if K8s adds a new noise field, it stays hidden by
 // default until we explicitly allowlist it.
+//
+// Sectioned shape (added for the section-grouping refactor): each
+// kind splits its allowlisted paths into 3 groups so the renderer
+// can present them as primary (always visible) / metadata (collapsed)
+// / advanced (hidden behind toggle). Path order within each group
+// drives display order. The flat list of "all allowlisted paths"
+// (primary ∪ metadata ∪ advanced) is what filterSchemaForKind hands
+// to the schema-narrowing pass.
 
-import type { JSONSchema } from "./types";
+import type { FieldSection, JSONSchema } from "./types";
 
 export type SupportedKind = "ConfigMap" | "Secret" | "Service" | "Ingress";
 
-/** Each kind declares the metadata fields and the spec/data subtree
- *  paths it surfaces. Paths are dotted, rooted at the K8s object
- *  (so e.g. `metadata.name`, `data`, `spec.type`). */
+/** Curated layout for a single kind. Each section's `paths` array
+ *  is dotted, rooted at the K8s object (e.g. `metadata.name`,
+ *  `data`, `spec.type`). Path order within an array drives display
+ *  order in that section. */
 interface KindSpec {
-  metadata: string[];
-  /** Top-level fields outside of `metadata` we surface (e.g. `data`,
-   *  `type`, `spec.type`). Each entry is a dotted path. */
-  paths: string[];
-  /** Fields that should be marked editable="create-only" — name and
-   *  namespace are immutable after create. */
+  primary: {
+    /** Section header — kind-specific so it tells the operator what
+     *  they're editing ("Data" for ConfigMap, "Networking" for
+     *  Service, "Routing & TLS" for Ingress). */
+    label: string;
+    paths: string[];
+  };
+  metadata: {
+    label: string;
+    paths: string[];
+  };
+  advanced: {
+    label: string;
+    paths: string[];
+  };
+  /** Fields the renderer marks editable="create-only" — name and
+   *  namespace are immutable after create; spec.clusterIP and
+   *  spec.loadBalancerClass are also immutable on Service updates. */
   createOnly: string[];
 }
 
@@ -46,30 +67,75 @@ export function getKindGVK(kind: SupportedKind): KindGVK {
 
 const KIND_SPECS: Record<SupportedKind, KindSpec> = {
   ConfigMap: {
-    metadata: ["name", "namespace", "labels", "annotations"],
-    paths: ["data", "binaryData", "immutable"],
+    primary: {
+      label: "Data",
+      // The whole point of a ConfigMap.
+      paths: ["data", "binaryData"],
+    },
+    metadata: {
+      label: "Metadata",
+      // Annotations live last so name/namespace/labels aren't
+      // visually crowded by controller-set annotations.
+      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+    },
+    advanced: {
+      label: "Advanced",
+      // immutable=true is a one-way door (apiserver rejects mutation
+      // after) — hide behind the advanced toggle so it can't be
+      // toggled accidentally from the primary section.
+      paths: ["immutable"],
+    },
     createOnly: ["metadata.name", "metadata.namespace"],
   },
   Secret: {
-    metadata: ["name", "namespace", "labels", "annotations"],
-    paths: ["type", "data", "stringData", "immutable"],
+    primary: {
+      label: "Data",
+      // type drives data semantics (Opaque vs kubernetes.io/tls vs
+      // kubernetes.io/dockerconfigjson etc.); data + stringData are
+      // the actual payload. base64 layer applies on top of `data`.
+      paths: ["type", "data", "stringData"],
+    },
+    metadata: {
+      label: "Metadata",
+      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+    },
+    advanced: {
+      label: "Advanced",
+      paths: ["immutable"],
+    },
     createOnly: ["metadata.name", "metadata.namespace"],
   },
   Service: {
-    metadata: ["name", "namespace", "labels", "annotations"],
-    paths: [
-      "spec.type",
-      "spec.selector",
-      "spec.ports",
-      "spec.clusterIP",
-      "spec.externalTrafficPolicy",
-      "spec.internalTrafficPolicy",
-      "spec.sessionAffinity",
-      "spec.loadBalancerSourceRanges",
-      "spec.loadBalancerClass",
-      "spec.ipFamilies",
-      "spec.ipFamilyPolicy",
-    ],
+    primary: {
+      label: "Networking",
+      // The "why isn't this routing traffic?" investigation surface:
+      // type (ClusterIP / NodePort / LoadBalancer / ExternalName),
+      // selector (label selector matching backing pods), ports
+      // (port → targetPort + protocol).
+      paths: ["spec.type", "spec.selector", "spec.ports"],
+    },
+    metadata: {
+      label: "Metadata",
+      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+    },
+    advanced: {
+      label: "Advanced",
+      // Traffic policy + IP family + LB-specific knobs operators
+      // touch maybe once per Service lifetime. clusterIP is also
+      // immutable on update (createOnly enforces read-only after
+      // create) but we still surface it so it's not dropped from
+      // the form silently.
+      paths: [
+        "spec.clusterIP",
+        "spec.externalTrafficPolicy",
+        "spec.internalTrafficPolicy",
+        "spec.sessionAffinity",
+        "spec.ipFamilies",
+        "spec.ipFamilyPolicy",
+        "spec.loadBalancerClass",
+        "spec.loadBalancerSourceRanges",
+      ],
+    },
     createOnly: [
       "metadata.name",
       "metadata.namespace",
@@ -81,8 +147,22 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
     ],
   },
   Ingress: {
-    metadata: ["name", "namespace", "labels", "annotations"],
-    paths: ["spec.ingressClassName", "spec.rules", "spec.tls", "spec.defaultBackend"],
+    primary: {
+      label: "Routing & TLS",
+      // ingressClassName picks the controller (nginx / alb / etc.);
+      // rules carry host + path → backend; tls carries cert refs.
+      paths: ["spec.ingressClassName", "spec.rules", "spec.tls"],
+    },
+    metadata: {
+      label: "Metadata",
+      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+    },
+    advanced: {
+      label: "Advanced",
+      // defaultBackend is the catch-all when no rule matches; rare
+      // in practice but valid.
+      paths: ["spec.defaultBackend"],
+    },
     createOnly: ["metadata.name", "metadata.namespace"],
   },
 };
@@ -93,6 +173,52 @@ export function isSupportedKind(kind: string): kind is SupportedKind {
 
 export function getCreateOnlyPaths(kind: SupportedKind): string[] {
   return KIND_SPECS[kind].createOnly;
+}
+
+/** Section labels for SchemaForm's grouped renderer. The primary
+ *  label is kind-specific; metadata + advanced are constant. */
+export function getSectionLabels(kind: SupportedKind): {
+  primary: string;
+  metadata: string;
+  advanced: string;
+} {
+  const s = KIND_SPECS[kind];
+  return {
+    primary: s.primary.label,
+    metadata: s.metadata.label,
+    advanced: s.advanced.label,
+  };
+}
+
+/** Build a path → { section, displayOrder } resolver for the given
+ *  kind. The walker calls this per top-level descriptor it emits;
+ *  unmatched paths return undefined and the renderer puts them in a
+ *  "Other" fallback section so future schema fields aren't dropped
+ *  silently. Dev-mode duplicate-path detection runs once at build
+ *  time and throws — a path may not legitimately appear in two
+ *  section lists for the same kind. */
+export function getSectionResolver(
+  kind: SupportedKind,
+): (path: string[]) => { section: FieldSection; displayOrder: number } | undefined {
+  const spec = KIND_SPECS[kind];
+  const map = new Map<string, { section: FieldSection; displayOrder: number }>();
+  const stamp = (paths: string[], section: FieldSection) => {
+    paths.forEach((p, i) => {
+      if (map.has(p)) {
+        // Authoring bug (same path in two sections). Surface loudly
+        // in dev so the duplicate is fixed at the spec level rather
+        // than silently winning the last write.
+        throw new Error(
+          `[k8sAllowlist] duplicate path "${p}" for ${kind}: already in section "${map.get(p)!.section}", trying to add to "${section}"`,
+        );
+      }
+      map.set(p, { section, displayOrder: i });
+    });
+  };
+  stamp(spec.primary.paths, "primary");
+  stamp(spec.metadata.paths, "metadata");
+  stamp(spec.advanced.paths, "advanced");
+  return (path: string[]) => map.get(path.join("."));
 }
 
 /** Return a narrowed schema whose `properties` only contain the
@@ -106,20 +232,33 @@ export function filterSchemaForKind(schema: JSONSchema, kind: SupportedKind): JS
   if (!schema || typeof schema !== "object") return schema;
   if (!schema.properties) return schema;
 
+  // Collect every allowlisted path across all sections — this is
+  // what the schema narrowing operates on.
+  const allPaths = [
+    ...spec.primary.paths,
+    ...spec.metadata.paths,
+    ...spec.advanced.paths,
+  ];
+
   const next: JSONSchema = { ...schema, properties: {}, required: [] };
   const props = schema.properties;
 
-  // metadata: narrow to the allowlisted sub-fields.
-  if (props.metadata) {
-    next.properties!.metadata = filterMetadata(props.metadata, spec.metadata);
+  // metadata: narrow to the allowlisted sub-fields. metadata paths
+  // are always of shape "metadata.<key>", so we strip the prefix.
+  const metadataKeys = spec.metadata.paths
+    .filter((p) => p.startsWith("metadata."))
+    .map((p) => p.slice("metadata.".length));
+  if (props.metadata && metadataKeys.length > 0) {
+    next.properties!.metadata = filterMetadata(props.metadata, metadataKeys);
   }
 
-  // Top-level allowlisted paths. Each path may be top-level
-  // (`data`) or nested (`spec.type`); group nested-under-spec paths
-  // and emit one filtered `spec` object covering them.
+  // Top-level + nested-under-spec paths. Everything that doesn't
+  // start with `metadata.` either lives at the root (e.g. `data`,
+  // `binaryData`, `immutable`, `type`, `stringData`) or under spec.
   const topLevel = new Set<string>();
   const specSubFields = new Set<string>();
-  for (const p of spec.paths) {
+  for (const p of allPaths) {
+    if (p.startsWith("metadata.")) continue;
     if (p.startsWith("spec.")) specSubFields.add(p.slice("spec.".length));
     else topLevel.add(p);
   }

--- a/web/src/lib/schemaForm/roundTrip.test.ts
+++ b/web/src/lib/schemaForm/roundTrip.test.ts
@@ -21,6 +21,7 @@ import { buildFieldDescriptors } from "./walker";
 import { buildRefResolver, findSchemaByGVK } from "./refResolver";
 import {
   filterSchemaForKind,
+  getSectionResolver,
   getCreateOnlyPaths,
   getKindGVK,
   type SupportedKind,
@@ -414,4 +415,109 @@ describe("YAML 1.1 boolean-keyword strings — regression", () => {
       expect(result).toEqual({ data: { KEY: sample } });
     });
   }
+});
+
+describe("section grouping is UI-only — round-trip preserves all fields", () => {
+  // The renderer regroups descriptors into primary / metadata /
+  // advanced sections; that grouping must NOT alter the values
+  // payload that flows back through the bridge to YAML. This
+  // exercises the same buildFieldDescriptors → setAtPath →
+  // stringify path SchemaFormBridge uses, with sectionResolver
+  // turned on.
+
+  it("ConfigMap: edit a primary field, untouched annotations + immutable persist", () => {
+    const yaml = [
+      "apiVersion: v1",
+      "kind: ConfigMap",
+      "metadata:",
+      "  name: app-config",
+      "  namespace: default",
+      "  annotations:",
+      "    cert-manager.io/issuer: letsencrypt",
+      "  labels:",
+      "    app: web",
+      "data:",
+      "  PORT: \"8080\"",
+      "immutable: true",
+      "",
+    ].join("\n");
+
+    const schema = schemaFor("ConfigMap");
+    const opts = {
+      ...walkOptionsFor("ConfigMap"),
+      sectionResolver: getSectionResolver("ConfigMap"),
+    };
+    const ds = buildFieldDescriptors(schema, opts);
+    const all = flatten(ds);
+
+    // Confirm the walker stamped sections (sanity: this is what
+    // makes the renderer regroup; we want to prove the regroup
+    // doesn't drop fields on save).
+    const data = all.find((d) => d.path.join(".") === "data");
+    const annotations = all.find(
+      (d) => d.path.join(".") === "metadata.annotations",
+    );
+    const immutable = all.find((d) => d.path.join(".") === "immutable");
+    expect(data?.section).toBe("primary");
+    expect(annotations?.section).toBe("metadata");
+    expect(immutable?.section).toBe("advanced");
+
+    // Simulate a primary-section edit: bump data.PORT.
+    const obj = parseYaml(yaml) as Record<string, unknown>;
+    const dataPath = data?.path ?? [];
+    const updated = setAtPath(obj, [...dataPath, "PORT"], "9090");
+    const reYaml = stringifyYaml(updated, { lineWidth: 0, schema: "yaml-1.1" });
+    const reParsed = parseYaml(reYaml) as {
+      data: { PORT: string };
+      metadata: {
+        annotations: Record<string, string>;
+        labels: Record<string, string>;
+      };
+      immutable: boolean;
+    };
+
+    // Primary edit landed.
+    expect(reParsed.data.PORT).toBe("9090");
+    // Untouched fields from OTHER sections survived intact.
+    expect(reParsed.metadata.annotations["cert-manager.io/issuer"]).toBe(
+      "letsencrypt",
+    );
+    expect(reParsed.metadata.labels.app).toBe("web");
+    expect(reParsed.immutable).toBe(true);
+  });
+
+  it("Service: edit advanced clusterIP, primary type/selector/ports persist", () => {
+    const yaml = [
+      "apiVersion: v1",
+      "kind: Service",
+      "metadata:",
+      "  name: web",
+      "spec:",
+      "  type: ClusterIP",
+      "  selector:",
+      "    app: web",
+      "  ports:",
+      "    - port: 80",
+      "      targetPort: 8080",
+      "  clusterIP: 10.0.0.42",
+      "",
+    ].join("\n");
+
+    const obj = parseYaml(yaml) as Record<string, unknown>;
+    const updated = setAtPath(obj, ["spec", "clusterIP"], "10.0.0.99");
+    const reYaml = stringifyYaml(updated, { lineWidth: 0, schema: "yaml-1.1" });
+    const reParsed = parseYaml(reYaml) as {
+      spec: {
+        type: string;
+        selector: Record<string, string>;
+        ports: Array<{ port: number; targetPort: number }>;
+        clusterIP: string;
+      };
+    };
+
+    expect(reParsed.spec.clusterIP).toBe("10.0.0.99");
+    expect(reParsed.spec.type).toBe("ClusterIP");
+    expect(reParsed.spec.selector.app).toBe("web");
+    expect(reParsed.spec.ports[0]).toEqual({ port: 80, targetPort: 8080 });
+  });
 });

--- a/web/src/lib/schemaForm/sections.ts
+++ b/web/src/lib/schemaForm/sections.ts
@@ -1,0 +1,55 @@
+// schemaForm/sections.ts — pure helpers that group section-stamped
+// FieldDescriptors for the SchemaForm renderer. Lives in its own
+// file so SchemaForm.tsx exports only React components (the
+// react-refresh/only-export-components lint rule fires when a
+// component module also exports plain functions).
+
+import type { FieldDescriptor } from "./types";
+
+export interface SectionedBuckets {
+  primary: FieldDescriptor[];
+  metadata: FieldDescriptor[];
+  advanced: FieldDescriptor[];
+  total: number;
+}
+
+// Walk the descriptor tree and collect every descriptor whose walker
+// stamped a section. Descriptors land in the bucket directly, even if
+// they are nested children of an unsectioned object container (e.g.
+// `metadata.name` is collected under "metadata" while its parent
+// `metadata` descriptor itself is unsectioned and gets dropped from
+// the layout).
+export function collectSectioned(
+  descriptors: FieldDescriptor[],
+): SectionedBuckets {
+  const buckets: SectionedBuckets = {
+    primary: [],
+    metadata: [],
+    advanced: [],
+    total: 0,
+  };
+  const visit = (d: FieldDescriptor) => {
+    if (d.section) {
+      buckets[d.section].push(d);
+      buckets.total += 1;
+    }
+    if (d.children) {
+      for (const c of d.children) visit(c);
+    }
+  };
+  for (const d of descriptors) visit(d);
+  const byOrder = (a: FieldDescriptor, b: FieldDescriptor) =>
+    (a.displayOrder ?? Number.MAX_SAFE_INTEGER) -
+    (b.displayOrder ?? Number.MAX_SAFE_INTEGER);
+  buckets.primary.sort(byOrder);
+  buckets.metadata.sort(byOrder);
+  buckets.advanced.sort(byOrder);
+  return buckets;
+}
+
+export function descendantHasSection(d: FieldDescriptor): boolean {
+  if (!d.children) return false;
+  return d.children.some(
+    (c) => c.section !== undefined || descendantHasSection(c),
+  );
+}

--- a/web/src/lib/schemaForm/types.ts
+++ b/web/src/lib/schemaForm/types.ts
@@ -41,6 +41,27 @@ export type FieldType =
   | "discriminator"
   | "unsupported";
 
+/** Where a top-level descriptor lives in the sectioned form layout
+ *  (introduced for the K8s ConfigMap/Secret/Service/Ingress curated
+ *  forms — Helm consumers leave this unset and get flat rendering).
+ *
+ *  Section semantics:
+ *    primary  — the kind-specific spec content the operator came to
+ *               edit. Always visible at the top of the form.
+ *    metadata — metadata.name / namespace / labels / annotations.
+ *               Useful but rarely the reason someone opened the
+ *               editor; collapsed by default.
+ *    advanced — Spec fields that are valid but rarely touched
+ *               (Service.spec.externalTrafficPolicy etc.) plus
+ *               immutable-after-create flags. Hidden behind a
+ *               "Show advanced" toggle.
+ *
+ *  Stamped by the walker when WalkOptions.sectionResolver is
+ *  supplied. Children of object descriptors inherit visually from
+ *  their parent — only top-level descriptors carry an explicit
+ *  section. */
+export type FieldSection = "primary" | "metadata" | "advanced";
+
 /** One option in a `discriminator`-typed field. The renderer shows a
  *  branch picker (segmented buttons) and recurses into the chosen
  *  branch's `schema` to render the sub-form. `discriminatorKey` is
@@ -98,6 +119,16 @@ export interface FieldDescriptor {
   /** For type=unsupported, why we couldn't render this field as a
    *  form. Surfaced as a "edit in YAML mode" hint. */
   unsupportedReason?: string;
+  /** Curated layout grouping — set on top-level descriptors by the
+   *  walker when WalkOptions.sectionResolver is supplied. The K8s
+   *  forms use this to render primary fields above the fold and
+   *  collapse metadata/advanced. Helm + other unsectioned consumers
+   *  leave this undefined and get the flat-list render. */
+  section?: FieldSection;
+  /** Explicit ordering within a section. Lower number renders first.
+   *  Set alongside `section` by the walker. When unset, descriptors
+   *  fall back to schema-walk order within their section. */
+  displayOrder?: number;
 }
 
 export interface ValidationIssue {

--- a/web/src/lib/schemaForm/walker.test.ts
+++ b/web/src/lib/schemaForm/walker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildFieldDescriptors } from "./walker";
 import { buildRefResolver, findSchemaByGVK } from "./refResolver";
-import { filterSchemaForKind, getCreateOnlyPaths } from "./k8sAllowlist";
+import { filterSchemaForKind, getCreateOnlyPaths, getSectionResolver } from "./k8sAllowlist";
 import type { JSONSchema } from "./types";
 import type { OpenAPIDoc } from "../api";
 
@@ -464,5 +464,158 @@ describe("walker — allOf merging (#132)", () => {
     const ds = buildFieldDescriptors(schema);
     const bad = ds.find((d) => d.path.join(".") === "bad");
     expect(bad?.type).toBe("unsupported");
+  });
+});
+
+describe("walker — sectionResolver stamps descriptor.section + displayOrder", () => {
+  // Synthetic ConfigMap-shaped schema. Lets the test exercise the
+  // walker's stamping in isolation from the live K8s OpenAPI schema
+  // (we test the per-kind resolvers directly via k8sAllowlist).
+  const cmShape: JSONSchema = {
+    type: "object",
+    properties: {
+      metadata: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          namespace: { type: "string" },
+          labels: { type: "object", additionalProperties: { type: "string" } },
+          annotations: { type: "object", additionalProperties: { type: "string" } },
+        },
+      },
+      data: { type: "object", additionalProperties: { type: "string" } },
+      binaryData: { type: "object", additionalProperties: { type: "string" } },
+      immutable: { type: "boolean" },
+    },
+  };
+
+  it("ConfigMap: top-level primary/advanced fields are stamped at root", () => {
+    const ds = buildFieldDescriptors(cmShape, {
+      allowKvMap: true,
+      sectionResolver: getSectionResolver("ConfigMap"),
+    });
+    const data = ds.find((d) => d.path.join(".") === "data");
+    const binaryData = ds.find((d) => d.path.join(".") === "binaryData");
+    const immutable = ds.find((d) => d.path.join(".") === "immutable");
+    const metadata = ds.find((d) => d.path.join(".") === "metadata");
+
+    expect(data?.section).toBe("primary");
+    expect(data?.displayOrder).toBe(0);
+    expect(binaryData?.section).toBe("primary");
+    expect(binaryData?.displayOrder).toBe(1);
+    expect(immutable?.section).toBe("advanced");
+    expect(immutable?.displayOrder).toBe(0);
+    // The metadata container itself is NOT stamped — only its
+    // children are. The renderer drops the unsectioned parent and
+    // promotes the children into the metadata section.
+    expect(metadata?.section).toBeUndefined();
+  });
+
+  it("ConfigMap: nested metadata.* children get the metadata section", () => {
+    const ds = buildFieldDescriptors(cmShape, {
+      allowKvMap: true,
+      sectionResolver: getSectionResolver("ConfigMap"),
+    });
+    const metaChildren = ds.find((d) => d.path.join(".") === "metadata")?.children ?? [];
+    const byPath = (p: string) => metaChildren.find((c) => c.path.join(".") === p);
+
+    expect(byPath("metadata.name")?.section).toBe("metadata");
+    expect(byPath("metadata.name")?.displayOrder).toBe(0);
+    expect(byPath("metadata.namespace")?.section).toBe("metadata");
+    expect(byPath("metadata.namespace")?.displayOrder).toBe(1);
+    expect(byPath("metadata.labels")?.section).toBe("metadata");
+    expect(byPath("metadata.labels")?.displayOrder).toBe(2);
+    expect(byPath("metadata.annotations")?.section).toBe("metadata");
+    expect(byPath("metadata.annotations")?.displayOrder).toBe(3);
+  });
+
+  it("Service: spec.* fields split between primary and advanced", () => {
+    const svcShape: JSONSchema = {
+      type: "object",
+      properties: {
+        spec: {
+          type: "object",
+          properties: {
+            type: { type: "string" },
+            selector: { type: "object", additionalProperties: { type: "string" } },
+            ports: { type: "array", items: { type: "object" } },
+            clusterIP: { type: "string" },
+            externalTrafficPolicy: { type: "string" },
+            sessionAffinity: { type: "string" },
+          },
+        },
+      },
+    };
+    const ds = buildFieldDescriptors(svcShape, {
+      allowKvMap: true,
+      allowArrayOfObjects: true,
+      sectionResolver: getSectionResolver("Service"),
+    });
+    const specChildren = ds.find((d) => d.path.join(".") === "spec")?.children ?? [];
+    const byPath = (p: string) => specChildren.find((c) => c.path.join(".") === p);
+
+    expect(byPath("spec.type")?.section).toBe("primary");
+    expect(byPath("spec.type")?.displayOrder).toBe(0);
+    expect(byPath("spec.selector")?.section).toBe("primary");
+    expect(byPath("spec.selector")?.displayOrder).toBe(1);
+    expect(byPath("spec.ports")?.section).toBe("primary");
+    expect(byPath("spec.ports")?.displayOrder).toBe(2);
+    expect(byPath("spec.clusterIP")?.section).toBe("advanced");
+    expect(byPath("spec.externalTrafficPolicy")?.section).toBe("advanced");
+    expect(byPath("spec.sessionAffinity")?.section).toBe("advanced");
+  });
+
+  it("Ingress: spec.rules and spec.tls primary; spec.defaultBackend advanced", () => {
+    const ingShape: JSONSchema = {
+      type: "object",
+      properties: {
+        spec: {
+          type: "object",
+          properties: {
+            ingressClassName: { type: "string" },
+            rules: { type: "array", items: { type: "object" } },
+            tls: { type: "array", items: { type: "object" } },
+            defaultBackend: { type: "object", properties: { service: { type: "object" } } },
+          },
+        },
+      },
+    };
+    const ds = buildFieldDescriptors(ingShape, {
+      allowArrayOfObjects: true,
+      sectionResolver: getSectionResolver("Ingress"),
+    });
+    const specChildren = ds.find((d) => d.path.join(".") === "spec")?.children ?? [];
+    const byPath = (p: string) => specChildren.find((c) => c.path.join(".") === p);
+
+    expect(byPath("spec.ingressClassName")?.section).toBe("primary");
+    expect(byPath("spec.ingressClassName")?.displayOrder).toBe(0);
+    expect(byPath("spec.rules")?.section).toBe("primary");
+    expect(byPath("spec.rules")?.displayOrder).toBe(1);
+    expect(byPath("spec.tls")?.section).toBe("primary");
+    expect(byPath("spec.tls")?.displayOrder).toBe(2);
+    expect(byPath("spec.defaultBackend")?.section).toBe("advanced");
+    expect(byPath("spec.defaultBackend")?.displayOrder).toBe(0);
+  });
+
+  it("paths not in any section list get no section property", () => {
+    const ds = buildFieldDescriptors(cmShape, {
+      allowKvMap: true,
+      sectionResolver: getSectionResolver("ConfigMap"),
+    });
+    // `metadata.uid` doesn't exist in our test shape, but more
+    // importantly: the `metadata` container path itself has no
+    // entry in the resolver — verify that yields an undefined
+    // section rather than a default like "primary".
+    const metadata = ds.find((d) => d.path.join(".") === "metadata");
+    expect(metadata?.section).toBeUndefined();
+    expect(metadata?.displayOrder).toBeUndefined();
+  });
+
+  it("walker without sectionResolver leaves descriptors unstamped (Helm back-compat)", () => {
+    const ds = buildFieldDescriptors(cmShape, { allowKvMap: true });
+    for (const d of ds) {
+      expect(d.section).toBeUndefined();
+      expect(d.displayOrder).toBeUndefined();
+    }
   });
 });

--- a/web/src/lib/schemaForm/walker.ts
+++ b/web/src/lib/schemaForm/walker.ts
@@ -8,7 +8,12 @@
 // unchanged.
 
 import { mergeAllOf } from "./allOfMerger";
-import type { DiscriminatorBranch, FieldDescriptor, JSONSchema } from "./types";
+import type {
+  DiscriminatorBranch,
+  FieldDescriptor,
+  FieldSection,
+  JSONSchema,
+} from "./types";
 
 export interface WalkOptions {
   /** Resolve a `$ref` string (e.g. "#/components/schemas/...") to a
@@ -32,6 +37,15 @@ export interface WalkOptions {
    *  flag with `editable: "create-only"`. Surfaced by the renderer
    *  as read-only inputs in edit mode. */
   createOnlyPaths?: string[];
+  /** When provided, the walker stamps `descriptor.section` and
+   *  `descriptor.displayOrder` on every descriptor whose dotted path
+   *  matches. K8sSchemaForm uses this to assign primary/metadata/
+   *  advanced sections per kind; SchemaForm renders sectioned blocks
+   *  when any descriptor carries a section, otherwise falls back to
+   *  the flat layout (back-compat for the Helm consumer). */
+  sectionResolver?: (
+    path: string[],
+  ) => { section: FieldSection; displayOrder: number } | undefined;
 }
 
 /** Walk schema, emit a tree of field descriptors. */
@@ -94,6 +108,24 @@ function walkObject(
 }
 
 function walkField(
+  raw: JSONSchema,
+  path: string[],
+  required: boolean,
+  options: WalkOptions,
+  parentSeen: Set<string>,
+): FieldDescriptor {
+  const desc = walkFieldImpl(raw, path, required, options, parentSeen);
+  if (options.sectionResolver) {
+    const sec = options.sectionResolver(path);
+    if (sec) {
+      desc.section = sec.section;
+      desc.displayOrder = sec.displayOrder;
+    }
+  }
+  return desc;
+}
+
+function walkFieldImpl(
   raw: JSONSchema,
   path: string[],
   required: boolean,


### PR DESCRIPTION
## Summary

- Per-kind section grouping for the schema-aware form editor: **Primary** (kind-specific, always open) → **Metadata** (collapsed) → **Advanced** (collapsed, with field count). Applies to ConfigMap / Secret / Service / Ingress.
- Walker stamps `descriptor.section` + `displayOrder` from a per-kind resolver in `k8sAllowlist`. Renderer regroups at display time only — values payload and YAML round-trip are unaffected.
- Helm consumer is opt-out by default: when no `sectionLabels` prop is passed, the renderer falls back to the legacy flat list.

Closes #143

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 279 / 279 pass (was 263; +16 new section-grouping cases across `walker.test.ts`, `SchemaForm.test.ts` (new), and `roundTrip.test.ts`)
- [ ] Manual smoke — open ConfigMap → confirm `Data` section open, `Metadata` collapsed, `Advanced (1)` showing `immutable`
- [ ] Repeat for Secret (`Data`), Service (`Networking`), Ingress (`Routing & TLS`)
- [ ] Helm install/upgrade dialog still renders flat (back-compat)
- [ ] Form → YAML → form preserves untouched fields in collapsed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)