### PR TITLE
feat: helm release rollback (#77, supersedes #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ tag.
   
 ### Added
 
+- Helm release rollback (#77). New `POST /api/clusters/{c}/helm/
+  releases/{ns}/{name}/rollback` endpoint patches the cluster from
+  the current revision to the operator-selected target revision via
+  the helm SDK. Pre-flight SAR (verb=patch) runs against the target
+  revision’s manifest list; denials block the action with a 403 and
+  surface the (verb, GVR) tuples in the modal so the operator can
+  take them to their cluster admin. Audit emits a pre/post pair
+  (`helm_rollback_intent` / `helm_rollback`) carrying
+  `fromRevision` / `toRevision` / `newRevision`. The release page
+  history tab adds a per-row Rollback button (disabled on the
+  current revision); the modal renders a side-by-side diff of the
+  current vs. target manifests before submission and stays open with
+  a spinner + inline error / denial state until the mutation
+  settles.
+
 - Form-mode coverage for `oneOf` discriminators and `allOf`
   composition (#132, builds on #131). Adds two extensions to the
   shared `lib/schemaForm/` engine that close the most common

--- a/cmd/periscope/helm_action_handler.go
+++ b/cmd/periscope/helm_action_handler.go
@@ -50,6 +50,7 @@ var (
 	installHelmReleaseFn   = k8s.InstallHelmRelease
 	upgradeHelmReleaseFn   = k8s.UpgradeHelmRelease
 	uninstallHelmReleaseFn = k8s.UninstallHelmRelease
+	rollbackHelmReleaseFn  = k8s.RollbackHelmRelease
 )
 
 // helmActionDefaultTimeout / helmActionMaxTimeout are server-side
@@ -469,6 +470,141 @@ func emitHelmUninstallOutcome(ctx context.Context, emitter *audit.Emitter, c clu
 	emitter.Record(ctx, audit.Event{
 		Actor:   actorFromContext(ctx),
 		Verb:    audit.VerbHelmUninstall,
+		Outcome: outcome,
+		Cluster: c.Name,
+		Resource: audit.ResourceRef{
+			Namespace: args.Namespace,
+			Name:      args.ReleaseName,
+		},
+		Reason: reason,
+		Extra:  extra,
+	})
+}
+
+// helmRollbackRequest is the rollback body. Revision is the only
+// required field; the wait/cleanup/disable-hooks knobs follow the
+// install/upgrade pattern. timeoutSeconds is honored within the
+// server-side cap (helmActionMaxTimeout).
+type helmRollbackRequest struct {
+	Revision       int   `json:"revision"`
+	Wait           *bool `json:"wait,omitempty"`
+	CleanupOnFail  bool  `json:"cleanupOnFail,omitempty"`
+	DisableHooks   bool  `json:"disableHooks,omitempty"`
+	TimeoutSeconds int   `json:"timeoutSeconds,omitempty"`
+}
+
+// helmRollbackHandler powers POST /api/clusters/{cluster}/helm/
+// releases/{ns}/{name}/rollback. Sync — blocks until the helm SDK
+// rollback returns. Audit pre/post pair fires around the SDK call.
+//
+// URL conforms to the existing helm sub-resource pattern (verb at
+// the end, namespace + release name in the path), matching the
+// upgrade/uninstall siblings. Body carries only the bits that
+// can't live in the URL.
+func helmRollbackHandler(reg *clusters.Registry, emitter *audit.Emitter) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		ns := chi.URLParam(r, "ns")
+		name := chi.URLParam(r, "name")
+		if ns == "" || name == "" {
+			http.Error(w, "namespace and name path params required", http.StatusBadRequest)
+			return
+		}
+
+		var req helmRollbackRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Revision <= 0 {
+			http.Error(w, "revision must be > 0", http.StatusBadRequest)
+			return
+		}
+
+		args := k8s.HelmRollbackArgs{
+			Namespace:     ns,
+			ReleaseName:   name,
+			Revision:      req.Revision,
+			Wait:          boolDefault(req.Wait, true),
+			CleanupOnFail: req.CleanupOnFail,
+			DisableHooks:  req.DisableHooks,
+			Timeout:       clampTimeout(req.TimeoutSeconds),
+		}
+
+		emitHelmRollbackIntent(r.Context(), emitter, c, args)
+
+		result, err := rollbackHelmReleaseFn(r.Context(), p, c, args)
+		if err != nil {
+			handleHelmRollbackFailure(r.Context(), w, emitter, c, args, err)
+			return
+		}
+		emitHelmRollbackOutcome(r.Context(), emitter, c, audit.OutcomeSuccess, args, result, "")
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func handleHelmRollbackFailure(ctx context.Context, w http.ResponseWriter, emitter *audit.Emitter, c clusters.Cluster, args k8s.HelmRollbackArgs, err error) {
+	if denied, ok := k8s.IsDeniedError(err); ok {
+		emitHelmRollbackOutcome(ctx, emitter, c, audit.OutcomeDenied, args, nil, err.Error())
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"code":    "E_HELM_PREFLIGHT_DENIED",
+			"message": "RBAC pre-flight denied one or more resources",
+			"denied":  denied.Denials,
+		})
+		return
+	}
+	slog.WarnContext(ctx, "helm rollback failed",
+		"cluster", c.Name, "namespace", args.Namespace, "releaseName", args.ReleaseName,
+		"targetRevision", args.Revision, "err", err)
+	emitHelmRollbackOutcome(ctx, emitter, c, audit.OutcomeFailure, args, nil, err.Error())
+	status, code := classifyHelmPreviewErr(err)
+	writeAPIErrorJSON(w, status, code, err.Error())
+}
+
+func emitHelmRollbackIntent(ctx context.Context, emitter *audit.Emitter, c clusters.Cluster, args k8s.HelmRollbackArgs) {
+	if emitter == nil {
+		return
+	}
+	emitter.Record(ctx, audit.Event{
+		Actor:   actorFromContext(ctx),
+		Verb:    audit.VerbHelmRollbackIntent,
+		Outcome: audit.OutcomeSuccess,
+		Cluster: c.Name,
+		Resource: audit.ResourceRef{
+			Namespace: args.Namespace,
+			Name:      args.ReleaseName,
+		},
+		Extra: map[string]any{
+			"targetRevision": args.Revision,
+			"wait":           args.Wait,
+			"cleanupOnFail":  args.CleanupOnFail,
+			"disableHooks":   args.DisableHooks,
+		},
+	})
+}
+
+func emitHelmRollbackOutcome(ctx context.Context, emitter *audit.Emitter, c clusters.Cluster, outcome audit.Outcome, args k8s.HelmRollbackArgs, result *k8s.HelmRollbackResult, reason string) {
+	if emitter == nil {
+		return
+	}
+	extra := map[string]any{
+		"targetRevision": args.Revision,
+		"wait":           args.Wait,
+		"cleanupOnFail":  args.CleanupOnFail,
+		"disableHooks":   args.DisableHooks,
+	}
+	if result != nil {
+		extra["fromRevision"] = result.FromRevision
+		extra["toRevision"] = result.ToRevision
+		extra["newRevision"] = result.NewRevision
+	}
+	emitter.Record(ctx, audit.Event{
+		Actor:   actorFromContext(ctx),
+		Verb:    audit.VerbHelmRollback,
 		Outcome: outcome,
 		Cluster: c.Name,
 		Resource: audit.ResourceRef{

--- a/cmd/periscope/helm_action_handler_test.go
+++ b/cmd/periscope/helm_action_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -493,5 +494,214 @@ func TestHelmUninstallHandler_ValidationMissingPathParams(t *testing.T) {
 	)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 for empty ns", rec.Code)
+	}
+}
+
+func withRollbackReleaseFn(t *testing.T, fn func(context.Context, credentials.Provider, clusters.Cluster, k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error)) {
+	t.Helper()
+	prev := rollbackHelmReleaseFn
+	rollbackHelmReleaseFn = fn
+	t.Cleanup(func() { rollbackHelmReleaseFn = prev })
+}
+
+func TestHelmRollbackHandler_HappyPathEmitsAuditPair(t *testing.T) {
+	withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, args k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+		if args.Namespace != "app-ns" || args.ReleaseName != "web" {
+			t.Errorf("rollback args ns/name should come from URL: %+v", args)
+		}
+		if args.Revision != 3 {
+			t.Errorf("revision should come from body: %+v", args)
+		}
+		if !args.Wait {
+			t.Error("Wait should default to true")
+		}
+		return &k8s.HelmRollbackResult{
+			Release: k8s.ActionReleaseInfo{
+				Name: "web", Namespace: "app-ns", Revision: 6, Status: "deployed",
+			},
+			NewRevision:  6,
+			FromRevision: 5,
+			ToRevision:   3,
+		}, nil
+	})
+
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+		http.MethodPost, "/api/clusters/test/helm/releases/app-ns/web/rollback",
+		map[string]string{"cluster": "test", "ns": "app-ns", "name": "web"},
+		[]byte(`{"revision":3}`),
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 audit events (intent + outcome), got %d", len(events))
+	}
+	if events[0].Verb != audit.VerbHelmRollbackIntent || events[1].Verb != audit.VerbHelmRollback {
+		t.Errorf("verb pair wrong: %q + %q", events[0].Verb, events[1].Verb)
+	}
+	if events[1].Outcome != audit.OutcomeSuccess {
+		t.Errorf("outcome row = %q, want success", events[1].Outcome)
+	}
+	if from, _ := events[1].Extra["fromRevision"].(int); from != 5 {
+		t.Errorf("Extra.fromRevision = %v, want 5", events[1].Extra["fromRevision"])
+	}
+	if to, _ := events[1].Extra["toRevision"].(int); to != 3 {
+		t.Errorf("Extra.toRevision = %v, want 3", events[1].Extra["toRevision"])
+	}
+	if newRev, _ := events[1].Extra["newRevision"].(int); newRev != 6 {
+		t.Errorf("Extra.newRevision = %v, want 6", events[1].Extra["newRevision"])
+	}
+}
+
+func TestHelmRollbackHandler_KnobsHonored(t *testing.T) {
+	var captured k8s.HelmRollbackArgs
+	withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, args k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+		captured = args
+		return &k8s.HelmRollbackResult{Release: k8s.ActionReleaseInfo{Name: "web"}}, nil
+	})
+	reg := testRegistry(t)
+	body := `{"revision":2,"wait":false,"cleanupOnFail":true,"disableHooks":true,"timeoutSeconds":120}`
+	rec, _ := actionHandlerInvoke(t,
+		func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+		http.MethodPost, "/api/clusters/test/helm/releases/app-ns/web/rollback",
+		map[string]string{"cluster": "test", "ns": "app-ns", "name": "web"},
+		[]byte(body),
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if captured.Wait {
+		t.Error("Wait should be false when body wait=false")
+	}
+	if !captured.CleanupOnFail {
+		t.Error("CleanupOnFail should be true when body cleanupOnFail=true")
+	}
+	if !captured.DisableHooks {
+		t.Error("DisableHooks should be true when body disableHooks=true")
+	}
+	if captured.Timeout <= 0 {
+		t.Error("Timeout should be set (positive duration) when timeoutSeconds=120")
+	}
+}
+
+func TestHelmRollbackHandler_ValidationMissingRevision(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{}`},
+		{"zero revision", `{"revision":0}`},
+		{"negative revision", `{"revision":-1}`},
+		{"malformed json", `{not json`},
+	}
+	reg := testRegistry(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, _ k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+				t.Fatal("rollback fn should NOT be called when validation fails")
+				return nil, nil
+			})
+			rec, _ := actionHandlerInvoke(t,
+				func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+				http.MethodPost, "/api/clusters/test/helm/releases/app-ns/web/rollback",
+				map[string]string{"cluster": "test", "ns": "app-ns", "name": "web"},
+				[]byte(tc.body),
+			)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHelmRollbackHandler_PreflightDeniedReturns403(t *testing.T) {
+	withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, _ k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+		return nil, &k8s.DeniedError{Denials: []k8s.PreviewDenial{
+			{Group: "apps", Resource: "deployments", Verb: "patch", Reason: "denied"},
+		}}
+	})
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+		http.MethodPost, "/api/clusters/test/helm/releases/app-ns/web/rollback",
+		map[string]string{"cluster": "test", "ns": "app-ns", "name": "web"},
+		[]byte(`{"revision":3}`),
+	)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "E_HELM_PREFLIGHT_DENIED") {
+		t.Errorf("body missing E_HELM_PREFLIGHT_DENIED: %s", rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 2 || events[1].Outcome != audit.OutcomeDenied {
+		t.Errorf("expected intent + denied outcome pair; got %+v", events)
+	}
+}
+
+func TestHelmRollbackHandler_NoOpRollbackRejected(t *testing.T) {
+	// rollback to current is rejected by the k8s layer; verify the
+	// handler bubbles the error and emits a Failure outcome.
+	withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, _ k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+		return nil, fmt.Errorf("rollback: target revision 5 is already current")
+	})
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+		http.MethodPost, "/api/clusters/test/helm/releases/app-ns/web/rollback",
+		map[string]string{"cluster": "test", "ns": "app-ns", "name": "web"},
+		[]byte(`{"revision":5}`),
+	)
+	if rec.Code < 400 {
+		t.Fatalf("status = %d, want >=400; body=%s", rec.Code, rec.Body.String())
+	}
+	events := sink.snapshot()
+	if len(events) != 2 || events[1].Outcome != audit.OutcomeFailure {
+		t.Errorf("expected intent + failure outcome pair; got %+v", events)
+	}
+}
+
+func TestHelmRollbackHandler_ReleaseNotFoundReturns404(t *testing.T) {
+	withRollbackReleaseFn(t, func(_ context.Context, _ credentials.Provider, _ clusters.Cluster, _ k8s.HelmRollbackArgs) (*k8s.HelmRollbackResult, error) {
+		return nil, driver.ErrReleaseNotFound
+	})
+	reg := testRegistry(t)
+	rec, _ := actionHandlerInvoke(t,
+		func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+		http.MethodPost, "/api/clusters/test/helm/releases/app-ns/missing/rollback",
+		map[string]string{"cluster": "test", "ns": "app-ns", "name": "missing"},
+		[]byte(`{"revision":1}`),
+	)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHelmRollbackHandler_ValidationMissingPathParams(t *testing.T) {
+	cases := []struct {
+		name        string
+		urlSuffix   string
+		params      map[string]string
+		wantStatus  int
+	}{
+		{"missing ns", "/helm/releases//web/rollback", map[string]string{"cluster": "test", "ns": "", "name": "web"}, http.StatusBadRequest},
+		{"missing name", "/helm/releases/app-ns//rollback", map[string]string{"cluster": "test", "ns": "app-ns", "name": ""}, http.StatusBadRequest},
+		{"unknown cluster", "/helm/releases/app-ns/web/rollback", map[string]string{"cluster": "missing", "ns": "app-ns", "name": "web"}, http.StatusNotFound},
+	}
+	reg := testRegistry(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, _ := actionHandlerInvoke(t,
+				func(e *audit.Emitter) credentials.Handler { return helmRollbackHandler(reg, e) },
+				http.MethodPost, "/api/clusters/"+tc.params["cluster"]+tc.urlSuffix,
+				tc.params, []byte(`{"revision":1}`),
+			)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
 	}
 }

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -297,6 +297,11 @@ func main() {
 		credentials.Wrap(factory, helmUpgradeHandler(registry, auditEmitter)))
 	router.Delete("/api/clusters/{cluster}/helm/releases/{ns}/{name}",
 		credentials.Wrap(factory, helmUninstallHandler(registry, auditEmitter)))
+	// Helm release rollback (#77). Sync handler; pre/post audit pair
+	// fires around the SDK call. SAR pre-flight against TARGET
+	// revision's manifests with verb=patch.
+	router.Post("/api/clusters/{cluster}/helm/releases/{ns}/{name}/rollback",
+		credentials.Wrap(factory, helmRollbackHandler(registry, auditEmitter)))
 	// --- EKS Upgrade Insights (read-only) ---
 	//
 	// EKS scans every cluster's audit log daily and produces a list

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -96,6 +96,15 @@ const (
 	// 8 revisions of release X" vs "release was already at 1 revision".
 	VerbHelmUninstallIntent Verb = "helm_uninstall_intent"
 	VerbHelmUninstall       Verb = "helm_uninstall"
+	// VerbHelmRollbackIntent / VerbHelmRollback — pre/post pair for
+	// the helm rollback action (issue #77). Pre-flight SAR (verb=patch)
+	// runs against each kind in the TARGET revision's manifest list;
+	// denial blocks before the SDK call. Intent fires before the
+	// helm SDK call captures revision target + current revision so a
+	// hung or partitioned rollback still leaves a forensic trail.
+	// Outcome carries the new revision number on success in Extra.
+	VerbHelmRollbackIntent Verb = "helm_rollback_intent"
+	VerbHelmRollback       Verb = "helm_rollback"
 	// VerbRollbackIntent is emitted before the apiserver patch fires —
 	// captures the operator's intent (target revision, reason) even
 	// when the patch later fails or the request hangs. Pair with

--- a/internal/k8s/helm_rollback.go
+++ b/internal/k8s/helm_rollback.go
@@ -1,0 +1,200 @@
+// helm_rollback.go — Helm release rollback action (issue #77).
+//
+// Wraps action.NewRollback(...).Run(name) with Wait, CleanupOnFail,
+// and DisableHooks operator-controllable. Pre-flight SAR with
+// verb=patch runs against each kind in the TARGET revision's manifest
+// list before the SDK call fires. If any kind is denied, we never
+// trigger the rollback — same fail-fast discipline as the rest of
+// the helm write surface.
+//
+// Why patch (not delete + create)? helm internally compares the
+// target revision's manifests against the current cluster state and
+// issues 3-way patches; "patch" is the apiserver verb the rollback
+// will exercise. This also matches what helm upgrade asks for, so
+// an operator who can upgrade can rollback.
+//
+// Sync; rollbacks usually finish in 5-30s but a hook-rich chart
+// can run longer. Handler caps at the same 10min ceiling as install
+// / upgrade / uninstall.
+//
+// Audit: pre/post pair. Intent fires BEFORE the SDK call so a
+// partition or hung rollback still leaves a forensic trail.
+//
+// Type names (HelmRollbackArgs / HelmRollbackResult) are prefixed
+// to disambiguate from the workload rollback (#71) which owns the
+// unprefixed RollbackArgs / RollbackResult symbols in this package.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"helm.sh/helm/v3/pkg/action"
+
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+)
+
+// HelmRollbackArgs is the input to RollbackHelmRelease. Namespace +
+// ReleaseName identify the existing release; Revision is the target
+// revision to roll back to (must be > 0 and != current).
+//
+// Wait blocks until the rolled-back manifests reach Ready. Defaults
+// to true at the handler — operators clicking Rollback expect "rolled
+// back" to mean "the cluster is at that revision now," not "we asked
+// helm to start rolling back."
+//
+// CleanupOnFail removes any partially-applied resources if the
+// rollback errors mid-flight; defaults to false matching helm's
+// default. Operators with hook-heavy charts may want to flip it.
+//
+// DisableHooks skips pre-/post-rollback hooks; useful when a hook
+// is the thing that's stuck and the operator wants to force-roll.
+type HelmRollbackArgs struct {
+	Namespace     string
+	ReleaseName   string
+	Revision      int
+	Wait          bool
+	CleanupOnFail bool
+	DisableHooks  bool
+	Timeout       time.Duration
+}
+
+// HelmRollbackResult is the response shape. The release block is the
+// post-rollback state; FromRevision and ToRevision capture the audit-
+// relevant transition; NewRevision is helm's freshly-assigned
+// revision number (helm rollback always creates a new revision
+// rather than mutating the target — handy for the SPA toast and the
+// audit row).
+type HelmRollbackResult struct {
+	Release      ActionReleaseInfo `json:"release"`
+	NewRevision  int               `json:"newRevision"`
+	FromRevision int               `json:"fromRevision"`
+	ToRevision   int               `json:"toRevision"`
+}
+
+// rollbackRunFn is the test seam for the actual helm SDK call.
+var rollbackRunFn = defaultRollbackRun
+
+// defaultRollbackRun runs the actual helm SDK rollback. action.Rollback
+// returns no useful payload of its own; callers re-read storage to
+// pick up the new revision.
+func defaultRollbackRun(ctx context.Context, cfg *action.Configuration, args HelmRollbackArgs) error {
+	rb := action.NewRollback(cfg)
+	rb.Version = args.Revision
+	rb.Wait = args.Wait
+	rb.CleanupOnFail = args.CleanupOnFail
+	rb.DisableHooks = args.DisableHooks
+	if args.Timeout > 0 {
+		rb.Timeout = args.Timeout
+	}
+	return rb.Run(args.ReleaseName)
+}
+
+// RollbackHelmRelease runs the rollback action against an existing
+// release. Pre-flight SAR (verb=patch) runs first against the TARGET
+// revision's manifest list; denial blocks the action.
+//
+// Returns:
+//   - (*HelmRollbackResult, nil) on success.
+//   - (nil, *DeniedError) on pre-flight RBAC denial.
+//   - (nil, err) on any other failure (release / target revision not
+//     found, no-op rollback to current, helm SDK error, etc.).
+//     Handler classifies via helmErrorToStatus.
+func RollbackHelmRelease(ctx context.Context, p credentials.Provider, c clusters.Cluster, args HelmRollbackArgs) (*HelmRollbackResult, error) {
+	if args.Namespace == "" || args.ReleaseName == "" {
+		return nil, fmt.Errorf("rollback: namespace and releaseName are required")
+	}
+	if args.Revision <= 0 {
+		return nil, fmt.Errorf("rollback: revision must be > 0")
+	}
+
+	// Read the current release first so we can (1) reject no-op
+	// rollback-to-self and (2) capture the pre-rollback revision
+	// for the response and audit row.
+	current, err := GetHelmRelease(ctx, p, c, args.Namespace, args.ReleaseName, 0, defaultDetailMaxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("rollback pre-flight: read current release: %w", err)
+	}
+	if current == nil {
+		return nil, fmt.Errorf("rollback: release %q not found in namespace %q", args.ReleaseName, args.Namespace)
+	}
+	if args.Revision == current.Revision {
+		return nil, fmt.Errorf("rollback: target revision %d is already current", args.Revision)
+	}
+
+	// Read the target revision's manifests for the SAR pre-flight.
+	// helm rollback patches the cluster from current → target and
+	// the apiserver enforces RBAC per resource — checking the
+	// target manifests gives the operator the fail-fast view of
+	// "your role doesn't allow this rollback" before any state
+	// mutation.
+	target, err := GetHelmRelease(ctx, p, c, args.Namespace, args.ReleaseName, args.Revision, defaultDetailMaxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("rollback pre-flight: read target revision %d: %w", args.Revision, err)
+	}
+	if target == nil {
+		return nil, fmt.Errorf("rollback: target revision %d of release %q not found", args.Revision, args.ReleaseName)
+	}
+	denied, err := preflightSARs(ctx, p, c, target.Resources, "patch")
+	if err != nil {
+		return nil, fmt.Errorf("rollback pre-flight: %w", err)
+	}
+	if len(denied) > 0 {
+		return nil, &DeniedError{Denials: denied}
+	}
+
+	// Pre-flight passed. Build action config + run the rollback.
+	cfg, err := buildHelmActionConfigFn(ctx, p, c, args.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if err := rollbackRunFn(ctx, cfg, args); err != nil {
+		return nil, err
+	}
+
+	// helm rollback creates a new revision rather than mutating the
+	// target — re-read storage so the response reflects post-rollback
+	// state (rev=0 returns latest deployed). If the post-read fails
+	// (transient apiserver error after a successful rollback), fall
+	// back to a synthesized result so the SPA can still show a toast
+	// rather than misleading the operator into thinking the rollback
+	// itself failed.
+	post, err := GetHelmRelease(ctx, p, c, args.Namespace, args.ReleaseName, 0, defaultDetailMaxBytes)
+	if err != nil || post == nil {
+		return &HelmRollbackResult{
+			Release:      releaseDetailToActionInfo(current),
+			NewRevision:  current.Revision + 1,
+			FromRevision: current.Revision,
+			ToRevision:   args.Revision,
+		}, nil
+	}
+	return &HelmRollbackResult{
+		Release:      releaseDetailToActionInfo(post),
+		NewRevision:  post.Revision,
+		FromRevision: current.Revision,
+		ToRevision:   args.Revision,
+	}, nil
+}
+
+// releaseDetailToActionInfo lifts a HelmReleaseDetail (read-path
+// shape) into the ActionReleaseInfo used by the write-path response
+// types. Avoids exposing the read-path struct on the write API.
+func releaseDetailToActionInfo(d *HelmReleaseDetail) ActionReleaseInfo {
+	if d == nil {
+		return ActionReleaseInfo{}
+	}
+	return ActionReleaseInfo{
+		Name:      d.Name,
+		Namespace: d.Namespace,
+		Revision:  d.Revision,
+		Status:    d.Status,
+		Chart: ActionChartRef{
+			Name:    d.ChartName,
+			Version: d.ChartVersion,
+		},
+		DeployedAt: d.Updated.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+}

--- a/internal/k8s/helm_rollback_test.go
+++ b/internal/k8s/helm_rollback_test.go
@@ -1,0 +1,94 @@
+// helm_rollback_test.go — function-level checks for the helm
+// rollback path (issue #77). End-to-end coverage (older revision →
+// success, current revision → no-op, denied → DeniedError) lives at
+// the handler-test layer where rollbackHelmReleaseFn is a fn-var that
+// can be stubbed without touching the apiserver.
+
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
+
+	"github.com/gnana997/periscope/internal/clusters"
+)
+
+func withRollbackRun(t *testing.T, fn func(context.Context, *action.Configuration, HelmRollbackArgs) error) {
+	t.Helper()
+	prev := rollbackRunFn
+	rollbackRunFn = fn
+	t.Cleanup(func() { rollbackRunFn = prev })
+}
+
+// TestRollbackHelmRelease_ValidationMissingFields covers the
+// function-level validation. The handler validates first, but the
+// function double-checks for direct callers.
+func TestRollbackHelmRelease_ValidationMissingFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args HelmRollbackArgs
+	}{
+		{"empty namespace", HelmRollbackArgs{ReleaseName: "r", Revision: 1}},
+		{"empty releaseName", HelmRollbackArgs{Namespace: "n", Revision: 1}},
+		{"zero revision", HelmRollbackArgs{Namespace: "n", ReleaseName: "r", Revision: 0}},
+		{"negative revision", HelmRollbackArgs{Namespace: "n", ReleaseName: "r", Revision: -1}},
+		{"all empty", HelmRollbackArgs{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := RollbackHelmRelease(context.Background(), nil, clusters.Cluster{Name: "k"}, tc.args)
+			if err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+// TestDefaultRollbackRun_StructFieldsPresent is a compile-time check
+// that the helm SDK Rollback action struct still has the fields we
+// reference. If helm renames Wait, CleanupOnFail, DisableHooks, or
+// Version, this fails to build — early warning ahead of any silent
+// behavior change.
+func TestDefaultRollbackRun_StructFieldsPresent(t *testing.T) {
+	rb := action.NewRollback(nil)
+	rb.Version = 1
+	rb.Wait = true
+	rb.CleanupOnFail = true
+	rb.DisableHooks = true
+	_ = rb
+}
+
+// TestDefaultRollbackRun_ErrorTypePropagation guards against a helm
+// SDK change that wraps driver sentinels in a way that breaks
+// errors.Is — the handler classifier (helmErrorToStatus) depends on
+// that match for the 404/422 branches.
+func TestDefaultRollbackRun_ErrorTypePropagation(t *testing.T) {
+	wrapped := errors.Join(driver.ErrReleaseNotFound, errors.New("rollback context"))
+	if !errors.Is(wrapped, driver.ErrReleaseNotFound) {
+		t.Error("errors.Join + ErrReleaseNotFound should match via errors.Is")
+	}
+	wrapped = errors.Join(driver.ErrNoDeployedReleases, errors.New("rollback context"))
+	if !errors.Is(wrapped, driver.ErrNoDeployedReleases) {
+		t.Error("errors.Join + ErrNoDeployedReleases should match via errors.Is")
+	}
+}
+
+// TestReleaseDetailToActionInfo_NilSafe verifies the converter
+// handles a nil HelmReleaseDetail without panicking — the recovery
+// path in RollbackHelmRelease uses this when the post-rollback
+// re-read fails, and a nil detail must produce a zero-value
+// ActionReleaseInfo rather than NPE.
+func TestReleaseDetailToActionInfo_NilSafe(t *testing.T) {
+	got := releaseDetailToActionInfo(nil)
+	if got != (ActionReleaseInfo{}) {
+		t.Errorf("nil detail should map to zero ActionReleaseInfo, got %+v", got)
+	}
+}
+
+// silence unused-import on withRollbackRun in this file. Real
+// invocations live in the handler test layer.
+var _ = withRollbackRun

--- a/web/src/components/helm/RollbackModal.tsx
+++ b/web/src/components/helm/RollbackModal.tsx
@@ -1,0 +1,252 @@
+// RollbackModal — confirmation dialog for helm release rollback
+// (#77). Mirrors UninstallReleaseModal's pattern for spinner +
+// error + denial surfacing rather than the lighter
+// ConfirmActionModal — rollback is destructive enough (manifest
+// patch across the namespace, can't be undone except by a forward
+// rollback) to warrant the same friction.
+//
+// Layout:
+//   - Header: from rev → to rev transition
+//   - Body: rendered diff (current vs target manifests) so the
+//     operator can see what's about to change
+//   - Advanced: wait / cleanupOnFail / disableHooks toggles
+//   - Pre-flight denials surface inline when the backend returns
+//     E_HELM_PREFLIGHT_DENIED — listed by GVR + verb so the operator
+//     can take it to their cluster admin without re-trying
+//
+// The modal stays open while the mutation is pending and only
+// dismisses on success (caller closes it). Cancel + ESC + backdrop
+// are disabled while pending so the operator can't navigate away
+// mid-rollback and lose the response.
+
+import { useState } from "react";
+import { useHelmDiff } from "../../hooks/useHelm";
+import { InlineDiff } from "../detail/yaml/InlineDiff";
+import { ErrorState, LoadingState } from "../table/states";
+import { Modal } from "../ui/Modal";
+
+export interface RollbackModalDenial {
+  group: string;
+  resource: string;
+  verb: string;
+  reason?: string;
+}
+
+export interface RollbackModalError {
+  status?: number;
+  message: string;
+  denied?: RollbackModalDenial[];
+}
+
+interface RollbackModalProps {
+  open: boolean;
+  cluster: string;
+  namespace: string;
+  releaseName: string;
+  currentRevision: number;
+  targetRevision: number;
+  pending: boolean;
+  error?: RollbackModalError | null;
+  onClose: () => void;
+  onConfirm: (opts: {
+    wait: boolean;
+    cleanupOnFail: boolean;
+    disableHooks: boolean;
+  }) => void;
+}
+
+export function RollbackModal({
+  open,
+  cluster,
+  namespace,
+  releaseName,
+  currentRevision,
+  targetRevision,
+  pending,
+  error,
+  onClose,
+  onConfirm,
+}: RollbackModalProps) {
+  const diffQuery = useHelmDiff(
+    cluster,
+    namespace,
+    releaseName,
+    currentRevision,
+    targetRevision,
+  );
+
+  const [wait, setWait] = useState(true);
+  const [cleanupOnFail, setCleanupOnFail] = useState(false);
+  const [disableHooks, setDisableHooks] = useState(false);
+
+  // The submit button is disabled when:
+  //  - the mutation is in flight
+  //  - the diff hasn't loaded yet (we want the operator to SEE the
+  //    diff before approving — denying the click protects them
+  //    from a "what did I just rollback?" moment)
+  //  - the backend has rejected with a denial; the operator must
+  //    close + fix RBAC + re-open
+  const blockedByDenial = (error?.denied?.length ?? 0) > 0;
+  const canSubmit = !pending && !!diffQuery.data && !blockedByDenial;
+
+  let diffBody: React.ReactNode;
+  if (diffQuery.isLoading) {
+    diffBody = <LoadingState resource="diff" />;
+  } else if (diffQuery.isError) {
+    diffBody = (
+      <ErrorState
+        title="couldn't compute diff"
+        message={(diffQuery.error as Error)?.message ?? "unknown"}
+      />
+    );
+  } else if (diffQuery.data) {
+    diffBody = (
+      <InlineDiff
+        original={diffQuery.data.from.yaml}
+        proposed={diffQuery.data.to.yaml}
+      />
+    );
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={pending ? () => {} : onClose}
+      labelledBy="rollback-release-title"
+      size="lg"
+      dismissOnEsc={!pending}
+      dismissOnBackdrop={!pending}
+    >
+      <div className="border-b border-border px-5 py-3 font-mono text-sm">
+        <span className="text-accent">rollback</span>{" "}
+        <span id="rollback-release-title" className="text-ink">
+          {releaseName}
+        </span>
+        <span className="ml-2 text-ink-faint">
+          revision {currentRevision} → {targetRevision}
+        </span>
+      </div>
+
+      <div className="space-y-4 px-5 py-4">
+        <p className="text-sm text-ink-muted">
+          helm will compute the patch from revision{" "}
+          <span className="font-mono text-ink">{currentRevision}</span> to{" "}
+          <span className="font-mono text-ink">{targetRevision}</span> and
+          apply it across namespace{" "}
+          <span className="font-mono text-ink">{namespace}</span>. helm
+          assigns a new revision; the rollback is itself reversible by
+          another rollback.
+        </p>
+
+        <div className="h-64 overflow-y-auto rounded-sm border border-border">
+          {diffBody}
+        </div>
+
+        <div className="space-y-2 border-t border-border pt-3 font-mono text-[11.5px]">
+          <p className="text-ink-faint uppercase tracking-[0.16em]">
+            advanced
+          </p>
+          <label className="flex items-start gap-2 text-ink-muted">
+            <input
+              type="checkbox"
+              checked={wait}
+              onChange={(e) => setWait(e.target.checked)}
+              disabled={pending}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-ink">wait</span> — block until rolled-back
+              resources are ready (recommended)
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-ink-muted">
+            <input
+              type="checkbox"
+              checked={cleanupOnFail}
+              onChange={(e) => setCleanupOnFail(e.target.checked)}
+              disabled={pending}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-ink">cleanup on fail</span> — remove
+              partially-applied resources if the rollback errors mid-flight
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-ink-muted">
+            <input
+              type="checkbox"
+              checked={disableHooks}
+              onChange={(e) => setDisableHooks(e.target.checked)}
+              disabled={pending}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-ink">disable hooks</span> — skip pre-/
+              post-rollback hooks (only when a hook is the thing that's
+              stuck)
+            </span>
+          </label>
+        </div>
+
+        {/* Pre-flight denial — explicit list of (verb, GVR) tuples
+            so the operator can take it to their cluster admin. */}
+        {blockedByDenial && (
+          <div className="rounded-sm border border-yellow/40 bg-yellow/5 px-3 py-2 font-mono text-xs">
+            <div className="mb-1 font-semibold uppercase tracking-[0.14em] text-yellow">
+              rbac pre-flight denied
+            </div>
+            <p className="mb-2 text-ink-muted">
+              your role can't apply one or more resources this rollback would
+              touch. ask your cluster admin for the verbs below before
+              retrying.
+            </p>
+            <ul className="space-y-0.5 text-ink-muted">
+              {error?.denied?.map((d, i) => (
+                <li key={i} className="text-[11px]">
+                  <span className="text-red">×</span>{" "}
+                  <span className="text-ink">{d.verb}</span>{" "}
+                  {d.group ? `${d.group}/` : ""}
+                  {d.resource}
+                  {d.reason ? (
+                    <span className="text-ink-faint"> — {d.reason}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Non-denial errors (release not found, helm SDK failure,
+            timeout, etc.). Denials get the dedicated treatment above
+            so the operator sees the verb list, not just a string. */}
+        {error && !blockedByDenial && (
+          <div className="rounded-sm border border-red bg-red-soft px-3 py-2 font-mono text-xs text-red">
+            <div className="mb-1 font-semibold">
+              {error.status ? `error ${error.status}` : "error"}
+            </div>
+            <pre className="whitespace-pre-wrap">{error.message}</pre>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={pending}
+          className="rounded-sm border border-border-strong px-3 py-1.5 font-mono text-sm text-ink-muted transition-colors hover:border-ink-muted hover:text-ink disabled:opacity-50"
+        >
+          cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => onConfirm({ wait, cleanupOnFail, disableHooks })}
+          disabled={!canSubmit}
+          className="rounded-sm bg-accent px-3 py-1.5 font-mono text-sm text-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {pending ? "rolling back…" : "rollback"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/hooks/useHelm.ts
+++ b/web/src/hooks/useHelm.ts
@@ -189,3 +189,45 @@ export function useUninstallHelmRelease(
     },
   });
 }
+
+// useRollbackHelmRelease (#77). Mutation wrapper around POST
+// /helm/releases/{ns}/{name}/rollback. Caller passes { revision }
+// (and optional knobs) to the .mutate() call. Cluster + namespace
+// + release name are bound at hook-construction time since they're
+// stable in the URL the hook is used from.
+//
+// Invalidates list (status badge), history (revision row state),
+// and the detail tab on success. Errors bubble through useMutation's
+// `error` so the caller can surface them — the modal in #77 keeps
+// itself open until the mutation settles and shows the error inline.
+export function useRollbackHelmRelease(
+  cluster: string,
+  namespace: string,
+  name: string,
+) {
+  const qc = useQueryClient();
+  return useMutation<
+    import("../lib/types").HelmRollbackResult,
+    Error,
+    {
+      revision: number;
+      wait?: boolean;
+      cleanupOnFail?: boolean;
+      disableHooks?: boolean;
+      timeoutSeconds?: number;
+    }
+  >({
+    mutationFn: (body) => api.helmRollback(cluster, namespace, name, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.cluster(cluster).helm.list() });
+      qc.invalidateQueries({
+        queryKey: queryKeys.cluster(cluster).helm.history(namespace, name),
+      });
+      // The detail key includes a revision, so invalidate the entire
+      // helm subtree for this release rather than enumerating revs.
+      qc.invalidateQueries({
+        queryKey: ["cluster", cluster, "helm", "detail", namespace, name],
+      });
+    },
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -88,6 +88,7 @@ import type {
   HelmUpgradeRequest,
   HelmActionResult,
   HelmUninstallResult,
+  HelmRollbackResult,
   RevisionHistory,
   RollbackRequest,
   RollbackResponse,
@@ -1015,6 +1016,24 @@ export const api = {
       signal,
     );
   },
+
+  /**
+   * Helm release rollback (#77). POST /helm/releases/{ns}/{name}/rollback.
+   * Sync — blocks until helm SDK returns. Pre-flight SAR (verb=patch)
+   * denials return 403 with E_HELM_PREFLIGHT_DENIED.
+   */
+  helmRollback: (
+    cluster: string,
+    namespace: string,
+    name: string,
+    body: { revision: number; wait?: boolean; cleanupOnFail?: boolean; disableHooks?: boolean; timeoutSeconds?: number },
+    signal?: AbortSignal,
+  ) =>
+    postJSON<HelmRollbackResult>(
+      `/api/clusters/${enc(cluster)}/helm/releases/${enc(namespace)}/${enc(name)}/rollback`,
+      body,
+      signal,
+    ),
 
   /**
    * Workload rollback (#71). Two endpoints, called from the

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1641,6 +1641,17 @@ export interface HelmUninstallResult {
   revisionsRemoved: number;
 }
 
+// HelmRollbackResult mirrors the backend (#77) HelmRollbackResult.
+// helm always assigns a NEW revision on rollback rather than mutating
+// the target — newRevision is what the SPA shows in the success toast,
+// fromRevision/toRevision capture the audit-relevant transition.
+export interface HelmRollbackResult {
+  release: HelmActionResult["release"];
+  newRevision: number;
+  fromRevision: number;
+  toRevision: number;
+}
+
 export interface HelmActionResult {
   release: {
     name: string;

--- a/web/src/pages/HelmReleasePage.tsx
+++ b/web/src/pages/HelmReleasePage.tsx
@@ -7,8 +7,17 @@
 
 import { useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { useHelmHistory, useHelmRelease, useUninstallHelmRelease } from "../hooks/useHelm";
+import {
+  useHelmHistory,
+  useHelmRelease,
+  useRollbackHelmRelease,
+  useUninstallHelmRelease,
+} from "../hooks/useHelm";
 import { UninstallReleaseModal } from "../components/helm/UninstallReleaseModal";
+import {
+  RollbackModal,
+  type RollbackModalError,
+} from "../components/helm/RollbackModal";
 import { showToast } from "../lib/toastBus";
 import { ApiError } from "../lib/api";
 import type { HelmHistoryEntry, HelmManifestObject } from "../lib/types";
@@ -273,6 +282,9 @@ function ResourceSummary({ resources }: { resources: HelmManifestObject[] }) {
 // row → "compare" button enables → diff route. Single-click on a row
 // navigates the page to that revision.
 function HistoryTab({
+  cluster,
+  namespace,
+  name,
   entries,
   currentRevision,
   isLoading,
@@ -293,6 +305,16 @@ function HistoryTab({
   onCompare: (from: number, to: number) => void;
 }) {
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [rollbackTarget, setRollbackTarget] = useState<number | undefined>(undefined);
+  const rollbackMutation = useRollbackHelmRelease(cluster, namespace, name);
+
+  // ApiError carries the JSON error body as bodyText. For 403 the
+  // backend returns { code, message, denied: [...] }; parse it once
+  // here so the modal renders denials specifically rather than dumping
+  // the raw body.
+  const rollbackError: RollbackModalError | null = rollbackMutation.error
+    ? toRollbackModalError(rollbackMutation.error)
+    : null;
 
   if (isLoading) return <LoadingState resource="history" />;
   if (isError) {
@@ -330,6 +352,7 @@ function HistoryTab({
   const sortedSel = Array.from(selected).sort((a, b) => a - b);
 
   return (
+    <>
     <div className="flex h-full min-h-0 w-full flex-col">
       <div className="flex items-center justify-between border-b border-border px-6 py-2">
         <span className="font-mono text-[11px] text-ink-muted">
@@ -395,10 +418,87 @@ function HistoryTab({
                   {e.updated ? ageFrom(e.updated) : "—"}
                 </span>
               </button>
+              {/* Rollback button per row — disabled on the current
+                  revision since rolling back to self is a no-op the
+                  backend rejects with a 422. */}
+              <button
+                type="button"
+                disabled={isCurrent}
+                onClick={() => setRollbackTarget(e.revision)}
+                aria-label={`rollback to revision ${e.revision}`}
+                className={cn(
+                  "rounded-sm border border-border-strong px-2.5 py-1 font-mono text-[11.5px] transition-colors",
+                  "hover:border-ink-muted hover:text-ink",
+                  "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-border-strong",
+                )}
+              >
+                rollback
+              </button>
             </div>
           );
         })}
       </div>
     </div>
+      <RollbackModal
+        open={rollbackTarget !== undefined}
+        cluster={cluster}
+        namespace={namespace}
+        releaseName={name}
+        currentRevision={currentRevision}
+        targetRevision={rollbackTarget ?? 0}
+        pending={rollbackMutation.isPending}
+        error={rollbackError}
+        onClose={() => {
+          setRollbackTarget(undefined);
+          rollbackMutation.reset();
+        }}
+        onConfirm={(opts) => {
+          if (rollbackTarget === undefined) return;
+          rollbackMutation.mutate(
+            { revision: rollbackTarget, ...opts },
+            {
+              onSuccess: (result) => {
+                showToast(
+                  `rolled back ${name} to revision ${result.toRevision} (now r${result.newRevision})`,
+                  "success",
+                );
+                setRollbackTarget(undefined);
+                rollbackMutation.reset();
+              },
+            },
+          );
+        }}
+      />
+    </>
   );
+}
+
+// toRollbackModalError extracts a structured error shape from the
+// thrown ApiError so the modal can render denials specifically. The
+// backend returns:
+//   200    → not an error
+//   403    → { code: "E_HELM_PREFLIGHT_DENIED", message, denied: [...] }
+//   422    → { code: "E_HELM_NO_DEPLOYED_RELEASES", message }
+//   404    → { code: "E_HELM_RELEASE_NOT_FOUND", message }
+//   500    → { code: "E_INTERNAL", message } or plain text
+function toRollbackModalError(err: unknown): RollbackModalError {
+  if (err instanceof ApiError) {
+    if (err.bodyText) {
+      try {
+        const parsed = JSON.parse(err.bodyText) as {
+          message?: string;
+          denied?: RollbackModalError["denied"];
+        };
+        return {
+          status: err.status,
+          message: parsed.message ?? err.message,
+          denied: parsed.denied,
+        };
+      } catch {
+        return { status: err.status, message: err.bodyText || err.message };
+      }
+    }
+    return { status: err.status, message: err.message };
+  }
+  return { message: (err as Error)?.message ?? "unknown error" };
 }


### PR DESCRIPTION
## Summary

Adds the helm release rollback action — the last missing piece of the helm write surface (after install #107, uninstall #123, upgrade #75).

**Backend**
- `POST /api/clusters/{c}/helm/releases/{ns}/{name}/rollback` — sync, audit-paired (`helm_rollback_intent` + `helm_rollback`), pre-flight SAR with `verb=patch` against the **target** revision's manifests. Denial → 403 with `E_HELM_PREFLIGHT_DENIED` and the `(verb, GVR)` tuples. Helm SDK errors classified via the existing `helmErrorToStatus` (404 for `ErrReleaseNotFound`, 422 for `ErrNoDeployedReleases`).
- `internal/k8s/helm_rollback.go` — `RollbackHelmRelease` follows the per-action file pattern set by install/upgrade/uninstall. Type names prefixed (`HelmRollbackArgs` / `HelmRollbackResult`) to avoid collision with the workload-rollback symbols (#71) in the same package.
- Audit verbs: `VerbHelmRollbackIntent` + `VerbHelmRollback` — helm-scoped pair, distinct from the workload-scoped `VerbRollback`.

**Frontend**
- Per-row Rollback button on the release history tab, **disabled on the current revision** (the inverted-disabled bug from the #101 review).
- `RollbackModal` built on the lower-level `<Modal>` primitive (matching `UninstallReleaseModal`): renders the current↔target diff via `useHelmDiff`, three advanced toggles (`wait` / `cleanupOnFail` / `disableHooks`), spinner-while-pending, dedicated treatment of pre-flight denials (lists the verb + GVR tuples in their own block instead of dumping the raw error body), inline error block for non-denial failures.
- Success toast on commit; modal stays open with feedback until the mutation settles, so the operator can't navigate away mid-rollback.

**Supersedes #101** — design credit to @viveknimbolkar (per-row button, diff-in-modal pattern, hook + endpoint shape). The rewrite was necessary because the v1.1 helm scaffolding that landed after #101 was opened (`cmd/periscope/helm_action_handler.go` + per-action files in `internal/k8s/`) doesn't match the original PR's targets.

Co-authored-by: viveknimbolkar <viveknimbolkar50@gmail.com>

Closes #77.

## Test plan

- [x] `go test ./...` — all backend suites pass; new tests cover validation, knob propagation, RBAC denial → 403, no-op rollback rejection, release-not-found → 404, missing path params
- [x] `pnpm lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test -- --run` — 279 / 279 frontend tests pass
- [ ] Manual smoke on demo cluster: rollback to previous rev (success path), rollback to current (rejected with explanatory error in modal), rollback when impersonated user has read-only RBAC (denial list rendered in modal)
- [ ] Confirm audit log emits the intent/outcome pair with correct `fromRevision` / `toRevision` / `newRevision` in `Extra`
- [ ] Impersonation validation per #101 review item 2: SA cluster-admin + impersonated user `view`-only → rollback should be denied at pre-flight, never reach the helm SDK