### PR TITLE
docs(audit): RFC 0003-4 + Helm verbs + filter strip + round-trip test

### DIFF
--- a/docs/rfcs/0003-audit-log.md
+++ b/docs/rfcs/0003-audit-log.md
@@ -114,6 +114,16 @@ are not allowed — every emission site uses a `audit.Verb*` constant.
 | `bulk_download` | `bulkDownloadAuditHandler` (POST `/api/clusters/{c}/audit/bulk-download`, called by the SPA after a bulk YAML download resolves) | `success` (≥1 fetch succeeded) / `failure` (zero fetches succeeded) | `kind: string`, `count: int`, `ids: []string` (server-truncated to 50), `failure_count: int` |
 | `exec_open` | `execHandler` immediately after session admit | `success` only | `session_id`, `container`, `tty`, `command`, `k8s_identity`, `started_at` |
 | `exec_close` | `execHandler` once `execsess.Run` returns | `success` / `failure` | all `exec_open` fields plus `transport`, `ended_at`, `duration_ms`, `exit_code`, `bytes_stdin`, `bytes_stdout`, `err`. `Reason` carries the close disposition: `completed` / `idle_timeout` / `abort` / `server_error` |
+| `helm_chart_fetch` | `helmChartHandler` (POST `/api/clusters/{c}/helm/chart/values`) | `success` / `failure` | `ref: string`, `chart: string`, `version: string`, `cached: bool` |
+| `helm_preview` | `helmInstallPreviewHandler` / `helmUpgradePreviewHandler` | `success` / `failure` / `denied` | `op: "install" | "upgrade"`. `denied` outcome carries the SAR pre-flight verdict in `Reason`. |
+| `helm_install_intent` | `helmInstallHandler`, BEFORE the helm SDK call | `success` only (intent rows are always success) | `ref: string`, `version: string`, `atomic: bool`, `wait: bool`, `timeoutSeconds: int` |
+| `helm_install` | `helmInstallHandler`, AFTER the helm SDK call returns | `success` / `failure` / `denied` | `ref: string`, `version: string`, `atomic: bool`. On `success`: `revision: int`, optional `rolledBack: bool` (helm Atomic auto-rollback) |
+| `helm_upgrade_intent` | `helmUpgradeHandler`, BEFORE the helm SDK call | `success` only | `ref: string`, `version: string`, `atomic: bool`, `wait: bool`, `timeoutSeconds: int` |
+| `helm_upgrade` | `helmUpgradeHandler`, AFTER | `success` / `failure` / `denied` | `ref: string`, `version: string`, `atomic: bool`. On `success`: `revision: int`, optional `rolledBack: bool` |
+| `helm_uninstall_intent` | `helmUninstallHandler`, BEFORE | `success` only | `keepHistory: bool`, `disableHooks: bool` |
+| `helm_uninstall` | `helmUninstallHandler`, AFTER | `success` / `failure` / `denied` | `keepHistory: bool`, `disableHooks: bool`. On `success`: `revisionsRemoved: int` |
+| `helm_rollback_intent` | `helmRollbackHandler`, BEFORE | `success` only | `targetRevision: int`, `wait: bool`, `cleanupOnFail: bool`, `disableHooks: bool` |
+| `helm_rollback` | `helmRollbackHandler`, AFTER | `success` / `failure` / `denied` | `targetRevision: int`, `wait: bool`, `cleanupOnFail: bool`, `disableHooks: bool`. On `success`: `fromRevision: int`, `toRevision: int`, `newRevision: int` |
 | `log_open` | _reserved_ | _reserved_ | _reserved_ |
 
 `bulk_download` is **SPA-emitted**, not server-derived. The endpoint
@@ -138,6 +148,30 @@ update.
 because the access pattern (long-lived SSE) needs ratelimit-aware
 emission to avoid flooding the audit table. Adding it is a self-contained
 follow-up; the constant exists so the taxonomy is visible.
+
+
+The `helm_*` verbs (install / upgrade / uninstall / rollback) all
+emit as **intent / outcome pairs**: `<verb>_intent` fires BEFORE the
+helm SDK call, `<verb>` fires AFTER it returns. The intent row
+captures operator-stated parameters (target revision, ref, atomic
+flag, etc.) so a hung or partitioned helm action still leaves a
+forensic trail; the outcome row closes the loop with the resulting
+revision number. Querying audit for "what did helm do?" should join
+the pair via `(actor, cluster, namespace, name, timestamp window)` —
+a successful pair has both rows; a hung action has only the intent.
+
+`helm_install` and `helm_upgrade` carry an optional `rolledBack: true`
+on `success` outcomes when the helm Atomic flag triggered an
+auto-rollback after a partial-failure. The outcome is still `success`
+in audit terms (the apiserver state is back to a healthy revision)
+but the flag is the canonical signal for "the upgrade tried, failed,
+and atomically reverted."
+
+Helm `denied` outcomes come from the SAR pre-flight that runs before
+every action — operators whose role can't apply / patch / delete the
+release's manifests get a 403 with the failing (verb, GVR) tuples
+in the response body and a `denied` audit row before any helm SDK
+state mutation. Mirrors the `apply` verb's pre-flight pattern.
 
 ---
 

