### PR TITLE
feat(schema): Deployment + StatefulSet form layout (#136, supersedes #135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,25 @@ tag.
   
 ### Added
 
+- Schema-aware form editor: Deployment + StatefulSet support, with
+  per-kind L1 sectioning (#136, builds on #144). Each workload kind
+  now opens with the most-edited fields up top — Containers
+  (replicas + containers[] + initContainers[]) is always open;
+  Volumes auto-expands when populated; Strategy & lifecycle, Pod
+  metadata, the Deployment's own Metadata, the immutable Selector,
+  and Advanced (15-field count) live in collapsed `<details>`
+  sections. StatefulSet adds a Persistent storage section for
+  `volumeClaimTemplates` + retention policy. Container array rows
+  themselves get an L2 sub-section split inside the row — Primary
+  (image / env / resources), Probes & lifecycle, Volume mounts
+  (auto-expanding when populated), and Container advanced (count).
+  Walker stamps both L1 and L2 section ids via a single resolver
+  using `*` as the array-element boundary in synthetic absolute
+  paths. Brings in K8s-style polymorphism support too: Probe /
+  LifecycleHandler / Volume / EnvVarSource render as proper
+  discriminator pickers via a hint table, instead of surfacing all
+  ~30 sibling Volume types as simultaneously editable.
+
 - Helm release rollback (#77). New `POST /api/clusters/{c}/helm/
   releases/{ns}/{name}/rollback` endpoint patches the cluster from
   the current revision to the operator-selected target revision via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ tag.
   
 ### Added
 
+- Schema form: form sections start collapsed; users open what they
+  need to edit. Replaces the prior "primary section open by default"
+  layout — for Deployment / StatefulSet (7+ sections) the always-
+  open header was overwhelming, so all sections at every depth
+  (top-level, container row, container row sub-section) start
+  closed. New `+ expand all` / `− collapse all` buttons in the
+  form header sweep every accordion in one click (VSCode-style).
+  Last-opened L1 section per kind is remembered in localStorage so
+  the next visit restores your preferred entry point.
+
 - Schema-aware form editor: Deployment + StatefulSet support, with
   per-kind L1 sectioning (#136, builds on #144). Each workload kind
   now opens with the most-edited fields up top — Containers

--- a/web/src/components/edit/DeploymentForm.tsx
+++ b/web/src/components/edit/DeploymentForm.tsx
@@ -1,0 +1,32 @@
+// DeploymentForm — schema-aware form view for editing Deployments.
+//
+// POC status: this wrapper is a thin passthrough on K8sSchemaForm,
+// the same shape as ServiceForm/IngressForm. The allowlist in
+// k8sAllowlist.ts surfaces metadata + spec.{replicas, selector,
+// strategy, template, minReadySeconds, revisionHistoryLimit,
+// progressDeadlineSeconds, paused}.
+//
+// Because `filterSchemaForKind` narrows only one level deep,
+// allowlisting `spec.template` exposes the full PodTemplateSpec
+// transitively. This is intentional for the POC — the goal of
+// this iteration is to catalogue what the existing walker /
+// renderer handles cleanly versus what it stumbles on (Quantity,
+// IntOrString, env[*].valueFrom oneOf, ports[*].containerPort,
+// volume oneOf with ~30 branches, probe handler oneOf, etc.).
+// The gap report drives the follow-up scoping.
+
+import { K8sSchemaForm } from "./K8sSchemaForm";
+import type { SchemaFormMode } from "../../lib/schemaForm/SchemaForm";
+import type { ReactNode } from "react";
+
+interface DeploymentFormProps {
+  cluster: string;
+  valuesYaml: string;
+  onValuesYamlChange: (next: string) => void;
+  mode: SchemaFormMode;
+  banner?: ReactNode;
+}
+
+export function DeploymentForm(props: DeploymentFormProps) {
+  return <K8sSchemaForm {...props} kind="Deployment" />;
+}

--- a/web/src/components/edit/K8sSchemaForm.tsx
+++ b/web/src/components/edit/K8sSchemaForm.tsx
@@ -103,6 +103,7 @@ export function K8sSchemaForm({
       schema={rootSchema}
       walkOptions={walkOptions}
       sections={getSections(kind)}
+      formKey={kind}
       mode={mode}
       onValuesYamlChange={onValuesYamlChange}
       banner={banner}

--- a/web/src/components/edit/K8sSchemaForm.tsx
+++ b/web/src/components/edit/K8sSchemaForm.tsx
@@ -14,9 +14,11 @@ import type { ReactNode } from "react";
 import { useOpenAPISchema } from "../../hooks/useResource";
 import { SchemaFormBridge } from "../../lib/schemaForm/SchemaFormBridge";
 import { buildRefResolver, findSchemaByGVK } from "../../lib/schemaForm/refResolver";
+import { buildK8sDiscriminatorHints } from "../../lib/schemaForm/k8sDiscriminatorHints";
 import {
   filterSchemaForKind,
-  getSectionLabels,
+  getSections,
+  getRowSubSections,
   getSectionResolver,
   getCreateOnlyPaths,
   getKindGVK,
@@ -69,6 +71,8 @@ export function K8sSchemaForm({
       allowOneOfDiscriminator: true,
       createOnlyPaths: getCreateOnlyPaths(kind),
       sectionResolver: getSectionResolver(kind),
+      subSectionResolver: (parentPath) => getRowSubSections(kind, parentPath.join(".")),
+      discriminatorHints: buildK8sDiscriminatorHints(),
     };
     return { rootSchema: filtered, walkOptions: opts };
   }, [schemaQuery.data, gvk.group, gvk.version, gvk.kind, kind]);
@@ -98,7 +102,7 @@ export function K8sSchemaForm({
       valuesYaml={valuesYaml}
       schema={rootSchema}
       walkOptions={walkOptions}
-      sectionLabels={getSectionLabels(kind)}
+      sections={getSections(kind)}
       mode={mode}
       onValuesYamlChange={onValuesYamlChange}
       banner={banner}

--- a/web/src/components/edit/KindEditRouter.tsx
+++ b/web/src/components/edit/KindEditRouter.tsx
@@ -33,6 +33,8 @@ import { ConfigMapForm } from "./ConfigMapForm";
 import { SecretForm } from "./SecretForm";
 import { ServiceForm } from "./ServiceForm";
 import { IngressForm } from "./IngressForm";
+import { DeploymentForm } from "./DeploymentForm";
+import { StatefulSetForm } from "./StatefulSetForm";
 import { useApplySubmit } from "./useApplySubmit";
 
 const YamlEditor = lazy(() =>
@@ -240,6 +242,22 @@ function BufferedEditor({
             )}
             {kind === "Ingress" && (
               <IngressForm
+                cluster={cluster}
+                valuesYaml={draftYaml}
+                onValuesYamlChange={onValuesYamlChange}
+                mode="edit"
+              />
+            )}
+            {kind === "Deployment" && (
+              <DeploymentForm
+                cluster={cluster}
+                valuesYaml={draftYaml}
+                onValuesYamlChange={onValuesYamlChange}
+                mode="edit"
+              />
+            )}
+            {kind === "StatefulSet" && (
+              <StatefulSetForm
                 cluster={cluster}
                 valuesYaml={draftYaml}
                 onValuesYamlChange={onValuesYamlChange}

--- a/web/src/components/edit/StatefulSetForm.tsx
+++ b/web/src/components/edit/StatefulSetForm.tsx
@@ -1,0 +1,28 @@
+// StatefulSetForm — schema-aware form view for editing StatefulSets.
+//
+// Thin passthrough on K8sSchemaForm. The allowlist in
+// k8sAllowlist.ts surfaces the StatefulSet-specific fields
+// (serviceName, podManagementPolicy, updateStrategy,
+// volumeClaimTemplates, persistentVolumeClaimRetentionPolicy,
+// ordinals) plus the same curated PodSpec subset Deployment uses
+// (containers, initContainers, volumes, probes, lifecycle,
+// pod-level admin surface flagged advanced).
+//
+// Selector / serviceName / podManagementPolicy / volumeClaimTemplates
+// are create-only — the apiserver rejects mutations after create.
+
+import { K8sSchemaForm } from "./K8sSchemaForm";
+import type { SchemaFormMode } from "../../lib/schemaForm/SchemaForm";
+import type { ReactNode } from "react";
+
+interface StatefulSetFormProps {
+  cluster: string;
+  valuesYaml: string;
+  onValuesYamlChange: (next: string) => void;
+  mode: SchemaFormMode;
+  banner?: ReactNode;
+}
+
+export function StatefulSetForm(props: StatefulSetFormProps) {
+  return <K8sSchemaForm {...props} kind="StatefulSet" />;
+}

--- a/web/src/components/edit/kindFromYamlKind.ts
+++ b/web/src/components/edit/kindFromYamlKind.ts
@@ -11,6 +11,8 @@ const PLURAL_TO_KIND: Record<string, SupportedKind> = {
   secrets: "Secret",
   services: "Service",
   ingresses: "Ingress",
+  deployments: "Deployment",
+  statefulsets: "StatefulSet",
 };
 
 export function kindFromYamlKind(yamlKind: string): SupportedKind | undefined {

--- a/web/src/lib/schemaForm/SchemaForm.test.ts
+++ b/web/src/lib/schemaForm/SchemaForm.test.ts
@@ -42,12 +42,12 @@ describe("collectSectioned", () => {
     ];
     const out = collectSectioned(ds);
     expect(out.total).toBe(3);
-    expect(out.primary.map((d) => d.path.join("."))).toEqual([
+    expect((out.byId.get("primary") ?? []).map((d) => d.path.join("."))).toEqual([
       "data",
       "binaryData",
     ]);
-    expect(out.advanced.map((d) => d.path.join("."))).toEqual(["immutable"]);
-    expect(out.metadata).toEqual([]);
+    expect((out.byId.get("advanced") ?? []).map((d) => d.path.join("."))).toEqual(["immutable"]);
+    expect((out.byId.get("metadata") ?? [])).toEqual([]);
   });
 
   it("promotes nested children of an unsectioned parent into their section bucket", () => {
@@ -64,7 +64,7 @@ describe("collectSectioned", () => {
     const out = collectSectioned(ds);
     expect(out.total).toBe(5);
     // Sorted by displayOrder regardless of the source-tree order.
-    expect(out.metadata.map((d) => d.path.join("."))).toEqual([
+    expect((out.byId.get("metadata") ?? []).map((d) => d.path.join("."))).toEqual([
       "metadata.name",
       "metadata.namespace",
       "metadata.labels",
@@ -79,9 +79,9 @@ describe("collectSectioned", () => {
     ];
     const out = collectSectioned(ds);
     expect(out.total).toBe(0);
-    expect(out.primary).toEqual([]);
-    expect(out.metadata).toEqual([]);
-    expect(out.advanced).toEqual([]);
+    expect((out.byId.get("primary") ?? [])).toEqual([]);
+    expect((out.byId.get("metadata") ?? [])).toEqual([]);
+    expect((out.byId.get("advanced") ?? [])).toEqual([]);
   });
 
   it("descriptors without displayOrder sort to the end of their bucket", () => {
@@ -91,7 +91,7 @@ describe("collectSectioned", () => {
       stringField(["c"], { section: "primary", displayOrder: 1 }),
     ];
     const out = collectSectioned(ds);
-    expect(out.primary.map((d) => d.path.join("."))).toEqual(["b", "c", "a"]);
+    expect((out.byId.get("primary") ?? []).map((d) => d.path.join("."))).toEqual(["b", "c", "a"]);
   });
 });
 

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -10,14 +10,22 @@
 //   - Validation runs on every change; issues are passed down by
 //     path so each field can render its inline error.
 
-import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { buildFieldDescriptors, type WalkOptions } from "./walker";
 import { validateValues } from "./validate";
+import { FormOpenContext, useFormOpen, useFormOpenContext, type FormOpenApi } from "./useFormOpen";
+import { rowSummary } from "./arrayRowSummary";
 import {
   collectRowSubSections,
   collectSectioned,
   descendantHasSection,
-  descriptorHasContent,
 } from "./sections";
 import { cn } from "../cn";
 import { getAtPath, setAtPath } from "./pathOps";
@@ -89,6 +97,10 @@ export interface SchemaFormProps {
    *  order. K8sSchemaForm passes `getSections(kind)`; Helm leaves it
    *  undefined to keep the legacy flat layout. */
   sections?: SchemaFormSectionConfig[];
+  /** Stable string identifier for localStorage-backed open-state
+   *  memory. K8sSchemaForm passes the kind name; Helm leaves it
+   *  undefined (no persistence). */
+  formKey?: string;
 }
 
 export function SchemaForm({
@@ -99,6 +111,7 @@ export function SchemaForm({
   mode = "edit",
   emptyMessage,
   sections,
+  formKey,
 }: SchemaFormProps) {
   const descriptors = useMemo(
     () => buildFieldDescriptors(schema, walkOptions),
@@ -106,6 +119,7 @@ export function SchemaForm({
   );
   const issues = useMemo(() => validateValues(schema, values), [schema, values]);
   const sectioned = useMemo(() => collectSectioned(descriptors), [descriptors]);
+  const openApi = useFormOpen(formKey);
 
   if (descriptors.length === 0) {
     return (
@@ -128,7 +142,9 @@ export function SchemaForm({
 
   // Back-compat fallback: when the caller hasn't asked for sections,
   // OR no descriptor has a section stamp (Helm path), render the flat
-  // ordered list exactly like the pre-#142 layout.
+  // ordered list exactly like the pre-#142 layout. No FormOpenContext
+  // provider — array-of-objects rows fall back to always-open
+  // fieldsets the way they always did for Helm.
   if (!sections || sections.length === 0 || sectioned.total === 0) {
     return (
       <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
@@ -147,50 +163,128 @@ export function SchemaForm({
   );
 
   return (
-    <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
-      {sections.map((section) => {
-        const bucket = sectioned.byId.get(section.id) ?? [];
-        if (bucket.length === 0) return null;
-        const populated = section.openWhenPopulated
-          ? bucket.some((d) => descriptorHasContent(d, values))
-          : false;
-        const isOpen = section.defaultOpen ?? populated;
-        const summaryText = section.showCount
-          ? `${section.label} (${bucket.length})`
-          : section.label;
-        if (section.defaultOpen) {
+    <FormOpenContext.Provider value={openApi}>
+      <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
+        <ExpandCollapseToolbar openApi={openApi} />
+        {sections.map((section) => {
+          const bucket = sectioned.byId.get(section.id) ?? [];
+          if (bucket.length === 0) return null;
+          const id = `section.${section.id}`;
+          const summaryText = section.showCount
+            ? `${section.label} (${bucket.length})`
+            : section.label;
           return (
-            <section key={section.id} className="space-y-3">
-              <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
-                {section.label}
-              </h3>
-              <div className="space-y-3">{bucket.map(renderRow)}</div>
-            </section>
+            <DetailsBlock
+              key={section.id}
+              id={id}
+              summary={summaryText}
+              level="l1"
+            >
+              {bucket.map(renderRow)}
+            </DetailsBlock>
           );
-        }
-        return (
-          <details
-            key={section.id}
-            className="group rounded-sm border border-border"
-            open={isOpen}
-          >
-            <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
-              {summaryText}
-            </summary>
-            <div className="space-y-3 px-3 pb-3 pt-1">{bucket.map(renderRow)}</div>
-          </details>
-        );
-      })}
+        })}
 
-      {others.length > 0 && (
-        <details className="group rounded-sm border border-border">
-          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
-            Other ({others.length})
-          </summary>
-          <div className="space-y-3 px-3 pb-3 pt-1">{others.map(renderRow)}</div>
-        </details>
-      )}
-    </form>
+        {others.length > 0 && (
+          <DetailsBlock id="section.__other__" summary={`Other (${others.length})`} level="l1">
+            {others.map(renderRow)}
+          </DetailsBlock>
+        )}
+      </form>
+    </FormOpenContext.Provider>
+  );
+}
+
+// DetailsBlock — controlled <details> tied to FormOpenContext. The
+// `level` prop drives visual weight: L1 (top sections) get the full
+// border; L2 (row sub-sections) and L3 (rows themselves) drop to a
+// lighter border with smaller padding so the nesting reads as a
+// hierarchy rather than competing equal-weight boxes.
+function DetailsBlock({
+  id,
+  summary,
+  level,
+  children,
+}: {
+  id: string;
+  summary: ReactNode;
+  level: "l1" | "l2" | "row";
+  children: ReactNode;
+}) {
+  const openApi = useFormOpenContext();
+  const open = openApi ? openApi.isOpen(id) : true;
+  const styles = (() => {
+    switch (level) {
+      case "l1":
+        return {
+          container: "group rounded-sm border border-border",
+          summary:
+            "cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink",
+          body: "space-y-3 px-3 pb-3 pt-1",
+        };
+      case "l2":
+        return {
+          container: "rounded-sm border border-border/60",
+          summary:
+            "cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink",
+          body: "space-y-2 px-2.5 pb-2.5 pt-1",
+        };
+      case "row":
+        return {
+          container: "rounded-sm border border-border/80 bg-bg/40",
+          summary:
+            "cursor-pointer select-none px-3 py-1.5 font-mono text-[11px] tracking-[0.06em] text-ink-muted transition-colors hover:text-ink",
+          body: "space-y-3 px-3 pb-3 pt-1",
+        };
+    }
+  })();
+  return (
+    <details
+      className={styles.container}
+      open={open}
+      onToggle={(e) => {
+        if (!openApi) return;
+        const target = e.currentTarget;
+        // Sync only when state diverges (toggle was a real user action,
+        // not a controlled-render echo) to avoid feedback loops.
+        if (target.open !== open) {
+          openApi.toggle(id);
+        }
+      }}
+    >
+      <summary className={styles.summary}>{summary}</summary>
+      <div className={styles.body}>{children}</div>
+    </details>
+  );
+}
+
+// ExpandCollapseToolbar — VSCode-style + / − buttons that flip the
+// form's mode wholesale. Live in the form header so they're stable
+// across section scrolling.
+function ExpandCollapseToolbar({ openApi }: { openApi: FormOpenApi }) {
+  return (
+    <div className="flex items-center justify-end gap-1 pb-1">
+      <button
+        type="button"
+        onClick={openApi.expandAll}
+        disabled={openApi.isAllExpanded}
+        title="Expand all sections"
+        aria-label="Expand all"
+        className="rounded-sm border border-border-strong px-2 py-0.5 font-mono text-[10.5px] text-ink-faint transition-colors hover:border-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        + expand all
+      </button>
+      <button
+        type="button"
+        onClick={openApi.collapseAll}
+        disabled={openApi.isAllCollapsed}
+        title="Collapse all sections"
+        aria-label="Collapse all"
+        className="rounded-sm border border-border-strong px-2 py-0.5 font-mono text-[10.5px] text-ink-faint transition-colors hover:border-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        − collapse all
+      </button>
+    </div>
   );
 }
 
@@ -636,33 +730,25 @@ function ArrayOfObjectsInput({
   return (
     <div className="space-y-2">
       {arr.map((row, idx) => (
-        <fieldset key={idx} className="rounded-sm border border-border px-3 pb-3 pt-2">
-          <legend className="flex items-center gap-2 px-1">
-            <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
-              {descriptor.label} #{idx + 1}
-            </span>
-            {readOnly ? null : (
-              <button
-                type="button"
-                onClick={() => removeRow(idx)}
-                className="font-mono text-[10.5px] text-ink-faint hover:text-red"
-                aria-label={`remove ${descriptor.label} ${idx + 1}`}
-              >
-                remove
-              </button>
-            )}
-          </legend>
-          <div className="space-y-3">
-            <ArrayRowChildren
-              row={row}
-              rowIdx={idx}
-              childDescriptors={childDescriptors}
-              subSections={descriptor.rowSubSections}
-              onChange={updateRow}
-              readOnly={readOnly}
-            />
-          </div>
-        </fieldset>
+        <ArrayRow
+          key={idx}
+          rowIdx={idx}
+          row={row}
+          parentPath={descriptor.path}
+          label={descriptor.label}
+          readOnly={readOnly}
+          onRemove={() => removeRow(idx)}
+        >
+          <ArrayRowChildren
+            row={row}
+            rowIdx={idx}
+            parentPath={descriptor.path}
+            childDescriptors={childDescriptors}
+            subSections={descriptor.rowSubSections}
+            onChange={updateRow}
+            readOnly={readOnly}
+          />
+        </ArrayRow>
       ))}
       {readOnly ? null : (
         <button
@@ -848,16 +934,105 @@ function BranchSubForm({
   );
 }
 
+// ArrayRow — single-row container for an array-of-objects descriptor's
+// row values. When the FormOpenContext is present (sectioned K8s
+// forms), renders as a controlled <details> with a row summary
+// (e.g. "name: ct-writer · image: ct-writer:local"). When absent
+// (Helm path), falls back to the legacy always-open <fieldset>.
+function ArrayRow({
+  rowIdx,
+  row,
+  parentPath,
+  label,
+  readOnly,
+  onRemove,
+  children,
+}: {
+  rowIdx: number;
+  row: Record<string, unknown>;
+  parentPath: string[];
+  label: string;
+  readOnly?: boolean;
+  onRemove: () => void;
+  children: ReactNode;
+}) {
+  const openApi = useFormOpenContext();
+  const summary = rowSummary(row);
+
+  if (!openApi) {
+    return (
+      <fieldset className="rounded-sm border border-border px-3 pb-3 pt-2">
+        <legend className="flex items-center gap-2 px-1">
+          <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
+            {label} #{rowIdx + 1}
+          </span>
+          {readOnly ? null : (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="font-mono text-[10.5px] text-ink-faint hover:text-red"
+              aria-label={`remove ${label} ${rowIdx + 1}`}
+            >
+              remove
+            </button>
+          )}
+        </legend>
+        <div className="space-y-3">{children}</div>
+      </fieldset>
+    );
+  }
+
+  // Controlled <details> path. Row id includes the parent dotted path
+  // so two arrays with index-0 rows don't collide.
+  const id = `row.${parentPath.join(".")}[${rowIdx}]`;
+  const open = openApi.isOpen(id);
+  return (
+    <details
+      className="rounded-sm border border-border/80 bg-bg/40"
+      open={open}
+      onToggle={(e) => {
+        const target = e.currentTarget;
+        if (target.open !== open) openApi.toggle(id);
+      }}
+    >
+      <summary className="flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 font-mono text-[11px] tracking-[0.06em] text-ink-muted transition-colors hover:text-ink">
+        <span className="text-ink-faint">{label} #{rowIdx + 1}</span>
+        {summary ? (
+          <span className="truncate text-ink-faint">— {summary}</span>
+        ) : null}
+        {readOnly ? null : (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onRemove();
+            }}
+            className="ml-auto font-mono text-[10.5px] text-ink-faint hover:text-red"
+            aria-label={`remove ${label} ${rowIdx + 1}`}
+          >
+            remove
+          </button>
+        )}
+      </summary>
+      <div className="space-y-3 px-3 pb-3 pt-1">{children}</div>
+    </details>
+  );
+}
+
 // ArrayRowChildren — renders an array-of-objects ROW's children.
 // When the descriptor carries a rowSubSections list (kind has
 // declared per-row sub-section grouping for this array), the
-// children get grouped by section and rendered as L2 blocks (a
-// primary `<section>` + collapsed `<details>` for the rest).
-// When no rowSubSections are set, falls back to the flat list
-// render — preserves Helm + non-sectioned-K8s behavior.
+// children get grouped by section and rendered as L2 blocks. The
+// L2 sub-section <details> are controlled by the same FormOpenContext
+// as L1, so the expand-all / collapse-all buttons sweep them too.
+// When no rowSubSections are set OR no descriptor carries a sub-
+// section stamp, falls back to the flat list render — preserves
+// Helm + non-sectioned-K8s behavior.
 function ArrayRowChildren({
   row,
   rowIdx,
+  parentPath,
   childDescriptors,
   subSections,
   onChange,
@@ -865,11 +1040,13 @@ function ArrayRowChildren({
 }: {
   row: Record<string, unknown>;
   rowIdx: number;
+  parentPath: string[];
   childDescriptors: FieldDescriptor[];
   subSections?: RowSubSectionConfig[];
   onChange: (idx: number, next: Record<string, unknown>) => void;
   readOnly?: boolean;
 }) {
+  const openApi = useFormOpenContext();
   const renderRow = (child: FieldDescriptor) => (
     <FieldRow
       key={child.path.join(".")}
@@ -882,7 +1059,6 @@ function ArrayRowChildren({
   );
 
   if (!subSections || subSections.length === 0) {
-    // No sub-section grouping declared — flat render as before.
     return <>{childDescriptors.map(renderRow)}</>;
   }
 
@@ -895,31 +1071,28 @@ function ArrayRowChildren({
   // the bottom in an "Other" fold so we don't silently drop new K8s
   // fields the allowlist hasn't been updated for.
   const others = childDescriptors.filter((c) => c.section === undefined);
+  const rowKey = `${parentPath.join(".")}[${rowIdx}]`;
 
   return (
     <>
       {subSections.map((sub) => {
         const bucket = grouped.byId.get(sub.id) ?? [];
         if (bucket.length === 0) return null;
-        const populated = sub.openWhenPopulated
-          ? bucket.some((d) => descriptorHasContent(d, row))
-          : false;
-        const isOpen = sub.defaultOpen ?? populated;
         const summaryText = sub.showCount
           ? `${sub.label} (${bucket.length})`
           : sub.label;
-        if (sub.defaultOpen) {
-          return (
-            <div key={sub.id} className="space-y-2">
-              {bucket.map(renderRow)}
-            </div>
-          );
-        }
+        const id = `subsection.${rowKey}.${sub.id}`;
+        const open = openApi ? openApi.isOpen(id) : false;
         return (
           <details
             key={sub.id}
             className="rounded-sm border border-border/60"
-            open={isOpen}
+            open={open}
+            onToggle={(e) => {
+              if (!openApi) return;
+              const target = e.currentTarget;
+              if (target.open !== open) openApi.toggle(id);
+            }}
           >
             <summary className="cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink">
               {summaryText}
@@ -928,19 +1101,29 @@ function ArrayRowChildren({
           </details>
         );
       })}
-      {others.length > 0 && (
-        <details className="rounded-sm border border-border/60">
-          <summary className="cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink">
-            Other ({others.length})
-          </summary>
-          <div className="space-y-2 px-2.5 pb-2.5 pt-1">{others.map(renderRow)}</div>
-        </details>
-      )}
+      {others.length > 0 && (() => {
+        const id = `subsection.${rowKey}.__other__`;
+        const open = openApi ? openApi.isOpen(id) : false;
+        return (
+          <details
+            className="rounded-sm border border-border/60"
+            open={open}
+            onToggle={(e) => {
+              if (!openApi) return;
+              const target = e.currentTarget;
+              if (target.open !== open) openApi.toggle(id);
+            }}
+          >
+            <summary className="cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink">
+              Other ({others.length})
+            </summary>
+            <div className="space-y-2 px-2.5 pb-2.5 pt-1">{others.map(renderRow)}</div>
+          </details>
+        );
+      })()}
     </>
   );
 }
-
-
 // ─── coercion / path helpers ────────────────────────────────────
 
 function pathStartsWith(p: string[], prefix: string[]): boolean {

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -13,10 +13,21 @@
 import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
 import { buildFieldDescriptors, type WalkOptions } from "./walker";
 import { validateValues } from "./validate";
-import { collectSectioned, descendantHasSection } from "./sections";
+import {
+  collectRowSubSections,
+  collectSectioned,
+  descendantHasSection,
+  descriptorHasContent,
+} from "./sections";
 import { cn } from "../cn";
 import { getAtPath, setAtPath } from "./pathOps";
-import type { FieldDescriptor, JSONSchema, ValidationIssue } from "./types";
+import type {
+  FieldDescriptor,
+  FieldSection,
+  JSONSchema,
+  RowSubSectionConfig,
+  ValidationIssue,
+} from "./types";
 import { Tooltip } from "../../components/Tooltip";
 
 // InfoTip — tiny "(i)" affordance next to a label that opens a
@@ -44,16 +55,20 @@ function InfoTip({ text }: { text: string | undefined }) {
 
 export type SchemaFormMode = "create" | "edit";
 
-export interface SchemaFormSectionLabels {
-  /** Required header for the always-open primary section. Kind-specific
-   *  to give the operator clear intent ("Data" for ConfigMap, "Networking"
-   *  for Service, etc.). */
-  primary: string;
-  /** Header for the collapsed metadata section. Defaults to "Metadata". */
-  metadata?: string;
-  /** Header for the collapsed advanced section. Defaults to "Advanced".
-   *  The renderer appends a `(N)` field count automatically. */
-  advanced?: string;
+/** One section in the form's L1 layout. The renderer draws sections
+ *  in declared order; the first one with `defaultOpen=true` renders
+ *  as a `<section>` with a heading; the rest render as `<details>`
+ *  with a clickable summary. */
+export interface SchemaFormSectionConfig {
+  id: FieldSection;
+  label: string;
+  defaultOpen?: boolean;
+  /** Override defaultOpen=false when the section's bucket has any
+   *  populated descriptor — useful for Volumes where editing
+   *  volumeMounts without seeing volumes is a footgun. */
+  openWhenPopulated?: boolean;
+  /** Append "(N)" field count in the summary. Used for Advanced. */
+  showCount?: boolean;
 }
 
 export interface SchemaFormProps {
@@ -70,12 +85,12 @@ export interface SchemaFormProps {
   mode?: SchemaFormMode;
   /** Rendered when the schema produces zero descriptors. */
   emptyMessage?: ReactNode;
-  /** When set, descriptors are grouped into primary / metadata /
-   *  advanced sections according to `descriptor.section` stamped by the
-   *  walker. K8sSchemaForm passes this; Helm leaves it undefined to
-   *  keep the legacy flat layout. */
-  sectionLabels?: SchemaFormSectionLabels;
+  /** When set, descriptors are grouped into the declared sections in
+   *  order. K8sSchemaForm passes `getSections(kind)`; Helm leaves it
+   *  undefined to keep the legacy flat layout. */
+  sections?: SchemaFormSectionConfig[];
 }
+
 export function SchemaForm({
   schema,
   values,
@@ -83,7 +98,7 @@ export function SchemaForm({
   walkOptions,
   mode = "edit",
   emptyMessage,
-  sectionLabels,
+  sections,
 }: SchemaFormProps) {
   const descriptors = useMemo(
     () => buildFieldDescriptors(schema, walkOptions),
@@ -114,7 +129,7 @@ export function SchemaForm({
   // Back-compat fallback: when the caller hasn't asked for sections,
   // OR no descriptor has a section stamp (Helm path), render the flat
   // ordered list exactly like the pre-#142 layout.
-  if (!sectionLabels || sectioned.total === 0) {
+  if (!sections || sections.length === 0 || sectioned.total === 0) {
     return (
       <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
         {descriptors.map(renderRow)}
@@ -133,34 +148,39 @@ export function SchemaForm({
 
   return (
     <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
-      <section className="space-y-3">
-        <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
-          {sectionLabels.primary}
-        </h3>
-        <div className="space-y-3">{sectioned.primary.map(renderRow)}</div>
-      </section>
-
-      {sectioned.metadata.length > 0 && (
-        <details className="group rounded-sm border border-border">
-          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
-            {sectionLabels.metadata ?? "Metadata"}
-          </summary>
-          <div className="space-y-3 px-3 pb-3 pt-1">
-            {sectioned.metadata.map(renderRow)}
-          </div>
-        </details>
-      )}
-
-      {sectioned.advanced.length > 0 && (
-        <details className="group rounded-sm border border-border">
-          <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
-            {sectionLabels.advanced ?? "Advanced"} ({sectioned.advanced.length})
-          </summary>
-          <div className="space-y-3 px-3 pb-3 pt-1">
-            {sectioned.advanced.map(renderRow)}
-          </div>
-        </details>
-      )}
+      {sections.map((section) => {
+        const bucket = sectioned.byId.get(section.id) ?? [];
+        if (bucket.length === 0) return null;
+        const populated = section.openWhenPopulated
+          ? bucket.some((d) => descriptorHasContent(d, values))
+          : false;
+        const isOpen = section.defaultOpen ?? populated;
+        const summaryText = section.showCount
+          ? `${section.label} (${bucket.length})`
+          : section.label;
+        if (section.defaultOpen) {
+          return (
+            <section key={section.id} className="space-y-3">
+              <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
+                {section.label}
+              </h3>
+              <div className="space-y-3">{bucket.map(renderRow)}</div>
+            </section>
+          );
+        }
+        return (
+          <details
+            key={section.id}
+            className="group rounded-sm border border-border"
+            open={isOpen}
+          >
+            <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink">
+              {summaryText}
+            </summary>
+            <div className="space-y-3 px-3 pb-3 pt-1">{bucket.map(renderRow)}</div>
+          </details>
+        );
+      })}
 
       {others.length > 0 && (
         <details className="group rounded-sm border border-border">
@@ -633,16 +653,14 @@ function ArrayOfObjectsInput({
             )}
           </legend>
           <div className="space-y-3">
-            {childDescriptors.map((child) => (
-              <FieldRow
-                key={child.path.join(".")}
-                descriptor={child}
-                values={row}
-                issues={[]}
-                mode={readOnly ? "edit" : "edit"}
-                onChange={(nextRow) => updateRow(idx, nextRow)}
-              />
-            ))}
+            <ArrayRowChildren
+              row={row}
+              rowIdx={idx}
+              childDescriptors={childDescriptors}
+              subSections={descriptor.rowSubSections}
+              onChange={updateRow}
+              readOnly={readOnly}
+            />
           </div>
         </fieldset>
       ))}
@@ -829,6 +847,99 @@ function BranchSubForm({
     </fieldset>
   );
 }
+
+// ArrayRowChildren — renders an array-of-objects ROW's children.
+// When the descriptor carries a rowSubSections list (kind has
+// declared per-row sub-section grouping for this array), the
+// children get grouped by section and rendered as L2 blocks (a
+// primary `<section>` + collapsed `<details>` for the rest).
+// When no rowSubSections are set, falls back to the flat list
+// render — preserves Helm + non-sectioned-K8s behavior.
+function ArrayRowChildren({
+  row,
+  rowIdx,
+  childDescriptors,
+  subSections,
+  onChange,
+  readOnly,
+}: {
+  row: Record<string, unknown>;
+  rowIdx: number;
+  childDescriptors: FieldDescriptor[];
+  subSections?: RowSubSectionConfig[];
+  onChange: (idx: number, next: Record<string, unknown>) => void;
+  readOnly?: boolean;
+}) {
+  const renderRow = (child: FieldDescriptor) => (
+    <FieldRow
+      key={child.path.join(".")}
+      descriptor={child}
+      values={row}
+      issues={[]}
+      mode={readOnly ? "edit" : "edit"}
+      onChange={(nextRow) => onChange(rowIdx, nextRow)}
+    />
+  );
+
+  if (!subSections || subSections.length === 0) {
+    // No sub-section grouping declared — flat render as before.
+    return <>{childDescriptors.map(renderRow)}</>;
+  }
+
+  const grouped = collectRowSubSections(childDescriptors);
+  if (grouped.total === 0) {
+    return <>{childDescriptors.map(renderRow)}</>;
+  }
+
+  // Children that didn't match any sub-section path stay visible at
+  // the bottom in an "Other" fold so we don't silently drop new K8s
+  // fields the allowlist hasn't been updated for.
+  const others = childDescriptors.filter((c) => c.section === undefined);
+
+  return (
+    <>
+      {subSections.map((sub) => {
+        const bucket = grouped.byId.get(sub.id) ?? [];
+        if (bucket.length === 0) return null;
+        const populated = sub.openWhenPopulated
+          ? bucket.some((d) => descriptorHasContent(d, row))
+          : false;
+        const isOpen = sub.defaultOpen ?? populated;
+        const summaryText = sub.showCount
+          ? `${sub.label} (${bucket.length})`
+          : sub.label;
+        if (sub.defaultOpen) {
+          return (
+            <div key={sub.id} className="space-y-2">
+              {bucket.map(renderRow)}
+            </div>
+          );
+        }
+        return (
+          <details
+            key={sub.id}
+            className="rounded-sm border border-border/60"
+            open={isOpen}
+          >
+            <summary className="cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink">
+              {summaryText}
+            </summary>
+            <div className="space-y-2 px-2.5 pb-2.5 pt-1">{bucket.map(renderRow)}</div>
+          </details>
+        );
+      })}
+      {others.length > 0 && (
+        <details className="rounded-sm border border-border/60">
+          <summary className="cursor-pointer select-none px-2.5 py-1.5 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint transition-colors hover:text-ink">
+            Other ({others.length})
+          </summary>
+          <div className="space-y-2 px-2.5 pb-2.5 pt-1">{others.map(renderRow)}</div>
+        </details>
+      )}
+    </>
+  );
+}
+
 
 // ─── coercion / path helpers ────────────────────────────────────
 

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -354,16 +354,21 @@ export function FieldRow({ descriptor, values, issues, mode, onChange }: FieldRo
   const readOnly = mode === "edit" && descriptor.editable === "create-only";
 
   return (
-    <div>
-      <div className="flex items-baseline gap-2">
+    <div className="min-w-0">
+      <div className="flex min-w-0 items-baseline gap-2">
         <label htmlFor={id} className="inline-flex items-baseline font-mono text-[12px] text-ink">
           {descriptor.label}
           {descriptor.required ? <span className="text-red"> *</span> : null}
           <InfoTip text={descriptor.description} />
         </label>
-        <span className="font-mono text-[10.5px] text-ink-faint">
-          {pathBreadcrumb(descriptor.path)}
-        </span>
+        {pathBreadcrumb(descriptor.path) ? (
+          <span
+            className="block min-w-0 truncate font-mono text-[10.5px] text-ink-faint"
+            title={descriptor.path.join(".")}
+          >
+            {pathBreadcrumb(descriptor.path)}
+          </span>
+        ) : null}
         {readOnly ? (
           <span className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-faint">
             read-only after create
@@ -1136,6 +1141,12 @@ function pathStartsWith(p: string[], prefix: string[]): boolean {
 
 function pathBreadcrumb(path: string[]): string {
   if (path.length <= 1) return "";
+  // Deeply-nested K8s paths (PodAffinity, NodeAffinity etc.) blow
+  // past the form's ~640px width — and at that depth the surrounding
+  // fieldset legends already locate the field, so the breadcrumb is
+  // redundant noise. Drop entirely beyond 4 segments.
+  if (path.length > 4) return "";
+  // For 2-4 segments, show full path (still short enough to fit).
   return path.join(".");
 }
 

--- a/web/src/lib/schemaForm/SchemaFormBridge.tsx
+++ b/web/src/lib/schemaForm/SchemaFormBridge.tsx
@@ -12,7 +12,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import {
   SchemaForm,
   type SchemaFormMode,
-  type SchemaFormSectionLabels,
+  type SchemaFormSectionConfig,
 } from "./SchemaForm";
 import type { JSONSchema } from "./types";
 import type { WalkOptions } from "./walker";
@@ -36,7 +36,7 @@ export interface SchemaFormBridgeProps {
   /** When provided, SchemaForm renders descriptors grouped into
    *  primary / metadata / advanced sections. K8sSchemaForm sets this;
    *  Helm leaves it undefined to keep the legacy flat layout. */
-  sectionLabels?: SchemaFormSectionLabels;
+  sections?: SchemaFormSectionConfig[];
 }
 
 export function SchemaFormBridge({
@@ -48,7 +48,7 @@ export function SchemaFormBridge({
   emptyMessage,
   banner,
   onParseError,
-  sectionLabels,
+  sections,
 }: SchemaFormBridgeProps) {
   const [obj, setObj] = useState<Record<string, unknown>>(() => parseSafe(valuesYaml, onParseError));
 
@@ -79,7 +79,7 @@ export function SchemaFormBridge({
         walkOptions={walkOptions}
         mode={mode}
         emptyMessage={emptyMessage}
-        sectionLabels={sectionLabels}
+        sections={sections}
         onChange={(next) => {
           setObj(next);
           // Re-serialize and bubble. Default key order — sortKeys

--- a/web/src/lib/schemaForm/SchemaFormBridge.tsx
+++ b/web/src/lib/schemaForm/SchemaFormBridge.tsx
@@ -37,6 +37,9 @@ export interface SchemaFormBridgeProps {
    *  primary / metadata / advanced sections. K8sSchemaForm sets this;
    *  Helm leaves it undefined to keep the legacy flat layout. */
   sections?: SchemaFormSectionConfig[];
+  /** Stable identifier for localStorage-backed open-state memory.
+   *  K8sSchemaForm passes the kind name. */
+  formKey?: string;
 }
 
 export function SchemaFormBridge({
@@ -49,6 +52,7 @@ export function SchemaFormBridge({
   banner,
   onParseError,
   sections,
+  formKey,
 }: SchemaFormBridgeProps) {
   const [obj, setObj] = useState<Record<string, unknown>>(() => parseSafe(valuesYaml, onParseError));
 
@@ -80,6 +84,7 @@ export function SchemaFormBridge({
         mode={mode}
         emptyMessage={emptyMessage}
         sections={sections}
+        formKey={formKey}
         onChange={(next) => {
           setObj(next);
           // Re-serialize and bubble. Default key order — sortKeys

--- a/web/src/lib/schemaForm/arrayRowSummary.test.ts
+++ b/web/src/lib/schemaForm/arrayRowSummary.test.ts
@@ -1,0 +1,131 @@
+// arrayRowSummary.test.ts — pure-function coverage for the row
+// summary heuristics + open-state helpers used by the array
+// renderers.
+
+import { describe, expect, it } from "vitest";
+import {
+  discriminatorRowSummary,
+  initialOpenSet,
+  rowSummary,
+  shiftOpenOnRemove,
+} from "./arrayRowSummary";
+import type { DiscriminatorBranch } from "./types";
+
+describe("rowSummary — array-of-objects row label", () => {
+  it("picks `name` as primary + `image` as secondary for container rows", () => {
+    expect(rowSummary({ name: "api", image: "ghcr.io/example/api:1.0.0" })).toBe(
+      "name: api · image: ghcr.io/example/api:1.0.0",
+    );
+  });
+
+  it("picks `name` + `mountPath` for volumeMount rows", () => {
+    expect(rowSummary({ name: "config", mountPath: "/etc/app", readOnly: true })).toBe(
+      "name: config · mountPath: /etc/app",
+    );
+  });
+
+  it("picks `name` + `value` for env rows", () => {
+    expect(rowSummary({ name: "LOG_LEVEL", value: "info" })).toBe(
+      "name: LOG_LEVEL · value: info",
+    );
+  });
+
+  it("picks `key` + `operator` for toleration rows (no `name` field)", () => {
+    expect(rowSummary({ key: "node.kubernetes.io/unreachable", operator: "Exists" })).toBe(
+      "key: node.kubernetes.io/unreachable · operator: Exists",
+    );
+  });
+
+  it("picks `host` for ingress-rule rows", () => {
+    expect(rowSummary({ host: "api.example.com", paths: [{ path: "/" }] })).toBe(
+      "host: api.example.com",
+    );
+  });
+
+  it("picks numeric primary when value is a number (e.g. ServicePort.port)", () => {
+    expect(rowSummary({ name: "http", port: 80 })).toBe("name: http · port: 80");
+  });
+
+  it("returns empty string for empty / null / non-object rows", () => {
+    expect(rowSummary({})).toBe("");
+    expect(rowSummary(null)).toBe("");
+    expect(rowSummary(undefined)).toBe("");
+    expect(rowSummary("plain string")).toBe("");
+    expect(rowSummary([1, 2, 3])).toBe("");
+  });
+
+  it("truncates long values with an ellipsis", () => {
+    const longImage = "ghcr.io/example/" + "x".repeat(200) + ":latest";
+    const out = rowSummary({ name: "api", image: longImage });
+    expect(out).toMatch(/^name: api · image: /);
+    // 40-char limit → 39 chars + ellipsis on the value side
+    expect(out.length).toBeLessThan(120);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("skips nested-object secondaries (only surfaces scalars)", () => {
+    expect(rowSummary({ name: "api", value: { nested: "x" } })).toBe("name: api");
+  });
+});
+
+describe("discriminatorRowSummary — array-of-discriminators row label", () => {
+  const volumeBranches: DiscriminatorBranch[] = [
+    { label: "ConfigMap", schema: {}, discriminatorKey: "configMap", descriptors: [] },
+    { label: "Secret", schema: {}, discriminatorKey: "secret", descriptors: [] },
+    { label: "emptyDir", schema: {}, discriminatorKey: "emptyDir", descriptors: [] },
+  ];
+
+  it("uses the active branch label as primary + row name as secondary", () => {
+    const row = { name: "app-config", configMap: { name: "config" } };
+    expect(discriminatorRowSummary(row, volumeBranches)).toBe("ConfigMap · name: app-config");
+  });
+
+  it("emits just the branch label when the row has no name", () => {
+    const row = { emptyDir: {} };
+    expect(discriminatorRowSummary(row, volumeBranches)).toBe("emptyDir");
+  });
+
+  it("falls back to plain rowSummary when no branch is active yet", () => {
+    // Row has `name` but no branch key set — operator added the row
+    // and named it but hasn't picked the volume type yet.
+    expect(discriminatorRowSummary({ name: "scratch" }, volumeBranches)).toBe("name: scratch");
+  });
+
+  it("handles empty / non-object rows", () => {
+    expect(discriminatorRowSummary({}, volumeBranches)).toBe("");
+    expect(discriminatorRowSummary(null, volumeBranches)).toBe("");
+  });
+});
+
+describe("initialOpenSet — default open state per row count", () => {
+  it("opens the only row in a single-row array", () => {
+    expect(initialOpenSet(1)).toEqual(new Set([0]));
+  });
+
+  it("collapses all rows when there are multiple", () => {
+    expect(initialOpenSet(3)).toEqual(new Set());
+  });
+
+  it("returns empty for zero-row arrays", () => {
+    expect(initialOpenSet(0)).toEqual(new Set());
+  });
+});
+
+describe("shiftOpenOnRemove — keeps open state attached to logical rows", () => {
+  it("drops the removed index", () => {
+    expect(shiftOpenOnRemove(new Set([1]), 1)).toEqual(new Set());
+  });
+
+  it("decrements indices that were higher than the removed one", () => {
+    // Remove row 1 → row 2 becomes row 1, row 3 becomes row 2.
+    expect(shiftOpenOnRemove(new Set([2, 3]), 1)).toEqual(new Set([1, 2]));
+  });
+
+  it("leaves indices below the removed one unchanged", () => {
+    expect(shiftOpenOnRemove(new Set([0, 4]), 2)).toEqual(new Set([0, 3]));
+  });
+
+  it("is idempotent on empty input", () => {
+    expect(shiftOpenOnRemove(new Set(), 0)).toEqual(new Set());
+  });
+});

--- a/web/src/lib/schemaForm/arrayRowSummary.ts
+++ b/web/src/lib/schemaForm/arrayRowSummary.ts
@@ -1,0 +1,112 @@
+// arrayRowSummary.ts — picks a one-line summary for an
+// array-of-objects / array-of-discriminators row when collapsed.
+// Pulled out of SchemaForm.tsx so the heuristics are unit-testable
+// without rendering React.
+//
+// Strategy: pick a primary "identifier" field (name / key / host /
+// secretName / topologyKey) — falling back to the first numeric or
+// non-empty string. Then a secondary field (image / value /
+// mountPath / port / etc.) for context. Result is rendered as
+// `name: api · image: ghcr.io/api`.
+//
+// For array-of-discriminators rows: the active branch label takes
+// the primary slot, and the row's `name` (if any) becomes secondary.
+// Volumes ("ConfigMap · name: app-config") and EnvFromSource
+// ("ConfigMap · name: app-config") both benefit.
+
+import type { FieldDescriptor } from "./types";
+
+export const IDENTIFIER_KEYS = [
+  "name",
+  "key",
+  "host",
+  "secretName",
+  "topologyKey",
+];
+
+export const SECONDARY_KEYS = [
+  "image",
+  "value",
+  "mountPath",
+  "operator",
+  "port",
+  "containerPort",
+  "path",
+];
+
+export function rowSummary(row: unknown): string {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return "";
+  const obj = row as Record<string, unknown>;
+  let primaryKey: string | undefined;
+  let primaryValue: string | undefined;
+  for (const k of IDENTIFIER_KEYS) {
+    const v = obj[k];
+    if (typeof v === "string" && v) {
+      primaryKey = k;
+      primaryValue = v;
+      break;
+    }
+    if (typeof v === "number") {
+      primaryKey = k;
+      primaryValue = String(v);
+      break;
+    }
+  }
+  let secondaryKey: string | undefined;
+  let secondaryValue: string | undefined;
+  for (const k of SECONDARY_KEYS) {
+    if (k === primaryKey) continue;
+    const v = obj[k];
+    if (v === undefined || v === null || v === "") continue;
+    if (typeof v === "object") continue;
+    secondaryKey = k;
+    secondaryValue = String(v);
+    break;
+  }
+  const parts: string[] = [];
+  if (primaryKey && primaryValue) parts.push(`${primaryKey}: ${truncate(primaryValue, 40)}`);
+  if (secondaryKey && secondaryValue)
+    parts.push(`${secondaryKey}: ${truncate(secondaryValue, 40)}`);
+  return parts.join(" · ");
+}
+
+export function discriminatorRowSummary(
+  row: unknown,
+  branches: NonNullable<FieldDescriptor["branches"]>,
+): string {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return "";
+  const obj = row as Record<string, unknown>;
+  const active = branches.find((b) => b.discriminatorKey && b.discriminatorKey in obj);
+  if (!active) return rowSummary(row);
+  const parts: string[] = [active.label];
+  for (const k of IDENTIFIER_KEYS) {
+    const v = obj[k];
+    if (typeof v === "string" && v) {
+      parts.push(`${k}: ${truncate(v, 40)}`);
+      break;
+    }
+  }
+  return parts.join(" · ");
+}
+
+export function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+/** Default-open set for a row count: open the only row, collapse all
+ *  if multiple. Used to seed the open-set on first mount. */
+export function initialOpenSet(rowCount: number): Set<number> {
+  if (rowCount === 1) return new Set([0]);
+  return new Set();
+}
+
+/** Shift open-indices down after removing row at `removedIdx` so
+ *  open state stays attached to the same logical row. */
+export function shiftOpenOnRemove(prev: Set<number>, removedIdx: number): Set<number> {
+  const next = new Set<number>();
+  for (const i of prev) {
+    if (i === removedIdx) continue;
+    next.add(i > removedIdx ? i - 1 : i);
+  }
+  return next;
+}

--- a/web/src/lib/schemaForm/k8sAllowlist.ts
+++ b/web/src/lib/schemaForm/k8sAllowlist.ts
@@ -1,48 +1,89 @@
-// schemaForm/k8sAllowlist.ts — per-kind narrowing of the K8s
-// OpenAPI v3 schema. Operators should never see status,
-// managedFields, creationTimestamp, uid, resourceVersion, etc.;
-// per #116 we filter the schema BEFORE the walker runs so the
-// renderer never even considers those fields.
+// k8sAllowlist.ts — per-kind sectioning + filtering for the schema-
+// aware form editor.
 //
-// Allowlist (not deny-list) per design call-out — predictable and
-// auditable; if K8s adds a new noise field, it stays hidden by
-// default until we explicitly allowlist it.
+// Two responsibilities:
 //
-// Sectioned shape (added for the section-grouping refactor): each
-// kind splits its allowlisted paths into 3 groups so the renderer
-// can present them as primary (always visible) / metadata (collapsed)
-// / advanced (hidden behind toggle). Path order within each group
-// drives display order. The flat list of "all allowlisted paths"
-// (primary ∪ metadata ∪ advanced) is what filterSchemaForKind hands
-// to the schema-narrowing pass.
+//  1. **Section layout** — declare the L1 sections each kind splits
+//     into (e.g. ConfigMap has Data / Metadata / Advanced; Deployment
+//     has Containers / Volumes / Strategy / Pod metadata / Metadata /
+//     Selector / Advanced). The renderer in `SchemaForm.tsx` reads
+//     the section list to render `<section>` + `<details>` blocks
+//     in the order declared here. Sub-section paths inside arrays of
+//     objects (e.g. per-container probes / lifecycle / advanced)
+//     also live in this table — see `Deployment.subSections` below.
+//
+//  2. **Schema narrowing** — `filterSchemaForKind` collects every
+//     allowlisted path across every section, builds a path trie, and
+//     prunes the OpenAPI schema down to those properties (recursively,
+//     with `*` matching any array-element index). This keeps form-
+//     mode focused on what we know how to render and hides noise
+//     like status / managedFields.
+//
+// Path syntax: dotted, rooted at the K8s object root.
+//   - `metadata.name`                        — depth 2 simple
+//   - `spec.template.spec.containers`        — depth N simple
+//   - `spec.template.spec.containers.*.image` — `*` is the array-
+//     element boundary; the resolver / filter both handle it.
 
 import type { FieldSection, JSONSchema } from "./types";
 
-export type SupportedKind = "ConfigMap" | "Secret" | "Service" | "Ingress";
+export type SupportedKind =
+  | "ConfigMap"
+  | "Secret"
+  | "Service"
+  | "Ingress"
+  | "Deployment"
+  | "StatefulSet";
 
-/** Curated layout for a single kind. Each section's `paths` array
- *  is dotted, rooted at the K8s object (e.g. `metadata.name`,
- *  `data`, `spec.type`). Path order within an array drives display
- *  order in that section. */
-interface KindSpec {
-  primary: {
-    /** Section header — kind-specific so it tells the operator what
-     *  they're editing ("Data" for ConfigMap, "Networking" for
-     *  Service, "Routing & TLS" for Ingress). */
-    label: string;
-    paths: string[];
-  };
-  metadata: {
-    label: string;
-    paths: string[];
-  };
-  advanced: {
-    label: string;
-    paths: string[];
-  };
+/** One L1 section inside a kind's form. */
+export interface SectionSpec {
+  /** Identifier — unique within a KindSpec. The walker stamps this on
+   *  matching descriptors as `section`. */
+  id: FieldSection;
+  /** Header text rendered above the section block. */
+  label: string;
+  /** Dotted paths whose descriptors land in this section. Order
+   *  drives display order within the section. */
+  paths: string[];
+  /** When true, the section renders as `<section>` (always open).
+   *  Default false → `<details>` (collapsed). Exactly one section
+   *  per kind should be marked defaultOpen. */
+  defaultOpen?: boolean;
+  /** When true, the section starts open if any descriptor in its
+   *  bucket has populated content. Useful for Volumes, where editing
+   *  volumeMounts without seeing volumes is a footgun. */
+  openWhenPopulated?: boolean;
+  /** When true, the section renders a `(N)` field count in its
+   *  summary — telegraphs "there's stuff inside" without forcing
+   *  the operator to expand. */
+  showCount?: boolean;
+}
+
+/** Sub-section grouping inside an array-of-objects ROW (e.g. per-
+ *  container fields). The walker stamps row children with the
+ *  matching sub-section id; the array-of-objects renderer reads
+ *  these to draw a smaller stack of blocks INSIDE each row. */
+export interface RowSubSection {
+  id: FieldSection;
+  label: string;
+  /** Child field paths relative to the row item. e.g.
+   *  `["image", "name", "ports"]` for container primary. */
+  paths: string[];
+  defaultOpen?: boolean;
+  openWhenPopulated?: boolean;
+  showCount?: boolean;
+}
+
+/** Curated layout for a single kind. */
+export interface KindSpec {
+  sections: SectionSpec[];
+  /** Per-array-of-objects-parent sub-section table. The key is the
+   *  parent path (e.g. `spec.template.spec.containers`); the value
+   *  is the ordered sub-section list rendered inside each row. */
+  subSections?: Record<string, RowSubSection[]>;
   /** Fields the renderer marks editable="create-only" — name and
-   *  namespace are immutable after create; spec.clusterIP and
-   *  spec.loadBalancerClass are also immutable on Service updates. */
+   *  namespace are immutable post-create; some service / selector
+   *  paths are also immutable and worth flagging. */
   createOnly: string[];
 }
 
@@ -59,113 +100,326 @@ const KIND_GVK: Record<SupportedKind, KindGVK> = {
   Secret: { group: "", version: "v1", kind: "Secret", resource: "secrets" },
   Service: { group: "", version: "v1", kind: "Service", resource: "services" },
   Ingress: { group: "networking.k8s.io", version: "v1", kind: "Ingress", resource: "ingresses" },
+  Deployment: { group: "apps", version: "v1", kind: "Deployment", resource: "deployments" },
+  StatefulSet: { group: "apps", version: "v1", kind: "StatefulSet", resource: "statefulsets" },
 };
 
 export function getKindGVK(kind: SupportedKind): KindGVK {
   return KIND_GVK[kind];
 }
 
+// ─── Per-container row sub-sections (shared by Deployment + StatefulSet) ──
+
+const CONTAINER_SUBSECTIONS: RowSubSection[] = [
+  {
+    id: "primary",
+    label: "Primary",
+    paths: ["name", "image", "imagePullPolicy", "ports", "env", "envFrom", "resources"],
+    defaultOpen: true,
+  },
+  {
+    id: "probes",
+    label: "Probes & lifecycle",
+    paths: ["livenessProbe", "readinessProbe", "startupProbe", "lifecycle"],
+  },
+  {
+    id: "mounts",
+    label: "Volume mounts",
+    paths: ["volumeMounts"],
+    openWhenPopulated: true,
+  },
+  {
+    id: "advanced",
+    label: "Container advanced",
+    paths: [
+      "command",
+      "args",
+      "workingDir",
+      "securityContext",
+      "terminationMessagePath",
+      "terminationMessagePolicy",
+      "tty",
+      "stdin",
+      "stdinOnce",
+    ],
+    showCount: true,
+  },
+];
+
+// initContainers — same shape as containers minus lifecycle hooks
+// (apiserver doesn't run them for init containers anyway).
+const INIT_CONTAINER_SUBSECTIONS: RowSubSection[] = CONTAINER_SUBSECTIONS.map((s) =>
+  s.id === "probes"
+    ? { ...s, label: "Probes", paths: s.paths.filter((p) => p !== "lifecycle") }
+    : s,
+);
+
+// ─── KIND_SPECS ──────────────────────────────────────────────────────────
+
 const KIND_SPECS: Record<SupportedKind, KindSpec> = {
   ConfigMap: {
-    primary: {
-      label: "Data",
-      // The whole point of a ConfigMap.
-      paths: ["data", "binaryData"],
-    },
-    metadata: {
-      label: "Metadata",
-      // Annotations live last so name/namespace/labels aren't
-      // visually crowded by controller-set annotations.
-      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
-    },
-    advanced: {
-      label: "Advanced",
-      // immutable=true is a one-way door (apiserver rejects mutation
-      // after) — hide behind the advanced toggle so it can't be
-      // toggled accidentally from the primary section.
-      paths: ["immutable"],
-    },
+    sections: [
+      { id: "primary", label: "Data", paths: ["data", "binaryData"], defaultOpen: true },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      { id: "advanced", label: "Advanced", paths: ["immutable"], showCount: true },
+    ],
     createOnly: ["metadata.name", "metadata.namespace"],
   },
+
   Secret: {
-    primary: {
-      label: "Data",
-      // type drives data semantics (Opaque vs kubernetes.io/tls vs
-      // kubernetes.io/dockerconfigjson etc.); data + stringData are
-      // the actual payload. base64 layer applies on top of `data`.
-      paths: ["type", "data", "stringData"],
-    },
-    metadata: {
-      label: "Metadata",
-      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
-    },
-    advanced: {
-      label: "Advanced",
-      paths: ["immutable"],
-    },
+    sections: [
+      { id: "primary", label: "Data", paths: ["type", "data", "stringData"], defaultOpen: true },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      { id: "advanced", label: "Advanced", paths: ["immutable"], showCount: true },
+    ],
     createOnly: ["metadata.name", "metadata.namespace"],
   },
+
   Service: {
-    primary: {
-      label: "Networking",
-      // The "why isn't this routing traffic?" investigation surface:
-      // type (ClusterIP / NodePort / LoadBalancer / ExternalName),
-      // selector (label selector matching backing pods), ports
-      // (port → targetPort + protocol).
-      paths: ["spec.type", "spec.selector", "spec.ports"],
-    },
-    metadata: {
-      label: "Metadata",
-      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
-    },
-    advanced: {
-      label: "Advanced",
-      // Traffic policy + IP family + LB-specific knobs operators
-      // touch maybe once per Service lifetime. clusterIP is also
-      // immutable on update (createOnly enforces read-only after
-      // create) but we still surface it so it's not dropped from
-      // the form silently.
-      paths: [
-        "spec.clusterIP",
-        "spec.externalTrafficPolicy",
-        "spec.internalTrafficPolicy",
-        "spec.sessionAffinity",
-        "spec.ipFamilies",
-        "spec.ipFamilyPolicy",
-        "spec.loadBalancerClass",
-        "spec.loadBalancerSourceRanges",
-      ],
-    },
+    sections: [
+      {
+        id: "primary",
+        label: "Networking",
+        paths: ["spec.type", "spec.selector", "spec.ports"],
+        defaultOpen: true,
+      },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      {
+        id: "advanced",
+        label: "Advanced",
+        paths: [
+          "spec.clusterIP",
+          "spec.externalTrafficPolicy",
+          "spec.internalTrafficPolicy",
+          "spec.sessionAffinity",
+          "spec.ipFamilies",
+          "spec.ipFamilyPolicy",
+          "spec.loadBalancerClass",
+          "spec.loadBalancerSourceRanges",
+        ],
+        showCount: true,
+      },
+    ],
     createOnly: [
       "metadata.name",
       "metadata.namespace",
       "spec.clusterIP",
-      // loadBalancerClass is also immutable on update per the K8s
-      // Service controller — picking a different LB implementation
-      // requires recreating the Service.
       "spec.loadBalancerClass",
     ],
   },
+
   Ingress: {
-    primary: {
-      label: "Routing & TLS",
-      // ingressClassName picks the controller (nginx / alb / etc.);
-      // rules carry host + path → backend; tls carries cert refs.
-      paths: ["spec.ingressClassName", "spec.rules", "spec.tls"],
-    },
-    metadata: {
-      label: "Metadata",
-      paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
-    },
-    advanced: {
-      label: "Advanced",
-      // defaultBackend is the catch-all when no rule matches; rare
-      // in practice but valid.
-      paths: ["spec.defaultBackend"],
-    },
+    sections: [
+      {
+        id: "primary",
+        label: "Routing & TLS",
+        paths: ["spec.ingressClassName", "spec.rules", "spec.tls"],
+        defaultOpen: true,
+      },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      {
+        id: "advanced",
+        label: "Advanced",
+        paths: ["spec.defaultBackend"],
+        showCount: true,
+      },
+    ],
     createOnly: ["metadata.name", "metadata.namespace"],
   },
+
+  // ─── Deployment ──────────────────────────────────────────────────────
+  Deployment: {
+    sections: [
+      {
+        id: "primary",
+        label: "Containers",
+        paths: [
+          "spec.replicas",
+          "spec.template.spec.containers",
+          "spec.template.spec.initContainers",
+        ],
+        defaultOpen: true,
+      },
+      {
+        id: "volumes",
+        label: "Volumes",
+        paths: ["spec.template.spec.volumes"],
+        openWhenPopulated: true,
+      },
+      {
+        id: "strategy",
+        label: "Strategy & lifecycle",
+        paths: [
+          "spec.strategy",
+          "spec.minReadySeconds",
+          "spec.revisionHistoryLimit",
+          "spec.progressDeadlineSeconds",
+          "spec.paused",
+          "spec.template.spec.terminationGracePeriodSeconds",
+          "spec.template.spec.restartPolicy",
+        ],
+      },
+      {
+        id: "podMetadata",
+        label: "Pod metadata",
+        paths: ["spec.template.metadata.labels", "spec.template.metadata.annotations"],
+      },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      {
+        id: "selector",
+        label: "Selector",
+        paths: ["spec.selector"],
+      },
+      {
+        id: "advanced",
+        label: "Advanced",
+        paths: [
+          "spec.template.spec.serviceAccountName",
+          "spec.template.spec.automountServiceAccountToken",
+          "spec.template.spec.imagePullSecrets",
+          "spec.template.spec.nodeSelector",
+          "spec.template.spec.affinity",
+          "spec.template.spec.tolerations",
+          "spec.template.spec.topologySpreadConstraints",
+          "spec.template.spec.securityContext",
+          "spec.template.spec.hostNetwork",
+          "spec.template.spec.hostPID",
+          "spec.template.spec.hostIPC",
+          "spec.template.spec.dnsPolicy",
+          "spec.template.spec.dnsConfig",
+          "spec.template.spec.priorityClassName",
+          "spec.template.spec.runtimeClassName",
+        ],
+        showCount: true,
+      },
+    ],
+    subSections: {
+      "spec.template.spec.containers": CONTAINER_SUBSECTIONS,
+      "spec.template.spec.initContainers": INIT_CONTAINER_SUBSECTIONS,
+    },
+    createOnly: ["metadata.name", "metadata.namespace", "spec.selector"],
+  },
+
+  // ─── StatefulSet ─────────────────────────────────────────────────────
+  // Adds a Persistent storage section for volumeClaimTemplates +
+  // retention policy. serviceName lives in primary (immutable, but
+  // conceptually part of "what this StatefulSet runs"). Strategy
+  // section uses updateStrategy instead of strategy.
+  StatefulSet: {
+    sections: [
+      {
+        id: "primary",
+        label: "Containers",
+        paths: [
+          "spec.replicas",
+          "spec.serviceName",
+          "spec.template.spec.containers",
+          "spec.template.spec.initContainers",
+        ],
+        defaultOpen: true,
+      },
+      {
+        id: "volumes",
+        label: "Volumes",
+        paths: ["spec.template.spec.volumes"],
+        openWhenPopulated: true,
+      },
+      {
+        id: "persistentStorage",
+        label: "Persistent storage",
+        paths: [
+          "spec.volumeClaimTemplates",
+          "spec.persistentVolumeClaimRetentionPolicy",
+          "spec.ordinals",
+        ],
+        openWhenPopulated: true,
+      },
+      {
+        id: "strategy",
+        label: "Strategy & lifecycle",
+        paths: [
+          "spec.updateStrategy",
+          "spec.podManagementPolicy",
+          "spec.minReadySeconds",
+          "spec.revisionHistoryLimit",
+          "spec.template.spec.terminationGracePeriodSeconds",
+          "spec.template.spec.restartPolicy",
+        ],
+      },
+      {
+        id: "podMetadata",
+        label: "Pod metadata",
+        paths: ["spec.template.metadata.labels", "spec.template.metadata.annotations"],
+      },
+      {
+        id: "metadata",
+        label: "Metadata",
+        paths: ["metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations"],
+      },
+      {
+        id: "selector",
+        label: "Selector",
+        paths: ["spec.selector"],
+      },
+      {
+        id: "advanced",
+        label: "Advanced",
+        paths: [
+          "spec.template.spec.serviceAccountName",
+          "spec.template.spec.automountServiceAccountToken",
+          "spec.template.spec.imagePullSecrets",
+          "spec.template.spec.nodeSelector",
+          "spec.template.spec.affinity",
+          "spec.template.spec.tolerations",
+          "spec.template.spec.topologySpreadConstraints",
+          "spec.template.spec.securityContext",
+          "spec.template.spec.hostNetwork",
+          "spec.template.spec.hostPID",
+          "spec.template.spec.hostIPC",
+          "spec.template.spec.dnsPolicy",
+          "spec.template.spec.dnsConfig",
+          "spec.template.spec.priorityClassName",
+          "spec.template.spec.runtimeClassName",
+        ],
+        showCount: true,
+      },
+    ],
+    subSections: {
+      "spec.template.spec.containers": CONTAINER_SUBSECTIONS,
+      "spec.template.spec.initContainers": INIT_CONTAINER_SUBSECTIONS,
+    },
+    createOnly: [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.selector",
+      "spec.serviceName",
+      "spec.podManagementPolicy",
+      "spec.volumeClaimTemplates",
+    ],
+  },
 };
+
+// ─── Public API ──────────────────────────────────────────────────────────
 
 export function isSupportedKind(kind: string): kind is SupportedKind {
   return kind in KIND_SPECS;
@@ -175,132 +429,153 @@ export function getCreateOnlyPaths(kind: SupportedKind): string[] {
   return KIND_SPECS[kind].createOnly;
 }
 
-/** Section labels for SchemaForm's grouped renderer. The primary
- *  label is kind-specific; metadata + advanced are constant. */
-export function getSectionLabels(kind: SupportedKind): {
-  primary: string;
-  metadata: string;
-  advanced: string;
-} {
-  const s = KIND_SPECS[kind];
-  return {
-    primary: s.primary.label,
-    metadata: s.metadata.label,
-    advanced: s.advanced.label,
-  };
+/** Return the section list for a kind, in render order. The renderer
+ *  iterates this to draw the L1 layout. */
+export function getSections(kind: SupportedKind): SectionSpec[] {
+  return KIND_SPECS[kind].sections;
 }
 
 /** Build a path → { section, displayOrder } resolver for the given
- *  kind. The walker calls this per top-level descriptor it emits;
- *  unmatched paths return undefined and the renderer puts them in a
- *  "Other" fallback section so future schema fields aren't dropped
- *  silently. Dev-mode duplicate-path detection runs once at build
- *  time and throws — a path may not legitimately appear in two
- *  section lists for the same kind. */
+ *  kind. The walker calls this per descriptor it emits during the
+ *  schema walk; unmatched paths return undefined and the renderer
+ *  puts them in a "Other" fallback section so future schema fields
+ *  aren't dropped silently.
+ *
+ *  Paths use `*` as the array-element boundary marker. So
+ *  `spec.template.spec.containers.*.image` matches the per-row
+ *  child stamped during the array-of-objects walk. The walker passes
+ *  these synthetic paths via parent-path concatenation; see
+ *  walker.walkObject for the construction.
+ *
+ *  Includes per-row sub-section stamps too — the array-of-objects
+ *  renderer consults `descriptor.section` on row children to do its
+ *  L2 grouping. */
 export function getSectionResolver(
   kind: SupportedKind,
 ): (path: string[]) => { section: FieldSection; displayOrder: number } | undefined {
   const spec = KIND_SPECS[kind];
   const map = new Map<string, { section: FieldSection; displayOrder: number }>();
-  const stamp = (paths: string[], section: FieldSection) => {
-    paths.forEach((p, i) => {
-      if (map.has(p)) {
-        // Authoring bug (same path in two sections). Surface loudly
-        // in dev so the duplicate is fixed at the spec level rather
-        // than silently winning the last write.
-        throw new Error(
-          `[k8sAllowlist] duplicate path "${p}" for ${kind}: already in section "${map.get(p)!.section}", trying to add to "${section}"`,
+  const stamp = (path: string, section: FieldSection, displayOrder: number) => {
+    if (map.has(path)) {
+      throw new Error(
+        `[k8sAllowlist] duplicate path "${path}" for ${kind}: already in section "${map.get(path)!.section}", trying to add to "${section}"`,
+      );
+    }
+    map.set(path, { section, displayOrder });
+  };
+  // L1: top-level sections.
+  for (const s of spec.sections) {
+    s.paths.forEach((p, i) => stamp(p, s.id, i));
+  }
+  // L2: per-row sub-sections inside arrays of objects. Stored under
+  // a synthetic path "<parent>.*.<child>" so the resolver matches
+  // when the walker descends into the array-element synthesizing
+  // exactly that path.
+  if (spec.subSections) {
+    for (const [parentPath, subs] of Object.entries(spec.subSections)) {
+      for (const sub of subs) {
+        sub.paths.forEach((childPath, i) =>
+          stamp(`${parentPath}.*.${childPath}`, sub.id, i),
         );
       }
-      map.set(p, { section, displayOrder: i });
-    });
-  };
-  stamp(spec.primary.paths, "primary");
-  stamp(spec.metadata.paths, "metadata");
-  stamp(spec.advanced.paths, "advanced");
-  return (path: string[]) => map.get(path.join("."));
+    }
+  }
+  return (path) => map.get(path.join("."));
 }
 
+/** Per-array-of-objects sub-section list. Renderer consults this when
+ *  rendering an array row to know how to group the row's children. */
+export function getRowSubSections(
+  kind: SupportedKind,
+  parentPath: string,
+): RowSubSection[] | undefined {
+  return KIND_SPECS[kind].subSections?.[parentPath];
+}
+
+// ─── Schema narrowing ────────────────────────────────────────────────────
+
 /** Return a narrowed schema whose `properties` only contain the
- *  metadata + spec subtrees the form should expose. Operates on the
- *  result of `derefIfNeeded` against the GVK root, so the input is
- *  expected to have a `properties` map (apiVersion/kind/metadata/
- *  spec/data/etc.). Falls back to the input untouched when the
- *  shape is unexpected (e.g. a CRD piped in by accident). */
+ *  allowlisted paths the form should expose. Recursive — handles
+ *  arbitrary depth and array-element wildcards (`*`). */
 export function filterSchemaForKind(schema: JSONSchema, kind: SupportedKind): JSONSchema {
   const spec = KIND_SPECS[kind];
   if (!schema || typeof schema !== "object") return schema;
+
+  // Collect every path across all sections + all sub-section row paths.
+  const allPaths: string[] = [];
+  for (const s of spec.sections) allPaths.push(...s.paths);
+  if (spec.subSections) {
+    for (const [parent, subs] of Object.entries(spec.subSections)) {
+      for (const sub of subs) {
+        for (const child of sub.paths) {
+          allPaths.push(`${parent}.*.${child}`);
+        }
+      }
+    }
+  }
+
+  const trie = buildPathTrie(allPaths);
+  return narrowBySectionTrie(schema, trie);
+}
+
+/** Path trie node. `terminal=true` means "include this node and the
+ *  whole subtree below it." Children handle deeper allowlist paths. */
+interface TrieNode {
+  terminal: boolean;
+  children: Map<string, TrieNode>;
+}
+
+function buildPathTrie(paths: string[]): TrieNode {
+  const root: TrieNode = { terminal: false, children: new Map() };
+  for (const p of paths) {
+    const segs = p.split(".");
+    let node = root;
+    for (const seg of segs) {
+      let next = node.children.get(seg);
+      if (!next) {
+        next = { terminal: false, children: new Map() };
+        node.children.set(seg, next);
+      }
+      node = next;
+    }
+    node.terminal = true;
+  }
+  return root;
+}
+
+function narrowBySectionTrie(schema: JSONSchema, trie: TrieNode): JSONSchema {
+  if (!schema || typeof schema !== "object") return schema;
+  // K8s wraps refs in `allOf:[{$ref:...}]` envelopes for many object
+  // types; can't narrow until the ref is resolved. Leave intact —
+  // walker resolves on its own and the trie still narrows at deeper
+  // levels via the resolver's path-based filtering.
+  if (schema.allOf || schema.$ref) return schema;
+
+  if (schema.type === "array") {
+    const wildcard = trie.children.get("*");
+    if (!wildcard) return schema;
+    const items = schema.items;
+    if (!items || typeof items !== "object") return schema;
+    return { ...schema, items: narrowBySectionTrie(items, wildcard) };
+  }
+
   if (!schema.properties) return schema;
-
-  // Collect every allowlisted path across all sections — this is
-  // what the schema narrowing operates on.
-  const allPaths = [
-    ...spec.primary.paths,
-    ...spec.metadata.paths,
-    ...spec.advanced.paths,
-  ];
-
-  const next: JSONSchema = { ...schema, properties: {}, required: [] };
-  const props = schema.properties;
-
-  // metadata: narrow to the allowlisted sub-fields. metadata paths
-  // are always of shape "metadata.<key>", so we strip the prefix.
-  const metadataKeys = spec.metadata.paths
-    .filter((p) => p.startsWith("metadata."))
-    .map((p) => p.slice("metadata.".length));
-  if (props.metadata && metadataKeys.length > 0) {
-    next.properties!.metadata = filterMetadata(props.metadata, metadataKeys);
-  }
-
-  // Top-level + nested-under-spec paths. Everything that doesn't
-  // start with `metadata.` either lives at the root (e.g. `data`,
-  // `binaryData`, `immutable`, `type`, `stringData`) or under spec.
-  const topLevel = new Set<string>();
-  const specSubFields = new Set<string>();
-  for (const p of allPaths) {
-    if (p.startsWith("metadata.")) continue;
-    if (p.startsWith("spec.")) specSubFields.add(p.slice("spec.".length));
-    else topLevel.add(p);
-  }
-
-  for (const key of topLevel) {
-    if (props[key]) next.properties![key] = props[key];
-  }
-
-  if (specSubFields.size > 0 && props.spec) {
-    next.properties!.spec = filterByKeys(props.spec, specSubFields);
-  }
-
-  // Preserve `required` only for fields we still surface — the
-  // renderer reads required[] off the parent.
-  const surfaced = new Set(Object.keys(next.properties!));
-  next.required = (schema.required ?? []).filter((r) => surfaced.has(r));
-
-  return next;
-}
-
-function filterMetadata(metadata: JSONSchema, allowed: string[]): JSONSchema {
-  if (!metadata || typeof metadata !== "object" || !metadata.properties) return metadata;
-  const next: JSONSchema = { ...metadata, properties: {} };
-  for (const key of allowed) {
-    if (metadata.properties[key]) next.properties![key] = metadata.properties[key];
-  }
-  // Required gets pruned to the surfaced set; metadata typically
-  // doesn't list required for these fields anyway.
-  if (Array.isArray(metadata.required)) {
-    next.required = metadata.required.filter((r) => allowed.includes(r));
-  }
-  return next;
-}
-
-function filterByKeys(schema: JSONSchema, allowed: Set<string>): JSONSchema {
-  if (!schema || typeof schema !== "object" || !schema.properties) return schema;
   const next: JSONSchema = { ...schema, properties: {} };
-  for (const key of allowed) {
-    if (schema.properties[key]) next.properties![key] = schema.properties[key];
+  for (const [key, child] of Object.entries(schema.properties)) {
+    const childTrie = trie.children.get(key);
+    if (!childTrie) continue;
+    if (childTrie.terminal && childTrie.children.size === 0) {
+      // Whole subtree included.
+      next.properties![key] = child;
+    } else {
+      // Recurse to narrow further.
+      next.properties![key] = narrowBySectionTrie(child as JSONSchema, childTrie);
+    }
   }
+  // Preserve `required` only for fields we still surface.
+  const surfaced = new Set(Object.keys(next.properties!));
   if (Array.isArray(schema.required)) {
-    next.required = schema.required.filter((r) => allowed.has(r));
+    next.required = schema.required.filter((r) => surfaced.has(r));
   }
   return next;
 }

--- a/web/src/lib/schemaForm/k8sAllowlist.ts
+++ b/web/src/lib/schemaForm/k8sAllowlist.ts
@@ -115,7 +115,6 @@ const CONTAINER_SUBSECTIONS: RowSubSection[] = [
     id: "primary",
     label: "Primary",
     paths: ["name", "image", "imagePullPolicy", "ports", "env", "envFrom", "resources"],
-    defaultOpen: true,
   },
   {
     id: "probes",
@@ -159,7 +158,7 @@ const INIT_CONTAINER_SUBSECTIONS: RowSubSection[] = CONTAINER_SUBSECTIONS.map((s
 const KIND_SPECS: Record<SupportedKind, KindSpec> = {
   ConfigMap: {
     sections: [
-      { id: "primary", label: "Data", paths: ["data", "binaryData"], defaultOpen: true },
+      { id: "primary", label: "Data", paths: ["data", "binaryData"] },
       {
         id: "metadata",
         label: "Metadata",
@@ -172,7 +171,7 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
 
   Secret: {
     sections: [
-      { id: "primary", label: "Data", paths: ["type", "data", "stringData"], defaultOpen: true },
+      { id: "primary", label: "Data", paths: ["type", "data", "stringData"] },
       {
         id: "metadata",
         label: "Metadata",
@@ -189,7 +188,6 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
         id: "primary",
         label: "Networking",
         paths: ["spec.type", "spec.selector", "spec.ports"],
-        defaultOpen: true,
       },
       {
         id: "metadata",
@@ -226,7 +224,6 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
         id: "primary",
         label: "Routing & TLS",
         paths: ["spec.ingressClassName", "spec.rules", "spec.tls"],
-        defaultOpen: true,
       },
       {
         id: "metadata",
@@ -254,7 +251,6 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
           "spec.template.spec.containers",
           "spec.template.spec.initContainers",
         ],
-        defaultOpen: true,
       },
       {
         id: "volumes",
@@ -336,7 +332,6 @@ const KIND_SPECS: Record<SupportedKind, KindSpec> = {
           "spec.template.spec.containers",
           "spec.template.spec.initContainers",
         ],
-        defaultOpen: true,
       },
       {
         id: "volumes",

--- a/web/src/lib/schemaForm/k8sDiscriminatorHints.ts
+++ b/web/src/lib/schemaForm/k8sDiscriminatorHints.ts
@@ -1,0 +1,154 @@
+// k8sDiscriminatorHints.ts — hint table for K8s schemas that
+// encode polymorphism via sibling properties instead of JSON
+// Schema `oneOf`. The walker consults this table (via
+// `WalkOptions.discriminatorHints`) and emits Shape B
+// discriminator descriptors for matched types.
+//
+// Every entry here corresponds to a K8s API type whose Go struct
+// uses pointer fields the apiserver rejects unless exactly one is
+// set, but whose OpenAPI v3 schema doesn't model that constraint.
+// Without the hint the walker would surface 30 sibling properties
+// for `Volume`, 4 for `Probe`'s handler, etc., all simultaneously
+// editable — operators could fill multiple branches at once and the
+// apply would 422 with a confusing message.
+//
+// Hints are matched against the `$ref` of the property's primary
+// type, looking through a single-element `allOf:[{$ref:...}]`
+// envelope (the standard kube-openapi shape).
+//
+// New types should be added here, NOT inferred structurally —
+// sibling-property polymorphism is a K8s convention, not a schema
+// pattern, so there's no reliable way to detect it without a list.
+
+import type { DiscriminatorHint } from "./walker";
+
+const REF = (name: string) => `#/components/schemas/${name}`;
+
+/** Build the K8s hint table. Returns a fresh Map per call so callers
+ *  can mutate it (e.g. to layer in CRD-specific hints) without
+ *  affecting other consumers. */
+export function buildK8sDiscriminatorHints(): Map<string, DiscriminatorHint> {
+  const t = new Map<string, DiscriminatorHint>();
+
+  // Probe — used by livenessProbe / readinessProbe / startupProbe.
+  // Branches: handler types. Shared: threshold knobs (rendered as
+  // sharedChildren by the walker).
+  t.set(REF("io.k8s.api.core.v1.Probe"), {
+    branches: ["httpGet", "tcpSocket", "exec", "grpc"],
+    labels: {
+      httpGet: "HTTP GET",
+      tcpSocket: "TCP socket",
+      exec: "exec",
+      grpc: "gRPC",
+    },
+  });
+
+  // LifecycleHandler — used by lifecycle.preStop / lifecycle.postStart.
+  // Pre-1.23 was named `Handler` — modern clusters expose this name.
+  t.set(REF("io.k8s.api.core.v1.LifecycleHandler"), {
+    branches: ["httpGet", "tcpSocket", "exec", "sleep"],
+    labels: {
+      httpGet: "HTTP GET",
+      tcpSocket: "TCP socket",
+      exec: "exec",
+      sleep: "sleep",
+    },
+  });
+
+  // EnvVarSource — used by env[*].valueFrom.
+  t.set(REF("io.k8s.api.core.v1.EnvVarSource"), {
+    branches: ["fieldRef", "resourceFieldRef", "configMapKeyRef", "secretKeyRef"],
+    labels: {
+      fieldRef: "Field reference",
+      resourceFieldRef: "Resource field reference",
+      configMapKeyRef: "ConfigMap key",
+      secretKeyRef: "Secret key",
+    },
+  });
+
+  // EnvFromSource — used by container `envFrom[]` items. `prefix`
+  // is shared (always-on); branches are configMapRef / secretRef.
+  t.set(REF("io.k8s.api.core.v1.EnvFromSource"), {
+    branches: ["configMapRef", "secretRef"],
+    labels: {
+      configMapRef: "ConfigMap",
+      secretRef: "Secret",
+    },
+  });
+
+  // Volume — used by spec.template.spec.volumes[]. `name` is
+  // shared (the volume's identifier); branches are the volume
+  // types. Many branches → renderer collapses to a <select>.
+  //
+  // We intentionally include the full set so operators don't see
+  // "yaml only" for an obscure volume type. The kube-openapi-listed
+  // names are stable across K8s versions; new types added by future
+  // APIs would silently render as siblings until added here (same
+  // failure mode as the rest of the schema-form pipeline).
+  t.set(REF("io.k8s.api.core.v1.Volume"), {
+    branches: [
+      "configMap",
+      "secret",
+      "emptyDir",
+      "persistentVolumeClaim",
+      "hostPath",
+      "projected",
+      "downwardAPI",
+      "csi",
+      "ephemeral",
+      "nfs",
+      "iscsi",
+      "fc",
+      "rbd",
+      "cephfs",
+      "glusterfs",
+      "gitRepo",
+      "azureDisk",
+      "azureFile",
+      "gcePersistentDisk",
+      "awsElasticBlockStore",
+      "vsphereVolume",
+      "cinder",
+      "flexVolume",
+      "flocker",
+      "photonPersistentDisk",
+      "portworxVolume",
+      "quobyte",
+      "scaleIO",
+      "storageos",
+              ],
+    labels: {
+      configMap: "ConfigMap",
+      secret: "Secret",
+      emptyDir: "emptyDir",
+      persistentVolumeClaim: "PVC",
+      hostPath: "hostPath",
+      projected: "Projected",
+      downwardAPI: "Downward API",
+      csi: "CSI",
+      ephemeral: "Ephemeral",
+      nfs: "NFS",
+      iscsi: "iSCSI",
+      fc: "Fibre Channel",
+      rbd: "RBD",
+      cephfs: "CephFS",
+      glusterfs: "GlusterFS",
+      gitRepo: "Git repo",
+      azureDisk: "Azure Disk",
+      azureFile: "Azure File",
+      gcePersistentDisk: "GCE PD",
+      awsElasticBlockStore: "AWS EBS",
+      vsphereVolume: "vSphere",
+      cinder: "Cinder",
+      flexVolume: "FlexVolume",
+      flocker: "Flocker",
+      photonPersistentDisk: "Photon PD",
+      portworxVolume: "Portworx",
+      quobyte: "Quobyte",
+      scaleIO: "ScaleIO",
+      storageos: "StorageOS",
+    },
+  });
+
+  return t;
+}

--- a/web/src/lib/schemaForm/sections.ts
+++ b/web/src/lib/schemaForm/sections.ts
@@ -4,36 +4,50 @@
 // react-refresh/only-export-components lint rule fires when a
 // component module also exports plain functions).
 
-import type { FieldDescriptor } from "./types";
+import type { FieldDescriptor, FieldSection } from "./types";
 
+/** Map<section id → descriptors> + an aggregate total. The renderer
+ *  iterates the kind's declared section list (from k8sAllowlist) in
+ *  order and pulls each section's bucket from this map. Sections
+ *  that don't appear in the map at all simply render empty. */
 export interface SectionedBuckets {
-  primary: FieldDescriptor[];
-  metadata: FieldDescriptor[];
-  advanced: FieldDescriptor[];
+  byId: Map<FieldSection, FieldDescriptor[]>;
   total: number;
 }
 
-// Walk the descriptor tree and collect every descriptor whose walker
-// stamped a section. Descriptors land in the bucket directly, even if
-// they are nested children of an unsectioned object container (e.g.
-// `metadata.name` is collected under "metadata" while its parent
-// `metadata` descriptor itself is unsectioned and gets dropped from
-// the layout).
+/** Walk the descriptor tree and collect every descriptor whose walker
+ *  stamped a section. Descriptors land in their bucket directly,
+ *  even if they are nested children of an unsectioned object
+ *  container (e.g. `metadata.name` is collected under `metadata`
+ *  while its parent `metadata` descriptor itself is unsectioned and
+ *  gets dropped from the layout).
+ *
+ *  STOPS at array-of-objects boundaries: per-row children of an
+ *  array-of-objects descriptor are L2 — the array's renderer groups
+ *  them inside each row, not the form-level L1 layout.
+ *  `discriminator` descriptors stop for the same reason — their
+ *  branch children belong inside the picker, not the L1 layout. */
 export function collectSectioned(
   descriptors: FieldDescriptor[],
 ): SectionedBuckets {
-  const buckets: SectionedBuckets = {
-    primary: [],
-    metadata: [],
-    advanced: [],
-    total: 0,
+  const byId = new Map<FieldSection, FieldDescriptor[]>();
+  let total = 0;
+  const push = (id: FieldSection, d: FieldDescriptor) => {
+    let arr = byId.get(id);
+    if (!arr) {
+      arr = [];
+      byId.set(id, arr);
+    }
+    arr.push(d);
+    total += 1;
   };
   const visit = (d: FieldDescriptor) => {
     if (d.section) {
-      buckets[d.section].push(d);
-      buckets.total += 1;
+      push(d.section, d);
     }
-    if (d.children) {
+    // L1 collection stops at array-of-objects + discriminator
+    // boundaries; their inner descriptors are L2 / branch-local.
+    if (d.children && d.type !== "array-of-objects" && d.type !== "discriminator") {
       for (const c of d.children) visit(c);
     }
   };
@@ -41,15 +55,64 @@ export function collectSectioned(
   const byOrder = (a: FieldDescriptor, b: FieldDescriptor) =>
     (a.displayOrder ?? Number.MAX_SAFE_INTEGER) -
     (b.displayOrder ?? Number.MAX_SAFE_INTEGER);
-  buckets.primary.sort(byOrder);
-  buckets.metadata.sort(byOrder);
-  buckets.advanced.sort(byOrder);
-  return buckets;
+  for (const arr of byId.values()) arr.sort(byOrder);
+  return { byId, total };
+}
+
+/** L2 grouping for array-of-objects ROW children. Same shape as
+ *  collectSectioned but operates on a flat row-children list (which
+ *  is what the array-of-objects descriptor exposes). Doesn't recurse
+ *  past array-of-objects — nested arrays inside a row would need
+ *  their own L3 sub-section spec, which we don't support yet. */
+export function collectRowSubSections(
+  rowChildren: FieldDescriptor[],
+): SectionedBuckets {
+  const byId = new Map<FieldSection, FieldDescriptor[]>();
+  let total = 0;
+  for (const d of rowChildren) {
+    if (d.section) {
+      let arr = byId.get(d.section);
+      if (!arr) {
+        arr = [];
+        byId.set(d.section, arr);
+      }
+      arr.push(d);
+      total += 1;
+    }
+  }
+  const byOrder = (a: FieldDescriptor, b: FieldDescriptor) =>
+    (a.displayOrder ?? Number.MAX_SAFE_INTEGER) -
+    (b.displayOrder ?? Number.MAX_SAFE_INTEGER);
+  for (const arr of byId.values()) arr.sort(byOrder);
+  return { byId, total };
 }
 
 export function descendantHasSection(d: FieldDescriptor): boolean {
   if (!d.children) return false;
+  // Don't peek into array-of-objects rows — their stamps belong to
+  // L2, not the L1 grouping.
+  if (d.type === "array-of-objects" || d.type === "discriminator") return false;
   return d.children.some(
     (c) => c.section !== undefined || descendantHasSection(c),
   );
+}
+
+/** Return true if the descriptor's value is "populated" — used by the
+ *  openWhenPopulated section flag. Conservative definition: an array
+ *  with ≥1 element, an object with ≥1 own key, a non-empty string, or
+ *  a non-undefined boolean / number. */
+export function descriptorHasContent(
+  descriptor: FieldDescriptor,
+  values: Record<string, unknown>,
+): boolean {
+  let cursor: unknown = values;
+  for (const seg of descriptor.path) {
+    if (cursor == null || typeof cursor !== "object") return false;
+    cursor = (cursor as Record<string, unknown>)[seg];
+  }
+  if (cursor == null) return false;
+  if (Array.isArray(cursor)) return cursor.length > 0;
+  if (typeof cursor === "object") return Object.keys(cursor).length > 0;
+  if (typeof cursor === "string") return cursor.length > 0;
+  return true;
 }

--- a/web/src/lib/schemaForm/types.ts
+++ b/web/src/lib/schemaForm/types.ts
@@ -60,7 +60,33 @@ export type FieldType =
  *  supplied. Children of object descriptors inherit visually from
  *  their parent — only top-level descriptors carry an explicit
  *  section. */
-export type FieldSection = "primary" | "metadata" | "advanced";
+export type FieldSection = string;
+
+/** Per-row sub-section config. The walker stamps an array-of-objects
+ *  descriptor with `rowSubSections` so the renderer knows how to
+ *  group the row's children into Primary / Probes / Mounts /
+ *  Container advanced (or whatever the kind has declared). */
+export interface RowSubSectionConfig {
+  id: FieldSection;
+  label: string;
+  defaultOpen?: boolean;
+  openWhenPopulated?: boolean;
+  showCount?: boolean;
+}
+
+/** Sibling-property hint for K8s-style polymorphism — see WalkOptions
+ *  `discriminatorHints`. K8s encodes Probe / Volume / EnvVarSource /
+ *  LifecycleHandler this way (mutually exclusive sibling props with
+ *  no `oneOf`); the hint table tells the walker to emit a Shape B
+ *  discriminator instead of a flat object. */
+export interface DiscriminatorHint {
+  /** Property keys that are mutually exclusive — exactly one of them
+   *  should be set on the value at a time. The walker emits one
+   *  branch per key. */
+  branches: string[];
+  /** Optional human label per branch (defaults to the key). */
+  labels?: Record<string, string>;
+}
 
 /** One option in a `discriminator`-typed field. The renderer shows a
  *  branch picker (segmented buttons) and recurses into the chosen
@@ -106,6 +132,12 @@ export interface FieldDescriptor {
    *  between. The renderer recurses into the chosen branch's
    *  schema to render the sub-form. */
   branches?: DiscriminatorBranch[];
+  /** For type=discriminator (hinted shape): properties that are
+   *  NOT branch picks but should still render alongside the picker
+   *  (e.g. Probe's thresholds — initialDelaySeconds, periodSeconds —
+   *  rendered above the branch-specific sub-form, preserved across
+   *  branch switches). */
+  sharedChildren?: FieldDescriptor[];
   /** Constraints surfaced for inline validation hints. */
   pattern?: string;
   format?: string;
@@ -129,6 +161,11 @@ export interface FieldDescriptor {
    *  Set alongside `section` by the walker. When unset, descriptors
    *  fall back to schema-walk order within their section. */
   displayOrder?: number;
+  /** Sub-section grouping for an array-of-objects descriptor's row
+   *  children. Stamped by the walker when WalkOptions.subSectionResolver
+   *  matches. Renderer reads this list to draw L2 sections (e.g.
+   *  Primary / Probes / Mounts / Container advanced) inside each row. */
+  rowSubSections?: RowSubSectionConfig[];
 }
 
 export interface ValidationIssue {

--- a/web/src/lib/schemaForm/useFormOpen.ts
+++ b/web/src/lib/schemaForm/useFormOpen.ts
@@ -1,0 +1,148 @@
+// schemaForm/useFormOpen.ts — open-state hook for the form's
+// collapsible sections, sub-sections, and array-of-objects rows.
+//
+// Model:
+//   - Every collapsible element has a stable string id (e.g.
+//     `section.primary`, `row.spec.template.spec.containers[0]`,
+//     `subsection.spec.template.spec.containers[0].probes`).
+//   - State carries a single `mode` ("default-closed" | "default-open")
+//     plus a Set<string> of `overrides`. An element is open iff:
+//       mode === "default-open" XOR overrides.has(id)
+//     i.e. overrides flip the default for clicked elements.
+//   - Toggling a single element flips its membership in `overrides`.
+//   - Expand-all switches mode to "default-open" and clears overrides.
+//   - Collapse-all switches mode to "default-closed" and clears overrides.
+//
+// LocalStorage persistence:
+//   When `formKey` is provided, the FIRST L1 section the user opens
+//   from a fresh-default-closed state gets remembered. On next mount
+//   that id is restored as a single-element override (so the form
+//   opens with that section already expanded). Only the most-recent
+//   single click is remembered — to keep "default-closed" the
+//   genuine zero state.
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+
+export type OpenMode = "default-closed" | "default-open";
+
+export interface FormOpenApi {
+  /** True iff the element with the given id should render open. */
+  isOpen: (id: string) => boolean;
+  /** Flip the open state of a single element. */
+  toggle: (id: string) => void;
+  /** Set every element to open (mode=open, clear overrides). */
+  expandAll: () => void;
+  /** Set every element to closed (mode=closed, clear overrides). */
+  collapseAll: () => void;
+  /** Coarse "are we entirely default-closed with no overrides?" — the
+   *  collapse-all button can disable itself when this is true. */
+  isAllCollapsed: boolean;
+  /** Coarse "are we entirely default-open with no overrides?" — the
+   *  expand-all button can disable itself when this is true. */
+  isAllExpanded: boolean;
+}
+
+interface State {
+  mode: OpenMode;
+  overrides: Set<string>;
+}
+
+const STORAGE_PREFIX = "periscope.form.lastOpened.";
+
+export function useFormOpen(formKey?: string): FormOpenApi {
+  // Restore last-opened L1 section from localStorage on mount.
+  const initial = useMemo<State>(() => {
+    if (!formKey || typeof window === "undefined") {
+      return { mode: "default-closed", overrides: new Set() };
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_PREFIX + formKey);
+      if (stored) {
+        return { mode: "default-closed", overrides: new Set([stored]) };
+      }
+    } catch {
+      /* localStorage unavailable (Safari private mode, etc.) — fall
+       * through to fresh-closed. */
+    }
+    return { mode: "default-closed", overrides: new Set() };
+  }, [formKey]);
+
+  const [state, setState] = useState<State>(initial);
+  // Track the previous overrides set to detect "first L1 click" for
+  // localStorage persistence. We only remember single L1 clicks —
+  // L2 sub-section clicks and row toggles aren't worth persisting
+  // (would be noise in the restore).
+  const prevOverridesRef = useRef<Set<string>>(initial.overrides);
+
+  const persistIfFirstL1Click = useCallback(
+    (next: Set<string>) => {
+      if (!formKey || typeof window === "undefined") return;
+      // Only persist if going from empty → 1 entry AND that entry
+      // is an L1 section.
+      if (
+        prevOverridesRef.current.size === 0 &&
+        next.size === 1
+      ) {
+        const onlyId = next.values().next().value as string;
+        if (onlyId.startsWith("section.")) {
+          try {
+            window.localStorage.setItem(STORAGE_PREFIX + formKey, onlyId);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+      prevOverridesRef.current = next;
+    },
+    [formKey],
+  );
+
+  const isOpen = useCallback(
+    (id: string) => {
+      const overridden = state.overrides.has(id);
+      return state.mode === "default-open" ? !overridden : overridden;
+    },
+    [state],
+  );
+
+  const toggle = useCallback(
+    (id: string) => {
+      setState((prev) => {
+        const next = new Set(prev.overrides);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        persistIfFirstL1Click(next);
+        return { mode: prev.mode, overrides: next };
+      });
+    },
+    [persistIfFirstL1Click],
+  );
+
+  const expandAll = useCallback(() => {
+    setState({ mode: "default-open", overrides: new Set() });
+    prevOverridesRef.current = new Set();
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    setState({ mode: "default-closed", overrides: new Set() });
+    prevOverridesRef.current = new Set();
+  }, []);
+
+  const isAllCollapsed = state.mode === "default-closed" && state.overrides.size === 0;
+  const isAllExpanded = state.mode === "default-open" && state.overrides.size === 0;
+
+  return { isOpen, toggle, expandAll, collapseAll, isAllCollapsed, isAllExpanded };
+}
+
+// FormOpenContext — provides the open-state API to nested
+// renderers (ArrayRow, ArrayRowChildren) without prop drilling.
+// Lives here rather than in SchemaForm.tsx so the latter only
+// exports React components (react-refresh/only-export-components
+// rule).
+
+
+export const FormOpenContext = createContext<FormOpenApi | null>(null);
+
+export function useFormOpenContext(): FormOpenApi | null {
+  return useContext(FormOpenContext);
+}

--- a/web/src/lib/schemaForm/walker.test.ts
+++ b/web/src/lib/schemaForm/walker.test.ts
@@ -619,3 +619,96 @@ describe("walker — sectionResolver stamps descriptor.section + displayOrder", 
     }
   });
 });
+
+describe("walker — array-of-objects row child sub-section stamping (#136)", () => {
+  // Synthetic Deployment-like schema with a containers array.
+  // Tests that the walker stamps row children with the synthetic
+  // "*"-bearing absolute path, and stashes rowSubSections on the
+  // array descriptor.
+  const schema: JSONSchema = {
+    type: "object",
+    properties: {
+      spec: {
+        type: "object",
+        properties: {
+          template: {
+            type: "object",
+            properties: {
+              spec: {
+                type: "object",
+                properties: {
+                  containers: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        image: { type: "string" },
+                        livenessProbe: { type: "object", properties: { failureThreshold: { type: "integer" } } },
+                        command: { type: "array", items: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it("stamps row children with sub-section ids via synthetic `*` paths", () => {
+    const ds = buildFieldDescriptors(schema, {
+      allowArrayOfObjects: true,
+      sectionResolver: getSectionResolver("Deployment"),
+      subSectionResolver: (parentPath) => {
+        return parentPath.join(".") === "spec.template.spec.containers"
+          ? [
+              { id: "primary", label: "Primary", defaultOpen: true },
+              { id: "probes", label: "Probes" },
+              { id: "advanced", label: "Container advanced" },
+            ]
+          : undefined;
+      },
+    });
+
+    // Drill down to the containers descriptor.
+    const spec = ds.find((d) => d.path.join(".") === "spec");
+    const template = spec?.children?.find((c) => c.path.join(".") === "spec.template");
+    const podSpec = template?.children?.find((c) => c.path.join(".") === "spec.template.spec");
+    const containers = podSpec?.children?.find(
+      (c) => c.path.join(".") === "spec.template.spec.containers",
+    );
+
+    expect(containers?.type).toBe("array-of-objects");
+    expect(containers?.rowSubSections?.map((s) => s.id)).toEqual([
+      "primary",
+      "probes",
+      "advanced",
+    ]);
+
+    // Row children carry section stamps from the resolver via the
+    // synthetic "containers.*.image" / etc. lookup.
+    const rowChildren = containers?.children ?? [];
+    const byPath = (p: string) => rowChildren.find((c) => c.path.join(".") === p);
+
+    expect(byPath("name")?.section).toBe("primary");
+    expect(byPath("image")?.section).toBe("primary");
+    expect(byPath("livenessProbe")?.section).toBe("probes");
+    expect(byPath("command")?.section).toBe("advanced");
+  });
+
+  it("returns undefined rowSubSections when subSectionResolver is omitted", () => {
+    const ds = buildFieldDescriptors(schema, {
+      allowArrayOfObjects: true,
+      sectionResolver: getSectionResolver("Deployment"),
+    });
+    const containers = ds
+      .find((d) => d.path.join(".") === "spec")
+      ?.children?.find((c) => c.path.join(".") === "spec.template")
+      ?.children?.find((c) => c.path.join(".") === "spec.template.spec")
+      ?.children?.find((c) => c.path.join(".") === "spec.template.spec.containers");
+    expect(containers?.rowSubSections).toBeUndefined();
+  });
+});

--- a/web/src/lib/schemaForm/walker.ts
+++ b/web/src/lib/schemaForm/walker.ts
@@ -9,11 +9,15 @@
 
 import { mergeAllOf } from "./allOfMerger";
 import type {
+  DiscriminatorHint,
+  RowSubSectionConfig,
   DiscriminatorBranch,
   FieldDescriptor,
   FieldSection,
   JSONSchema,
 } from "./types";
+
+export type { DiscriminatorHint, RowSubSectionConfig } from "./types";
 
 export interface WalkOptions {
   /** Resolve a `$ref` string (e.g. "#/components/schemas/...") to a
@@ -46,6 +50,22 @@ export interface WalkOptions {
   sectionResolver?: (
     path: string[],
   ) => { section: FieldSection; displayOrder: number } | undefined;
+  /** Per-array-of-objects sub-section table. Called with the
+   *  array's parent path; if the kind has declared row
+   *  sub-sections for this array (e.g. Container Primary /
+   *  Probes / Mounts / Advanced for `spec.template.spec.containers`),
+   *  the resolver returns the ordered config list. The walker
+   *  stashes it on the array-of-objects descriptor as
+   *  `rowSubSections`; the renderer reads that to draw L2 blocks
+   *  inside each row. */
+  subSectionResolver?: (parentPath: string[]) => RowSubSectionConfig[] | undefined;
+  /** Sibling-property polymorphism hint table — see DiscriminatorHint.
+   *  Map key is the schema's `$ref` string (matched against the
+   *  property's primary ref before deref — covers both
+   *  `{$ref: X}` and `{allOf: [{$ref: X}]}` envelopes). When matched,
+   *  the walker emits a Shape B-style discriminator over `branches[]`
+   *  with the remaining (non-branch) properties as `sharedChildren`. */
+  discriminatorHints?: Map<string, DiscriminatorHint>;
 }
 
 /** Walk schema, emit a tree of field descriptors. */
@@ -137,6 +157,15 @@ function walkFieldImpl(
   // other's resolution state, or `Outer { a: Inner, b: Inner }`
   // would emit `b` as recursive even though it isn't.
   const seen = new Set(parentSeen);
+  // Discriminator hint pre-detect — match raw schema's primary $ref
+  // BEFORE deref so we can recognise K8s envelopes like
+  // `{allOf:[{$ref: Probe}]}` before they collapse into a flat object
+  // structurally indistinguishable from any other K8s sub-resource.
+  // Look up up front; act on it after deref (we still need the
+  // resolved properties to build the branch sub-forms).
+  const primaryRef = extractPrimaryRef(raw);
+  const hint =
+    primaryRef !== undefined ? options.discriminatorHints?.get(primaryRef) : undefined;
   // Resolve a $ref before reading the rest of the fields so the
   // walker can see the underlying type/properties.
   const schema = derefIfNeeded(raw, options, seen);
@@ -157,6 +186,21 @@ function walkFieldImpl(
     default: schema.default,
     ...(createOnly ? { editable: "create-only" as const } : {}),
   };
+
+  // Hinted discriminator: the host schema told us this type is
+  // a sibling-encoded oneOf. Build a Shape B-style picker over
+  // `hint.branches`; remaining properties become sharedChildren
+  // (rendered alongside the picker, preserved across branch
+  // switches). This is THE bridge that makes K8s Probe / Volume /
+  // EnvVarSource / LifecycleHandler render as proper discriminators
+  // even though their JSON Schema doesn't use `oneOf`.
+  if (hint && schema.properties) {
+    const built = buildHintedDiscriminator(schema, hint, options, seen);
+    if (built) {
+      return { ...base, type: "discriminator", ...built };
+    }
+    // Fall through when no branch keys present in resolved schema.
+  }
 
   // oneOf detection — emit a discriminator descriptor instead of
   // unsupported. Two structural shapes:
@@ -274,11 +318,26 @@ function walkFieldImpl(
         // Children paths are RELATIVE to the row item, not absolute
         // from the form root. The array-of-objects widget composes
         // the absolute path at render time.
-        return {
+        const rowChildren = walkObject(resolvedItems, [], options, seen);
+        // Stamp row children with section/displayOrder via synthetic
+        // absolute paths (parent path + "*" + child path). The
+        // resolver's key map for kinds with sub-sections has those
+        // synthetic keys baked in (see k8sAllowlist.getSectionResolver).
+        if (options.sectionResolver) {
+          stampRowChildrenSections(rowChildren, [...path, "*"], options.sectionResolver);
+        }
+        const arrayDesc: FieldDescriptor = {
           ...base,
           type: "array-of-objects",
-          children: walkObject(resolvedItems, [], options, seen),
+          children: rowChildren,
         };
+        // Stash the kind's row sub-section list on the descriptor so
+        // the renderer can draw L2 blocks inside each row.
+        if (options.subSectionResolver) {
+          const subs = options.subSectionResolver(path);
+          if (subs) arrayDesc.rowSubSections = subs;
+        }
+        return arrayDesc;
       }
       return {
         ...base,
@@ -509,4 +568,97 @@ function branchLabelFor(
   // Last resort. Operators editing CRDs with poorly-titled schemas
   // see "option N" — imperfect but better than yaml-only.
   return `option ${(fallbackIdx ?? 0) + 1}`;
+}
+
+// stampRowChildrenSections walks an array-of-objects descriptor's
+// row children and stamps `section` + `displayOrder` from a section
+// resolver, using a synthetic absolute path computed as
+// [...prefix, ...descriptor.path]. `prefix` is the array's parent
+// path with `*` appended (e.g. ["spec","template","spec","containers","*"]).
+//
+// Doesn't recurse into nested arrays-of-objects or discriminator
+// children — those carry their own walks and would conflict.
+function stampRowChildrenSections(
+  descriptors: FieldDescriptor[],
+  prefix: string[],
+  resolver: (path: string[]) => { section: FieldSection; displayOrder: number } | undefined,
+) {
+  for (const d of descriptors) {
+    const absolute = [...prefix, ...d.path];
+    const sec = resolver(absolute);
+    if (sec) {
+      d.section = sec.section;
+      d.displayOrder = sec.displayOrder;
+    }
+    if (d.children && d.type !== "array-of-objects" && d.type !== "discriminator") {
+      stampRowChildrenSections(d.children, prefix, resolver);
+    }
+  }
+}
+
+// extractPrimaryRef pulls the schema's $ref BEFORE deref. Looks
+// through a single-element `allOf:[{$ref:...}]` envelope (the standard
+// kube-openapi shape). Returns undefined when the schema isn't a ref
+// or has more complex structure.
+function extractPrimaryRef(schema: JSONSchema): string | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  if (typeof schema.$ref === "string") return schema.$ref;
+  if (Array.isArray(schema.allOf) && schema.allOf.length === 1) {
+    const entry = schema.allOf[0] as JSONSchema | undefined;
+    if (entry && typeof entry === "object" && typeof entry.$ref === "string") {
+      return entry.$ref;
+    }
+  }
+  return undefined;
+}
+
+// buildHintedDiscriminator constructs a Shape B-style discriminator
+// from a hint table entry. Each entry in hint.branches becomes a
+// branch with the corresponding property's schema; remaining
+// properties become sharedChildren (e.g. Probe's threshold knobs
+// render alongside the branch picker, preserved across switches).
+function buildHintedDiscriminator(
+  schema: JSONSchema,
+  hint: DiscriminatorHint,
+  options: WalkOptions,
+  parentSeen: Set<string>,
+): { branches: DiscriminatorBranch[]; sharedChildren?: FieldDescriptor[] } | undefined {
+  const props = schema.properties ?? {};
+  const branchKeys = hint.branches.filter((k) => k in props);
+  if (branchKeys.length === 0) return undefined;
+
+  const branches: DiscriminatorBranch[] = [];
+  for (const key of branchKeys) {
+    const sub = props[key];
+    if (!sub) continue;
+    const seen = new Set(parentSeen);
+    const descriptors = walkBranchSchema(sub, [key], options, seen);
+    branches.push({
+      label: hint.labels?.[key] ?? branchLabelFor(sub, key),
+      description: typeof sub.description === "string" ? sub.description : undefined,
+      schema: sub,
+      discriminatorKey: key,
+      descriptors,
+    });
+  }
+  if (branches.length === 0) return undefined;
+
+  // Remaining properties become sharedChildren — walked as relative-
+  // path descriptors rooted at [key] (consistent with the Shape B
+  // discriminator path convention).
+  const branchSet = new Set(branchKeys);
+  const sharedChildren: FieldDescriptor[] = [];
+  const requiredSet = new Set(schema.required ?? []);
+  for (const key of Object.keys(props)) {
+    if (branchSet.has(key)) continue;
+    const childSeen = new Set(parentSeen);
+    sharedChildren.push(
+      walkField(props[key], [key], requiredSet.has(key), options, childSeen),
+    );
+  }
+
+  return {
+    branches,
+    sharedChildren: sharedChildren.length > 0 ? sharedChildren : undefined,
+  };
 }

--- a/web/src/lib/schemaForm/walker.ts
+++ b/web/src/lib/schemaForm/walker.ts
@@ -318,7 +318,44 @@ function walkFieldImpl(
         // Children paths are RELATIVE to the row item, not absolute
         // from the form root. The array-of-objects widget composes
         // the absolute path at render time.
-        const rowChildren = walkObject(resolvedItems, [], options, seen);
+        // Hint check at the row-schema level: if the row schema is a
+        // sibling-encoded discriminator (Volume, EnvVarSource, etc.),
+        // emit a single discriminator descriptor as the row's only
+        // child instead of dumping all ~30 sibling properties as
+        // simultaneously editable fieldsets. Same hint table the
+        // walkField hint detection uses, just applied at the
+        // array-item boundary the array case otherwise bypasses.
+        const itemPrimaryRef = extractPrimaryRef(items);
+        const itemHint = itemPrimaryRef !== undefined
+          ? options.discriminatorHints?.get(itemPrimaryRef)
+          : undefined;
+        let rowChildren: FieldDescriptor[];
+        if (itemHint && resolvedItems.properties) {
+          const built = buildHintedDiscriminator(
+            resolvedItems,
+            itemHint,
+            options,
+            seen,
+          );
+          if (built) {
+            const rowLabel = (resolvedItems.title as string) || "";
+            const discDesc: FieldDescriptor = {
+              path: [],
+              label: rowLabel,
+              description: typeof resolvedItems.description === "string"
+                ? resolvedItems.description
+                : undefined,
+              type: "discriminator",
+              required: false,
+              ...built,
+            };
+            rowChildren = [discDesc];
+          } else {
+            rowChildren = walkObject(resolvedItems, [], options, seen);
+          }
+        } else {
+          rowChildren = walkObject(resolvedItems, [], options, seen);
+        }
         // Stamp row children with section/displayOrder via synthetic
         // absolute paths (parent path + "*" + child path). The
         // resolver's key map for kinds with sub-sections has those


### PR DESCRIPTION
## Summary

Extends the schema-aware form editor to workloads. Builds on the L1 sectioning landed in #144.

**L1 sections (per-kind layout)**
- Generalizes `KindSpec` from a fixed 3-section shape to an ordered `SectionSpec[]` with `id` / `label` / `defaultOpen` / `openWhenPopulated` / `showCount` knobs. ConfigMap / Secret / Service / Ingress migrate cleanly to the same model with 3 sections each.
- **Deployment** gets 7 sections: Containers → Volumes (open when populated) → Strategy & lifecycle → Pod metadata → Metadata → Selector (read-only post-create) → Advanced (15-field count).
- **StatefulSet** adds a Persistent storage section (volumeClaimTemplates + retention policy + ordinals). `serviceName` lives in the primary alongside containers.

**L2 sub-sections inside container array rows**
- Container row split into Primary (image / env / resources / ports) → Probes & lifecycle → Volume mounts (auto-expanding) → Container advanced (count). InitContainers reuses the spec sans the lifecycle hook entry.
- Walker stamps row children with a synthetic `*`-bearing absolute path so the same Map-based section resolver works for both flat and nested cases. Array-of-objects descriptors carry the `RowSubSectionConfig` list inline; renderer reads it to draw L2 blocks at lighter visual weight.

**K8s polymorphism support**
- Probe / LifecycleHandler / Volume / EnvVarSource render as proper discriminator pickers via a `WalkOptions.discriminatorHints` table mapping `$ref` → branch list. Array-of-objects rows whose item schema matches a hint (Volume[], EnvFromSource[], etc.) collapse into a single discriminator-picker child per row instead of dumping all ~25 sibling volume types as simultaneously editable fieldsets — the Ephemeral / PVCTemplate footgun.

**UX: collapse-all by default + expand/collapse buttons**
- Every L1 section, L2 sub-section, and container row starts collapsed. Operators open what they need to edit.
- VSCode-style `+ expand all` / `− collapse all` toolbar in the form header sweeps every accordion at every depth in one click.
- localStorage memory under `periscope.form.lastOpened.<kind>` — first L1 section the user opens from a clean default-closed state is remembered; next visit to the same kind opens that section immediately.

**Layout containment for deeply-nested fields**
- Path breadcrumb hint dropped at depth > 4 (the surrounding fieldset legends already locate the field at that depth). Shallower paths keep the breadcrumb with `block min-w-0 truncate` + `title=` tooltip for the full path.
- Outer flex containers gain `min-w-0` so child truncation actually applies.

**Schema narrowing**
- `filterSchemaForKind` rewritten with a recursive path trie that handles arbitrary depth + `*` wildcard (e.g. `spec.template.spec.containers.*.image`).

Closes #136. Supersedes #135 — design borrowed (per-row sub-sections, discriminator hint pattern), but rebuilt against the post-#144 sectioning system.

## Test plan

- [x] `pnpm lint` clean
- [x] `npx tsc -b --noEmit` clean
- [x] `pnpm test` — 301 / 301 (was 281 pre-PR; +20 new walker / SchemaForm / arrayRowSummary cases)
- [ ] Manual smoke on kind cluster's `ct-writer` Deployment:
  - [ ] All sections start collapsed; opening Containers shows the expected primary fields
  - [ ] Container row sub-sections (Primary / Probes / Mounts / Container advanced) render as nested `<details>`
  - [ ] Volumes section: each row renders a discriminator picker; Ephemeral expands the PVCTemplate cleanly without overflow
  - [ ] Affinity → NodeAffinity → preferredDuringScheduling… renders without horizontal scroll or clipped breadcrumb
  - [ ] `+ expand all` / `− collapse all` buttons sweep every depth
  - [ ] Reopen the form for the same Deployment; the section you last opened is restored
  - [ ] StatefulSet form renders the Persistent storage section with `volumeClaimTemplates`
  - [ ] ConfigMap / Secret / Service / Ingress forms still work with their 3-section layout (back-compat)
  - [ ] Helm install/upgrade dialog still renders flat (back-compat sanity)