--- a/internal/audit/sqlite_sink_test.go
+++ b/internal/audit/sqlite_sink_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"strings"
 	"context"
+	"encoding/json"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -485,5 +486,129 @@ func TestSQLiteSink_Migrations_RefuseDowngrade(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "downgrade") {
 		t.Errorf("error missing 'downgrade': %v", err)
+	}
+}
+
+// TestSQLiteSink_HelmRollbackRoundTrip verifies the helm verb
+// subject shape (#78) round-trips through the SQLite sink without
+// loss. Specifically:
+//   - The `helm.<verb>` constant is stored as its underlying string.
+//   - `Resource{Namespace, Name}` carries the release identity.
+//   - `Extra` carries the helm-specific bag (targetRevision /
+//     fromRevision / toRevision / newRevision for rollback,
+//     ref / version / atomic for install / upgrade) as JSON,
+//     and the round-tripped JSON parses back to the same field
+//     values.
+//
+// Mirrors the existing TestSQLiteSink_RoundTrip pattern so any
+// future schema-shape change in the SQLite columns surfaces a
+// failure here too.
+func TestSQLiteSink_HelmRollbackRoundTrip(t *testing.T) {
+	s := openTestSink(t, SQLiteConfig{})
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Intent row first.
+	s.Record(ctx, Event{
+		Timestamp: now,
+		RequestID: "req-rb-1",
+		Actor:     Actor{Sub: "ana@x", Email: "ana@x", Groups: []string{"sre"}},
+		Verb:      VerbHelmRollbackIntent,
+		Outcome:   OutcomeSuccess,
+		Cluster:   "prod",
+		Resource:  ResourceRef{Namespace: "demo", Name: "podinfo"},
+		Extra: map[string]any{
+			"targetRevision": 3,
+			"wait":           true,
+			"cleanupOnFail":  false,
+			"disableHooks":   false,
+		},
+	})
+
+	// Outcome row.
+	s.Record(ctx, Event{
+		Timestamp: now.Add(2 * time.Second),
+		RequestID: "req-rb-1",
+		Actor:     Actor{Sub: "ana@x", Email: "ana@x", Groups: []string{"sre"}},
+		Verb:      VerbHelmRollback,
+		Outcome:   OutcomeSuccess,
+		Cluster:   "prod",
+		Resource:  ResourceRef{Namespace: "demo", Name: "podinfo"},
+		Extra: map[string]any{
+			"targetRevision": 3,
+			"fromRevision":   5,
+			"toRevision":     3,
+			"newRevision":    6,
+			"wait":           true,
+			"cleanupOnFail":  false,
+			"disableHooks":   false,
+		},
+	})
+
+	rows, err := s.db.Query(`
+		SELECT verb, outcome, actor_sub, cluster, res_namespace, res_name, extra
+		FROM audit_events ORDER BY ts_unix_nano ASC`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	type rowT struct {
+		verb, outcome, actor, cluster, ns, name string
+		extra                                   string
+	}
+	var got []rowT
+	for rows.Next() {
+		var r rowT
+		var extra sql.NullString
+		if err := rows.Scan(&r.verb, &r.outcome, &r.actor, &r.cluster, &r.ns, &r.name, &extra); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !extra.Valid {
+			t.Errorf("extra is NULL for verb=%s; helm rows must always carry parameters", r.verb)
+		}
+		r.extra = extra.String
+		got = append(got, r)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows (intent + outcome), got %d", len(got))
+	}
+
+	// Pair shape — intent first, outcome second.
+	if got[0].verb != string(VerbHelmRollbackIntent) || got[1].verb != string(VerbHelmRollback) {
+		t.Errorf("verb pair wrong: %q + %q", got[0].verb, got[1].verb)
+	}
+	for _, r := range got {
+		if r.outcome != string(OutcomeSuccess) || r.actor != "ana@x" {
+			t.Errorf("unexpected base fields on %s: %+v", r.verb, r)
+		}
+		if r.cluster != "prod" || r.ns != "demo" || r.name != "podinfo" {
+			t.Errorf("release identity lost on %s: cluster=%q ns=%q name=%q",
+				r.verb, r.cluster, r.ns, r.name)
+		}
+	}
+
+	// Extra round-trip — outcome row carries the revision triplet.
+	var outcomeExtra map[string]any
+	if err := json.Unmarshal([]byte(got[1].extra), &outcomeExtra); err != nil {
+		t.Fatalf("outcome extra unmarshal: %v", err)
+	}
+	for _, want := range []struct {
+		key string
+		val float64 // JSON numbers come back as float64
+	}{
+		{"targetRevision", 3},
+		{"fromRevision", 5},
+		{"toRevision", 3},
+		{"newRevision", 6},
+	} {
+		got, ok := outcomeExtra[want.key].(float64)
+		if !ok {
+			t.Errorf("outcome.Extra[%q] missing or wrong type: %v", want.key, outcomeExtra[want.key])
+			continue
+		}
+		if got != want.val {
+			t.Errorf("outcome.Extra[%q] = %v, want %v", want.key, got, want.val)
+		}
 	}
 }

--- a/internal/audit/sqlite_sink_test.go
+++ b/internal/audit/sqlite_sink_test.go
@@ -551,7 +551,7 @@ func TestSQLiteSink_HelmRollbackRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	type rowT struct {
 		verb, outcome, actor, cluster, ns, name string

--- a/web/src/components/audit/AuditFilterStrip.tsx
+++ b/web/src/components/audit/AuditFilterStrip.tsx
@@ -10,14 +10,31 @@ const OUTCOMES: Array<{ value: AuditOutcome | "all"; label: string }> = [
 ];
 
 const VERBS = [
+  // Resource-mutation verbs.
   "apply",
   "delete",
   "trigger",
+  "secret_reveal",
+  // Bulk + meta.
+  "bulk_download",
+  // Pod exec / log.
   "exec_open",
   "exec_close",
-  "secret_reveal",
   "log_open",
-  "bulk_download",
+  // Helm action surface (#78). Intent rows fire before the SDK
+  // call; the unprefixed verb fires after. Operators investigating
+  // a single helm action typically want both rows joined by
+  // (actor, namespace, name, timestamp).
+  "helm_chart_fetch",
+  "helm_preview",
+  "helm_install_intent",
+  "helm_install",
+  "helm_upgrade_intent",
+  "helm_upgrade",
+  "helm_uninstall_intent",
+  "helm_uninstall",
+  "helm_rollback_intent",
+  "helm_rollback",
 ] as const;
 
 


### PR DESCRIPTION
## Summary

Closes the v1.1 audit-doc gap surfaced by the helm write surface. The Go audit verb constants and emit sites have been in place since the helm install / upgrade / uninstall / rollback PRs (#107, #119, #123, #145); this lands the three remaining acceptance items from #78.

**1. RFC 0003 §4 verb taxonomy** — extended with 10 helm verb rows:

| Verb | Emit site | Extras |
|---|---|---|
| `helm_chart_fetch` | `helmChartHandler` | `ref`, `chart`, `version`, `cached` |
| `helm_preview` | `helmInstall/UpgradePreviewHandler` | `op` |
| `helm_install_intent` / `helm_install` | `helmInstallHandler` | `ref`, `version`, `atomic`, `wait`, `timeoutSeconds` (intent) → `revision`, optional `rolledBack` (outcome) |
| `helm_upgrade_intent` / `helm_upgrade` | `helmUpgradeHandler` | same shape as install |
| `helm_uninstall_intent` / `helm_uninstall` | `helmUninstallHandler` | `keepHistory`, `disableHooks` → adds `revisionsRemoved` on success |
| `helm_rollback_intent` / `helm_rollback` | `helmRollbackHandler` | `targetRevision`, `wait`, `cleanupOnFail`, `disableHooks` → adds `fromRevision`, `toRevision`, `newRevision` on success |

Three new prose paragraphs document:
- The intent/outcome pair pattern (`<verb>_intent` BEFORE the SDK call; `<verb>` AFTER) and how to join the pair for forensics.
- `rolledBack: true` on `helm_install` / `helm_upgrade` `success` outcomes when helm Atomic triggered an auto-rollback.
- The `denied` outcome path via the SAR pre-flight (mirrors the `apply` verb pattern).

**2. SPA audit filter strip** — `web/src/components/audit/AuditFilterStrip.tsx` appends the 10 helm verbs to the `VERBS` array, grouped by category comments (resource-mutation / bulk-meta / exec / helm). The list is now 18 entries — wraps cleanly today but approaching the point where a redesign makes sense. Logged as a follow-up; will discuss options once this lands.

**3. Round-trip test** — new `TestSQLiteSink_HelmRollbackRoundTrip` in `internal/audit/sqlite_sink_test.go` records an intent + outcome pair through the SQLite sink, verifies the verb constants serialize as their snake_case strings, the release identity round-trips through `ResourceRef{Namespace, Name}`, and the revision triplet (`fromRevision` / `toRevision` / `newRevision`) survives JSON round-trip with correct types.

Closes #78.

## Test plan

- [x] `go test ./...` — all backend suites pass; the new round-trip case covers the helm subject shape end-to-end through SQLite.
- [x] `pnpm lint` clean
- [x] `npx tsc -b --noEmit` clean
- [x] `pnpm test` — 301 / 301 frontend tests pass.
- [ ] Manual smoke: open the audit page on a cluster with helm activity, confirm helm verbs appear as filter pills, confirm clicking one filters the list as expected.