### PR TITLE
Add CVE HTTP API + per-pod chip aggregation (issue #165)

### DIFF
--- a/cmd/periscope/cve_handler.go
+++ b/cmd/periscope/cve_handler.go
@@ -510,3 +510,118 @@ func buildPodRow(p *corev1.Pod, store *cve.Store) cve.PodRow {
 // for future content-negotiation needs (the SPA's fetch wrapper
 // trims trailing newlines so we don't pay for one).
 var _ = strings.TrimSpace
+
+// --- /by-workload/{kind}/{namespace}/{name} ---------------------
+
+func cveByWorkloadHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		kind := chi.URLParam(r, "kind")
+		namespace := chi.URLParam(r, "namespace")
+		name := chi.URLParam(r, "name")
+		if !cve.IsSupportedWorkloadKind(kind) {
+			// Tight allow-list — keeps the handler honest about what
+			// it can resolve. CronJob omission is documented in
+			// owner_walk.go.
+			http.Error(w, "unsupported workload kind: "+kind, http.StatusBadRequest)
+			return
+		}
+		empty := cve.WorkloadCveResp{
+			Workload: cve.WorkloadRef{Kind: kind, Namespace: namespace, Name: name},
+			Pods:     []cve.PodRow{},
+			Hydrated: true,
+		}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+
+		lister := mgr.PodLister(c.Name)
+		if lister == nil {
+			// Informer hasn't started yet — same race as /cve/pods.
+			// Return empty rather than 503 to keep the SPA's
+			// workload Security tab quiet during cold-path warmup.
+			writeJSON(w, http.StatusOK, cve.WorkloadCveResp{
+				Workload:         cve.WorkloadRef{Kind: kind, Namespace: namespace, Name: name},
+				Pods:             []cve.PodRow{},
+				InspectorEnabled: true,
+				Hydrated:         true,
+			})
+			return
+		}
+		rsLister := mgr.ReplicaSetLister(c.Name)
+		// rsLister == nil is fine when kind != "Deployment"; the
+		// owner-walk helper handles it.
+
+		allPods, err := lister.Pods(namespace).List(labels.Everything())
+		if err != nil {
+			slog.Warn("cve by-workload: lister failed", "cluster", c.Name, "err", err)
+			writeAPIError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		matched := make([]*corev1.Pod, 0, len(allPods))
+		for _, p := range allPods {
+			if cve.PodOwnedBy(p, kind, namespace, name, rsLister) {
+				matched = append(matched, p)
+			}
+		}
+		sort.Slice(matched, func(i, j int) bool { return matched[i].Name < matched[j].Name })
+
+		rolled := cve.SeverityCounts{}
+		scannedContainers, totalContainers := 0, 0
+		rows := make([]cve.PodRow, 0, len(matched))
+		for _, p := range matched {
+			row := buildPodRow(p, store)
+			rows = append(rows, row)
+			// Re-aggregate via WireSeverityCounts since PodRow only
+			// keeps the wire shape — cheap, the row already walked
+			// findings once.
+			rolled.Critical += row.RolledUpSeverityCounts.Critical
+			rolled.High += row.RolledUpSeverityCounts.High
+			rolled.Medium += row.RolledUpSeverityCounts.Medium
+			rolled.Low += row.RolledUpSeverityCounts.Low
+			rolled.Informational += row.RolledUpSeverityCounts.Informational
+			// Coverage counters: any scanned/non-scanned container
+			// contributes to the workload-wide ratio so a mostly-
+			// scanned DaemonSet with one outlier sidecar doesn't
+			// flip the chip to "none".
+			for _, ctr := range row.Containers {
+				totalContainers++
+				if ctr.ScanState == cve.ScanStateScanned {
+					scannedContainers++
+				}
+			}
+		}
+
+		var coverage cve.ScanCoverage
+		switch {
+		case totalContainers == 0:
+			// No matched pods (or pods with no containers — exotic).
+			// Render as "none" so the SPA shows a "no scan coverage"
+			// hint rather than a misleading "full" chip.
+			coverage = cve.CoverageNone
+		case scannedContainers == 0:
+			coverage = cve.CoverageNone
+		case scannedContainers == totalContainers:
+			coverage = cve.CoverageFull
+		default:
+			coverage = cve.CoveragePartial
+		}
+
+		writeJSON(w, http.StatusOK, cve.WorkloadCveResp{
+			Workload:               cve.WorkloadRef{Kind: kind, Namespace: namespace, Name: name},
+			Pods:                   rows,
+			RolledUpSeverityCounts: cve.WireSeverity(rolled),
+			ScanCoverage:           coverage,
+			InspectorEnabled:       true,
+			Hydrated:               true,
+		})
+	}
+}

--- a/cmd/periscope/cve_handler.go
+++ b/cmd/periscope/cve_handler.go
@@ -1,0 +1,512 @@
+// HTTP handlers for the CVE surface (#165).
+//
+// Seven endpoints under /api/clusters/{cluster}/cve/...:
+//
+//   GET  /status                            store flags + entry counts
+//   GET  /by-instance                       list instances + severity counts
+//   GET  /by-instance/{instanceID}          full findings for one instance
+//   GET  /by-digest/{digest}                full findings for one image digest
+//   GET  /pods                              per-pod aggregate, paginated
+//   GET  /pods/{namespace}/{pod}            full per-container findings for one pod
+//   POST /refresh                           force refresh, emits one cve_refresh audit row
+//
+// All read paths serve from the local cve.Store (never call Inspector
+// during a SPA request). Cold cluster activation blocks on
+// Manager.EnsureHydrated (~10-30s); subsequent reads are O(1).
+//
+// Empty-state contract: when the CVE manager is nil (Helm-disabled)
+// or the store reports Disabled (account-side Inspector v2 not on /
+// missing IAM), every endpoint returns HTTP 200 with
+// {inspectorEnabled:false, hydrated:true, ...} — NEVER an error.
+// This is the contract the SPA relies on to render the "Inspector v2
+// not enabled" hint without special-casing transport errors.
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+	"github.com/gnana997/periscope/internal/cve"
+)
+
+// cvePodsPageSize is the default + max page size for /cve/pods. Same
+// magnitude as the helm list cap; pods/page is the single biggest
+// driver of response size on the CVE surface so the cap is explicit
+// rather than configurable (frontend pages further anyway).
+const cvePodsPageSize = 100
+
+// resolveCveCluster is the shared route-prefix decoder. Returns the
+// matched cluster + the cve.Store if the manager is available; nil
+// store means "render empty state".
+func resolveCveCluster(w http.ResponseWriter, r *http.Request, reg *clusters.Registry) (clusters.Cluster, bool) {
+	c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+	if !ok {
+		http.Error(w, "cluster not found", http.StatusNotFound)
+		return clusters.Cluster{}, false
+	}
+	return c, true
+}
+
+// ensureHydratedOrEmpty drives the cold-path hydrate and short-
+// circuits the empty-state envelope when the manager is nil or the
+// store flips to Disabled. Returns (store, true) when the handler
+// should continue; (nil, false) when the handler has already written
+// an empty-state response and should return.
+func ensureHydratedOrEmpty(w http.ResponseWriter, r *http.Request, mgr *cve.Manager, c clusters.Cluster, empty any) (*cve.Store, bool) {
+	if mgr == nil {
+		w.Header().Set("Cache-Control", "no-store")
+		writeJSON(w, http.StatusOK, empty)
+		return nil, false
+	}
+	store, err := mgr.EnsureHydrated(r.Context(), c)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, false
+		}
+		slog.Warn("cve hydrate failed", "cluster", c.Name, "err", err)
+		// Degrade gracefully: surface the empty envelope (with
+		// hydrated:false) rather than 5xx. The SPA can poll /status
+		// to detect recovery.
+		w.Header().Set("Cache-Control", "no-store")
+		writeJSON(w, http.StatusOK, empty)
+		return nil, false
+	}
+	if store.Disabled() {
+		w.Header().Set("Cache-Control", "no-store")
+		writeJSON(w, http.StatusOK, empty)
+		return nil, false
+	}
+	return store, true
+}
+
+// cveETag derives a stable ETag for read endpoints from the store's
+// (lastHydrate, digestCount, instanceCount) tuple. A delta refresh
+// of a single digest does NOT bump the ETag — chips don't need
+// real-time accuracy and TTL-grained change detection is enough.
+func cveETag(store *cve.Store) string {
+	d, i := store.EntryCounts()
+	return fmt.Sprintf(`W/"%s-%d-%d"`,
+		strconv.FormatInt(store.LastHydrate().UnixNano(), 36), d, i)
+}
+
+// setCveReadHeaders applies Cache-Control + ETag for the read path
+// and short-circuits with 304 when the client sends a matching
+// If-None-Match. Returns true if the handler should return without
+// writing a body.
+func setCveReadHeaders(w http.ResponseWriter, r *http.Request, store *cve.Store) bool {
+	w.Header().Set("Cache-Control", "no-store")
+	etag := cveETag(store)
+	w.Header().Set("ETag", etag)
+	if inm := r.Header.Get("If-None-Match"); inm != "" && inm == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return true
+	}
+	return false
+}
+
+// --- /status -----------------------------------------------------
+
+func cveStatusHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		if mgr == nil {
+			writeJSON(w, http.StatusOK, cve.StatusResp{Hydrated: true})
+			return
+		}
+		// /status deliberately does NOT trigger hydrate — the SPA
+		// uses it to poll cache state and we don't want a status
+		// poll to start a 10-30s cold scan. Hydrate is triggered by
+		// the first read endpoint instead.
+		store := mgr.Get(c.Name)
+		if store == nil {
+			writeJSON(w, http.StatusOK, cve.StatusResp{Hydrated: false})
+			return
+		}
+		d, i := store.EntryCounts()
+		writeJSON(w, http.StatusOK, cve.StatusResp{
+			InspectorEnabled: !store.Disabled(),
+			Hydrated:         store.Hydrated(),
+			LastHydrate:      store.LastHydrate(),
+			EntryCounts:      cve.EntryCountsWire{Digests: d, Instances: i},
+		})
+	}
+}
+
+// --- /by-instance (list) ----------------------------------------
+
+func cveByInstanceHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		empty := cve.InstancesResp{Instances: []cve.InstanceRow{}, Hydrated: true}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+		_, instances := store.Snapshot()
+		rows := make([]cve.InstanceRow, 0, len(instances))
+		for _, e := range instances {
+			rows = append(rows, cve.InstanceRow{
+				InstanceID:     e.InstanceID,
+				Owner:          cve.OwnerRef{Kind: e.OwnerKind, Name: e.OwnerName},
+				AMI:            e.AMI,
+				SeverityCounts: cve.WireSeverity(cve.CountSeverities(e.Findings)),
+				LastFetchedAt:  e.LastFetched,
+			})
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].InstanceID < rows[j].InstanceID })
+		writeJSON(w, http.StatusOK, cve.InstancesResp{
+			Instances: rows, InspectorEnabled: true, Hydrated: true,
+		})
+	}
+}
+
+// --- /by-instance/{id} ------------------------------------------
+
+func cveByInstanceOneHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		empty := cve.FindingsResp{Findings: []cve.Finding{}, Hydrated: true}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+		id := chi.URLParam(r, "instanceID")
+		e := store.GetInstance(id)
+		if e == nil {
+			http.Error(w, "instance not found in CVE cache", http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, cve.FindingsResp{
+			Findings:         e.Findings,
+			LastFetchedAt:    e.LastFetched,
+			InspectorEnabled: true,
+			Hydrated:         true,
+		})
+	}
+}
+
+// --- /by-digest/{digest} ----------------------------------------
+
+func cveByDigestHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		empty := cve.FindingsResp{Findings: []cve.Finding{}, Hydrated: true}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+		// Chi unescapes ':' in the URL param, so sha256:abc lands
+		// here verbatim.
+		digest := chi.URLParam(r, "digest")
+		e := store.GetDigest(digest)
+		if e == nil {
+			http.Error(w, "digest not found in CVE cache", http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, cve.FindingsResp{
+			Findings:         e.Findings,
+			LastFetchedAt:    e.LastFetched,
+			InspectorEnabled: true,
+			Hydrated:         true,
+		})
+	}
+}
+
+// --- /pods (list, paginated) ------------------------------------
+
+func cvePodsHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		empty := cve.PodsResp{Pods: []cve.PodRow{}, Hydrated: true}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+
+		lister := mgr.PodLister(c.Name)
+		if lister == nil {
+			// Hydrate succeeded but the informer hasn't started —
+			// rare race during cold path. Empty list, hydrated:true
+			// so the SPA doesn't re-spinner.
+			writeJSON(w, http.StatusOK, cve.PodsResp{
+				Pods: []cve.PodRow{}, InspectorEnabled: true, Hydrated: true,
+			})
+			return
+		}
+		pods, err := lister.List(labels.Everything())
+		if err != nil {
+			slog.Warn("cve pods: lister failed", "cluster", c.Name, "err", err)
+			writeAPIError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		// Stable lex order so a base64(ns/name) cursor round-trips
+		// across pages.
+		sort.Slice(pods, func(i, j int) bool {
+			if pods[i].Namespace != pods[j].Namespace {
+				return pods[i].Namespace < pods[j].Namespace
+			}
+			return pods[i].Name < pods[j].Name
+		})
+
+		// Decode + apply cursor: skip every pod with key <=
+		// cursorKey. Empty cursor starts from the beginning.
+		cursorKey := decodeCursor(r.URL.Query().Get("cursor"))
+		start := 0
+		if cursorKey != "" {
+			start = sort.Search(len(pods), func(i int) bool {
+				return podKey(pods[i]) > cursorKey
+			})
+		}
+		end := start + cvePodsPageSize
+		if end > len(pods) {
+			end = len(pods)
+		}
+		page := pods[start:end]
+
+		rows := make([]cve.PodRow, 0, len(page))
+		for _, p := range page {
+			rows = append(rows, buildPodRow(p, store))
+		}
+		var next string
+		if end < len(pods) {
+			next = encodeCursor(podKey(page[len(page)-1]))
+		}
+		writeJSON(w, http.StatusOK, cve.PodsResp{
+			Pods:             rows,
+			Next:             next,
+			InspectorEnabled: true,
+			Hydrated:         true,
+		})
+	}
+}
+
+// --- /pods/{namespace}/{pod} ------------------------------------
+
+func cvePodsOneHandler(reg *clusters.Registry, mgr *cve.Manager) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		empty := cve.PodRow{Containers: []cve.ContainerRow{}}
+		store, ok := ensureHydratedOrEmpty(w, r, mgr, c, empty)
+		if !ok {
+			return
+		}
+		if setCveReadHeaders(w, r, store) {
+			return
+		}
+		lister := mgr.PodLister(c.Name)
+		if lister == nil {
+			http.Error(w, "pod informer not ready", http.StatusServiceUnavailable)
+			return
+		}
+		ns, name := chi.URLParam(r, "namespace"), chi.URLParam(r, "pod")
+		p, err := lister.Pods(ns).Get(name)
+		if err != nil {
+			writeAPIError(w, err, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, buildPodRow(p, store))
+	}
+}
+
+// --- POST /refresh ----------------------------------------------
+
+func cveRefreshHandler(reg *clusters.Registry, mgr *cve.Manager, auditer *audit.Emitter) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, _ credentials.Provider) {
+		c, ok := resolveCveCluster(w, r, reg)
+		if !ok {
+			return
+		}
+		var req cve.RefreshReq
+		if r.Body != nil {
+			// Empty body is acceptable — still emits an audit row
+			// (operator chose to act).
+			_ = json.NewDecoder(r.Body).Decode(&req)
+		}
+		evt := audit.Event{
+			Actor:   actorFromContext(r.Context()),
+			Verb:    audit.VerbCveRefresh,
+			Cluster: c.Name,
+			Extra: map[string]any{
+				"digests":     req.Digests,
+				"instanceIds": req.InstanceIDs,
+			},
+		}
+		if mgr == nil {
+			// Inspector disabled via Helm — record the action attempt
+			// but return cleanly so the SPA gets the same empty-
+			// state contract.
+			evt.Outcome = audit.OutcomeFailure
+			evt.Reason = "inspector disabled"
+			auditer.Record(r.Context(), evt)
+			w.Header().Set("Cache-Control", "no-store")
+			writeJSON(w, http.StatusOK, map[string]any{"inspectorEnabled": false})
+			return
+		}
+		// Hydrate-in-flight: if /refresh fires before the cold scan
+		// finishes (e.g. operator hit refresh during the spinner),
+		// queue behind it and signal 202 with a poll hint instead
+		// of blocking the request.
+		if store := mgr.Get(c.Name); store == nil || !store.Hydrated() {
+			evt.Outcome = audit.OutcomeSuccess
+			evt.Extra["queued"] = true
+			auditer.Record(r.Context(), evt)
+			w.Header().Set("Next-Poll", "2")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"queued": true})
+			return
+		}
+		err := mgr.Refresh(r.Context(), c, req.Digests, req.InstanceIDs)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			evt.Outcome = outcomeFor(err)
+			evt.Reason = err.Error()
+			auditer.Record(r.Context(), evt)
+			writeAPIError(w, err, httpStatusFor(err))
+			return
+		}
+		evt.Outcome = audit.OutcomeSuccess
+		auditer.Record(r.Context(), evt)
+		writeJSON(w, http.StatusOK, map[string]any{"refreshed": true})
+	}
+}
+
+// --- helpers ----------------------------------------------------
+
+// podKey is the cursor key shape (namespace/name). Used both for the
+// sort + cursor advance.
+func podKey(p *corev1.Pod) string {
+	return p.Namespace + "/" + p.Name
+}
+
+// encodeCursor / decodeCursor wrap the cursor in URL-safe base64 so
+// it survives URL round-tripping and is opaque-ish to clients.
+func encodeCursor(key string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(key))
+}
+func decodeCursor(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// buildPodRow joins a pod against the store: for each container,
+// classify ECR / non-ECR / pending and (when scanned) look up
+// findings for the digest. Roll up severity counts across scanned
+// containers; compute scanCoverage from the per-container mix.
+func buildPodRow(p *corev1.Pod, store *cve.Store) cve.PodRow {
+	rolled := cve.SeverityCounts{}
+	containers := make([]cve.ContainerRow, 0, len(p.Spec.Containers)+len(p.Spec.InitContainers))
+
+	idByName := make(map[string]string, len(p.Status.ContainerStatuses)+len(p.Status.InitContainerStatuses))
+	for _, cs := range p.Status.ContainerStatuses {
+		idByName[cs.Name] = cs.ImageID
+	}
+	for _, cs := range p.Status.InitContainerStatuses {
+		idByName[cs.Name] = cs.ImageID
+	}
+
+	scanned, others := 0, 0
+	addContainer := func(name, image string) {
+		digest, state := cve.ImageScanState(image, idByName[name])
+		row := cve.ContainerRow{Name: name, Image: image, Digest: digest, ScanState: state}
+		if state == cve.ScanStateScanned {
+			scanned++
+			if e := store.GetDigest(digest); e != nil {
+				counts := cve.CountSeverities(e.Findings)
+				wire := cve.WireSeverity(counts)
+				row.SeverityCounts = &wire
+				rolled.Add(counts)
+			} else {
+				zero := cve.WireSeverity(cve.SeverityCounts{})
+				row.SeverityCounts = &zero
+			}
+		} else {
+			others++
+		}
+		containers = append(containers, row)
+	}
+	for _, ctr := range p.Spec.Containers {
+		addContainer(ctr.Name, ctr.Image)
+	}
+	for _, ctr := range p.Spec.InitContainers {
+		addContainer(ctr.Name, ctr.Image)
+	}
+
+	var coverage cve.ScanCoverage
+	switch {
+	case scanned == 0:
+		coverage = cve.CoverageNone
+	case others == 0:
+		coverage = cve.CoverageFull
+	default:
+		coverage = cve.CoveragePartial
+	}
+
+	return cve.PodRow{
+		Namespace:              p.Namespace,
+		Name:                   p.Name,
+		Containers:             containers,
+		RolledUpSeverityCounts: cve.WireSeverity(rolled),
+		ScanCoverage:           coverage,
+	}
+}
+
+// stripTrailingNewline is a stylistic no-op; kept here as a hook
+// for future content-negotiation needs (the SPA's fetch wrapper
+// trims trailing newlines so we don't pay for one).
+var _ = strings.TrimSpace

--- a/cmd/periscope/cve_handler_test.go
+++ b/cmd/periscope/cve_handler_test.go
@@ -1,0 +1,477 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jonboulle/clockwork"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/gnana997/periscope/internal/audit"
+	"github.com/gnana997/periscope/internal/awsec2"
+	"github.com/gnana997/periscope/internal/clusters"
+	"github.com/gnana997/periscope/internal/credentials"
+	"github.com/gnana997/periscope/internal/cve"
+)
+
+// The package-level testRegistry helper (cani_handler_test.go) seeds
+// a cluster named "test"; cve handler tests reuse that name end-to-end.
+const cveTestCluster = "test"
+
+// ── stub clients ────────────────────────────────────────────────────
+
+type stubCveInsp struct {
+	enabled bool
+	digests map[string][]cve.Finding
+	insts   map[string][]cve.Finding
+}
+
+func (s *stubCveInsp) IsEnabled(_ context.Context) (bool, error) { return s.enabled, nil }
+
+func (s *stubCveInsp) ListFindingsByInstance(_ context.Context, ids []string) (map[string][]cve.Finding, error) {
+	out := make(map[string][]cve.Finding, len(ids))
+	for _, id := range ids {
+		out[id] = append([]cve.Finding(nil), s.insts[id]...)
+	}
+	return out, nil
+}
+
+func (s *stubCveInsp) ListFindingsByImageDigest(_ context.Context, ds []string) (map[string][]cve.Finding, error) {
+	out := make(map[string][]cve.Finding, len(ds))
+	for _, d := range ds {
+		out[d] = append([]cve.Finding(nil), s.digests[d]...)
+	}
+	return out, nil
+}
+
+type stubCveEC2 struct{ list []awsec2.InstanceMeta }
+
+func (s *stubCveEC2) DescribeInstances(_ context.Context, ids []string) ([]awsec2.InstanceMeta, error) {
+	if s.list != nil {
+		return s.list, nil
+	}
+	out := make([]awsec2.InstanceMeta, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, awsec2.InstanceMeta{InstanceID: id})
+	}
+	return out, nil
+}
+
+// cveFixtureOpts bundles every knob the CVE handler tests reach for.
+type cveFixtureOpts struct {
+	insp        *stubCveInsp
+	ec2         *stubCveEC2
+	pods        []corev1.Pod
+	nodes       []corev1.Node
+	skipHydrate bool
+}
+
+// buildCveFixture returns a manager wired against the provided pods +
+// findings. After EnsureHydrated returns, the cold path has run; the
+// pod informer indexer settles asynchronously, so tests that need
+// the lister must call waitForCveLister.
+func buildCveFixture(t *testing.T, o cveFixtureOpts) *cve.Manager {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	for i := range o.pods {
+		_, _ = cs.CoreV1().Pods(o.pods[i].Namespace).Create(context.Background(), &o.pods[i], metav1.CreateOptions{})
+	}
+	for i := range o.nodes {
+		_, _ = cs.CoreV1().Nodes().Create(context.Background(), &o.nodes[i], metav1.CreateOptions{})
+	}
+	factory := func(_ context.Context, _ clusters.Cluster) (kubernetes.Interface, error) {
+		return cs, nil
+	}
+	mgr := cve.NewManager(
+		o.insp, o.ec2, factory,
+		clockwork.NewFakeClock(),
+		cve.Config{
+			RefreshInterval:           time.Hour,
+			EvictAfter:                time.Hour,
+			TTLScanInterval:           time.Hour,
+			EvictionScanInterval:      time.Hour,
+			MaxConcurrentDeltaFetches: 1,
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	t.Cleanup(mgr.Stop)
+	if !o.skipHydrate {
+		if _, err := mgr.EnsureHydrated(context.Background(), clusters.Cluster{Name: cveTestCluster}); err != nil {
+			t.Fatalf("hydrate: %v", err)
+		}
+	}
+	return mgr
+}
+
+// invokeCveHandler wires up the chi route context the handler reads
+// and returns the response.
+func invokeCveHandler(t *testing.T, h credentials.Handler, method, url string, params map[string]string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var rd io.Reader = http.NoBody
+	if body != nil {
+		rd = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, url, rd)
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = credentials.WithSession(ctx, defaultTestSession)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h(rec, req, defaultTestProvider())
+	return rec
+}
+
+// unmarshalJSON decodes a response body into out, failing the test
+// on parse error. Named separately from helm_preview_handler_test's
+// mustJSON (which marshals).
+func unmarshalJSON(t *testing.T, raw []byte, into any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, into); err != nil {
+		t.Fatalf("json unmarshal: %v body=%s", err, raw)
+	}
+}
+
+// waitForCveLister polls until the manager's PodLister returns a
+// non-nil lister that has indexed at least min pods. The fake
+// informer sync is async; without this the tests race the cache build.
+func waitForCveLister(t *testing.T, mgr *cve.Manager, cluster string, min int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if l := mgr.PodLister(cluster); l != nil {
+			pods, _ := l.List(labels.Everything())
+			if len(pods) >= min {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pod lister never indexed %d pods", min)
+}
+
+// ── tests ───────────────────────────────────────────────────────────
+
+func TestCveStatus_NilManager_EmptyState(t *testing.T) {
+	reg := testRegistry(t)
+	h := cveStatusHandler(reg, nil)
+	rec := invokeCveHandler(t, h, http.MethodGet, "/cve/status",
+		map[string]string{"cluster": cveTestCluster}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", rec.Code, rec.Body)
+	}
+	var got cve.StatusResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if got.InspectorEnabled || !got.Hydrated {
+		t.Errorf("empty state: want enabled=false hydrated=true, got %+v", got)
+	}
+}
+
+func TestCveStatus_Hydrated_PopulatesCounts(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "CVE-1", Severity: "HIGH"}},
+		}},
+		ec2: &stubCveEC2{},
+		pods: []corev1.Pod{
+			cvePod("default", "app", "111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc"),
+		},
+	})
+	h := cveStatusHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet, "/cve/status",
+		map[string]string{"cluster": cveTestCluster}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var got cve.StatusResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if !got.InspectorEnabled || !got.Hydrated {
+		t.Errorf("got %+v", got)
+	}
+	if got.EntryCounts.Digests == 0 {
+		t.Errorf("entryCounts.digests should be > 0: %+v", got.EntryCounts)
+	}
+	if got.LastHydrate.IsZero() {
+		t.Errorf("lastHydrate should be set after hydrate")
+	}
+}
+
+func TestCveByInstance_SeverityRollupAndAMI(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{
+			enabled: true,
+			insts: map[string][]cve.Finding{
+				"i-1": {
+					{CVE: "A", Severity: "CRITICAL"},
+					{CVE: "B", Severity: "HIGH"},
+					{CVE: "C", Severity: "HIGH"},
+					{CVE: "D", Severity: "MEDIUM"},
+				},
+			},
+		},
+		ec2: &stubCveEC2{list: []awsec2.InstanceMeta{
+			{InstanceID: "i-1", AMI: "ami-test", Tags: map[string]string{"eks:nodegroup-name": "ng-a"}},
+		}},
+		nodes: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "n1"}, Spec: corev1.NodeSpec{ProviderID: "aws:///us-east-1a/i-1"}},
+		},
+	})
+	h := cveByInstanceHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet, "/cve/by-instance",
+		map[string]string{"cluster": cveTestCluster}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var got cve.InstancesResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if len(got.Instances) != 1 {
+		t.Fatalf("want 1 instance, got %d", len(got.Instances))
+	}
+	r := got.Instances[0]
+	if r.SeverityCounts.Critical != 1 || r.SeverityCounts.High != 2 || r.SeverityCounts.Medium != 1 {
+		t.Errorf("severity rollup: %+v", r.SeverityCounts)
+	}
+	if r.AMI != "ami-test" {
+		t.Errorf("AMI: want ami-test, got %q", r.AMI)
+	}
+	if r.Owner.Kind != cve.OwnerManagedNodegroup || r.Owner.Name != "ng-a" {
+		t.Errorf("owner: %+v", r.Owner)
+	}
+}
+
+func TestCveByInstanceOne_NotFound(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true},
+		ec2:  &stubCveEC2{},
+	})
+	h := cveByInstanceOneHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet, "/cve/by-instance/i-missing",
+		map[string]string{"cluster": cveTestCluster, "instanceID": "i-missing"}, nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d body=%s", rec.Code, rec.Body)
+	}
+}
+
+func TestCvePods_Pagination(t *testing.T) {
+	reg := testRegistry(t)
+	pods := make([]corev1.Pod, 250)
+	for i := 0; i < 250; i++ {
+		pods[i] = cvePod("ns", "pod-"+padN(i, 4),
+			"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc")
+	}
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "X", Severity: "HIGH"}},
+		}},
+		ec2:  &stubCveEC2{},
+		pods: pods,
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 250)
+
+	h := cvePodsHandler(reg, mgr)
+	p1 := getCvePodsPage(t, h, "")
+	if len(p1.Pods) != 100 || p1.Next == "" {
+		t.Fatalf("page1: pods=%d next=%q", len(p1.Pods), p1.Next)
+	}
+	p2 := getCvePodsPage(t, h, p1.Next)
+	if len(p2.Pods) != 100 || p2.Next == "" {
+		t.Fatalf("page2: pods=%d next=%q", len(p2.Pods), p2.Next)
+	}
+	p3 := getCvePodsPage(t, h, p2.Next)
+	if len(p3.Pods) != 50 || p3.Next != "" {
+		t.Fatalf("page3: pods=%d next=%q", len(p3.Pods), p3.Next)
+	}
+}
+
+func TestCvePods_ScanCoverageMix(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "X", Severity: "HIGH"}},
+		}},
+		ec2: &stubCveEC2{},
+		pods: []corev1.Pod{
+			cvePod("ns", "full",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc"),
+			cvePod2Containers("ns", "partial",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				"docker.io/library/nginx:latest", "docker-pullable://nginx@sha256:zzz"),
+			cvePod("ns", "none",
+				"docker.io/library/nginx:latest", "docker-pullable://nginx@sha256:zzz"),
+		},
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 3)
+
+	h := cvePodsHandler(reg, mgr)
+	body := getCvePodsPage(t, h, "")
+	coverage := map[string]cve.ScanCoverage{}
+	for _, p := range body.Pods {
+		coverage[p.Name] = p.ScanCoverage
+	}
+	if coverage["full"] != cve.CoverageFull {
+		t.Errorf("full: %q", coverage["full"])
+	}
+	if coverage["partial"] != cve.CoveragePartial {
+		t.Errorf("partial: %q", coverage["partial"])
+	}
+	if coverage["none"] != cve.CoverageNone {
+		t.Errorf("none: %q", coverage["none"])
+	}
+}
+
+func TestCveRefresh_EmitsAudit(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true},
+		ec2:  &stubCveEC2{},
+	})
+	sink := &recordingSink{}
+	h := cveRefreshHandler(reg, mgr, audit.New(sink))
+	body, _ := json.Marshal(cve.RefreshReq{
+		Digests:     []string{"sha256:abc"},
+		InstanceIDs: []string{"i-1"},
+	})
+	rec := invokeCveHandler(t, h, http.MethodPost, "/cve/refresh",
+		map[string]string{"cluster": cveTestCluster}, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d body=%s", rec.Code, rec.Body)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(events))
+	}
+	if events[0].Verb != audit.VerbCveRefresh {
+		t.Errorf("verb: %q", events[0].Verb)
+	}
+	if events[0].Cluster != cveTestCluster {
+		t.Errorf("cluster: %q", events[0].Cluster)
+	}
+	if events[0].Outcome != audit.OutcomeSuccess {
+		t.Errorf("outcome: %q", events[0].Outcome)
+	}
+}
+
+func TestCveRefresh_HydrateInFlight_202(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp:        &stubCveInsp{enabled: true},
+		ec2:         &stubCveEC2{},
+		skipHydrate: true,
+	})
+	sink := &recordingSink{}
+	h := cveRefreshHandler(reg, mgr, audit.New(sink))
+	rec := invokeCveHandler(t, h, http.MethodPost, "/cve/refresh",
+		map[string]string{"cluster": cveTestCluster}, []byte(`{}`))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: want 202, got %d body=%s", rec.Code, rec.Body)
+	}
+	if hdr := rec.Header().Get("Next-Poll"); hdr == "" {
+		t.Errorf("Next-Poll header missing")
+	}
+}
+
+func TestCveETag_NotModified(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true},
+		ec2:  &stubCveEC2{},
+	})
+	h := cveByInstanceHandler(reg, mgr)
+	rec1 := invokeCveHandler(t, h, http.MethodGet, "/cve/by-instance",
+		map[string]string{"cluster": cveTestCluster}, nil)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call: %d", rec1.Code)
+	}
+	etag := rec1.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("ETag missing on first response")
+	}
+	req2 := httptest.NewRequest(http.MethodGet, "/cve/by-instance", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("cluster", cveTestCluster)
+	ctx := context.WithValue(req2.Context(), chi.RouteCtxKey, rctx)
+	ctx = credentials.WithSession(ctx, defaultTestSession)
+	req2 = req2.WithContext(ctx)
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h(rec2, req2, defaultTestProvider())
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("conditional: want 304, got %d body=%s", rec2.Code, rec2.Body)
+	}
+}
+
+// ── pod / page helpers ──────────────────────────────────────────────
+
+func cvePod(ns, name, image, digest string) corev1.Pod {
+	imageID := ""
+	if digest != "" {
+		imageID = "docker-pullable://repo@" + digest
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: image}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", Image: image, ImageID: imageID},
+		}},
+	}
+}
+
+func cvePod2Containers(ns, name, image1, digest1, image2, imageID2 string) corev1.Pod {
+	imageID1 := ""
+	if digest1 != "" {
+		imageID1 = "docker-pullable://repo@" + digest1
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "app", Image: image1},
+			{Name: "sidecar", Image: image2},
+		}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", Image: image1, ImageID: imageID1},
+			{Name: "sidecar", Image: image2, ImageID: imageID2},
+		}},
+	}
+}
+
+func padN(n, w int) string {
+	s := strconv.Itoa(n)
+	for len(s) < w {
+		s = "0" + s
+	}
+	return s
+}
+
+func getCvePodsPage(t *testing.T, h credentials.Handler, cursor string) cve.PodsResp {
+	t.Helper()
+	url := "/cve/pods"
+	if cursor != "" {
+		url += "?cursor=" + cursor
+	}
+	rec := invokeCveHandler(t, h, http.MethodGet, url,
+		map[string]string{"cluster": cveTestCluster}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pods: %d body=%s", rec.Code, rec.Body)
+	}
+	var got cve.PodsResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	return got
+}

--- a/cmd/periscope/cve_handler_test.go
+++ b/cmd/periscope/cve_handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jonboulle/clockwork"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -474,4 +475,292 @@ func getCvePodsPage(t *testing.T, h credentials.Handler, cursor string) cve.Pods
 	var got cve.PodsResp
 	unmarshalJSON(t, rec.Body.Bytes(), &got)
 	return got
+}
+
+// ── /cve/by-workload tests ──────────────────────────────────────────
+
+// cvePodWithOwners returns a pod fixture annotated with the supplied
+// ownerReferences. Used by the workload-filter tests.
+func cvePodWithOwners(ns, name, image, digest string, owners ...metav1.OwnerReference) corev1.Pod {
+	p := cvePod(ns, name, image, digest)
+	p.OwnerReferences = owners
+	return p
+}
+
+// addReplicaSetToFixture seeds a ReplicaSet onto the manager's
+// ReplicaSet informer indexer so the owner walker can resolve a
+// two-hop Deployment lookup. Returns after waiting for the lister
+// to expose the RS.
+func addReplicaSetToFixture(t *testing.T, mgr *cve.Manager, cluster, ns, name, deploymentName string) {
+	t.Helper()
+	// The cve.Manager exposes the lister but not the underlying
+	// informer; tests reach into the lister-backing indexer via a
+	// known-shape approach: build the lister we want by populating
+	// the same fake clientset's ReplicaSet store before hydrate.
+	// In practice we ask the test author to seed it BEFORE
+	// buildCveFixture by extending fixtureOpts; see the test below.
+	_ = mgr
+	_ = cluster
+	_ = ns
+	_ = name
+	_ = deploymentName
+	// Body intentionally a no-op — tests use the rsFixtures field on
+	// cveFixtureOpts (added below) to seed the clientset directly.
+}
+
+func TestCveByWorkload_StatefulSet_DirectMatch(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "X", Severity: "HIGH"}},
+		}},
+		ec2: &stubCveEC2{},
+		pods: []corev1.Pod{
+			cvePodWithOwners("ns", "sts-0",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "StatefulSet", Name: "my-sts"}),
+			cvePodWithOwners("ns", "sts-1",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "StatefulSet", Name: "my-sts"}),
+			// Different STS — must NOT match.
+			cvePodWithOwners("ns", "other-0",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "StatefulSet", Name: "other-sts"}),
+		},
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 3)
+
+	h := cveByWorkloadHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet,
+		"/cve/by-workload/StatefulSet/ns/my-sts",
+		map[string]string{
+			"cluster": cveTestCluster, "kind": "StatefulSet",
+			"namespace": "ns", "name": "my-sts",
+		}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", rec.Code, rec.Body)
+	}
+	var got cve.WorkloadCveResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if len(got.Pods) != 2 {
+		t.Errorf("want 2 matched pods, got %d", len(got.Pods))
+	}
+	if got.Workload.Kind != "StatefulSet" || got.Workload.Name != "my-sts" {
+		t.Errorf("workload echo: %+v", got.Workload)
+	}
+	// Two pods × one container each, each scanned-ECR with one HIGH.
+	if got.RolledUpSeverityCounts.High != 2 {
+		t.Errorf("rolled up: %+v", got.RolledUpSeverityCounts)
+	}
+	if got.ScanCoverage != cve.CoverageFull {
+		t.Errorf("coverage: want full, got %q", got.ScanCoverage)
+	}
+}
+
+func TestCveByWorkload_Deployment_TwoHopViaReplicaSet(t *testing.T) {
+	reg := testRegistry(t)
+	// Two pods, both via the same ReplicaSet, which is owned by the
+	// Deployment. A third pod via a different RS owned by a
+	// different Deployment must NOT match.
+	mgr := buildCveFixtureWithRS(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "X", Severity: "CRITICAL"}},
+		}},
+		ec2: &stubCveEC2{},
+		pods: []corev1.Pod{
+			cvePodWithOwners("ns", "app-abc123-p1",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "ReplicaSet", Name: "app-abc123"}),
+			cvePodWithOwners("ns", "app-abc123-p2",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "ReplicaSet", Name: "app-abc123"}),
+			cvePodWithOwners("ns", "other-xyz-p1",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "ReplicaSet", Name: "other-xyz"}),
+		},
+	}, []*appsv1.ReplicaSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "app-abc123",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "app"}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "other-xyz",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "other"}}},
+		},
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 3)
+	waitForCveRSLister(t, mgr, cveTestCluster, 2)
+
+	h := cveByWorkloadHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet,
+		"/cve/by-workload/Deployment/ns/app",
+		map[string]string{
+			"cluster": cveTestCluster, "kind": "Deployment",
+			"namespace": "ns", "name": "app",
+		}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", rec.Code, rec.Body)
+	}
+	var got cve.WorkloadCveResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if len(got.Pods) != 2 {
+		t.Errorf("want 2 matched pods, got %d", len(got.Pods))
+	}
+	if got.RolledUpSeverityCounts.Critical != 2 {
+		t.Errorf("critical rollup: %+v", got.RolledUpSeverityCounts)
+	}
+}
+
+func TestCveByWorkload_DaemonSet_MixedScanCoverage(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true, digests: map[string][]cve.Finding{
+			"sha256:abc": {{CVE: "X", Severity: "HIGH"}},
+		}},
+		ec2: &stubCveEC2{},
+		pods: []corev1.Pod{
+			cvePodWithOwners("kube-system", "ds-1",
+				"111.dkr.ecr.us-east-1.amazonaws.com/agent:v1", "sha256:abc",
+				metav1.OwnerReference{Kind: "DaemonSet", Name: "ds"}),
+			// Two containers: one ECR-scanned, one non-ECR sidecar.
+			func() corev1.Pod {
+				p := cvePod2Containers("kube-system", "ds-2",
+					"111.dkr.ecr.us-east-1.amazonaws.com/agent:v1", "sha256:abc",
+					"docker.io/library/nginx:latest", "docker-pullable://nginx@sha256:zzz")
+				p.OwnerReferences = []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds"}}
+				return p
+			}(),
+		},
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 2)
+
+	h := cveByWorkloadHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet,
+		"/cve/by-workload/DaemonSet/kube-system/ds",
+		map[string]string{
+			"cluster": cveTestCluster, "kind": "DaemonSet",
+			"namespace": "kube-system", "name": "ds",
+		}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", rec.Code, rec.Body)
+	}
+	var got cve.WorkloadCveResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if len(got.Pods) != 2 {
+		t.Errorf("want 2 pods, got %d", len(got.Pods))
+	}
+	// One ECR-scanned container per pod (2 total) + one non-ECR
+	// sidecar in the second pod → partial coverage.
+	if got.ScanCoverage != cve.CoveragePartial {
+		t.Errorf("coverage: want partial, got %q", got.ScanCoverage)
+	}
+}
+
+func TestCveByWorkload_UnknownKind_400(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true},
+		ec2:  &stubCveEC2{},
+	})
+	h := cveByWorkloadHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet,
+		"/cve/by-workload/CronJob/ns/anything",
+		map[string]string{
+			"cluster": cveTestCluster, "kind": "CronJob",
+			"namespace": "ns", "name": "anything",
+		}, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for unsupported kind, got %d", rec.Code)
+	}
+}
+
+func TestCveByWorkload_NoMatchedPods_EmptyAndCoverageNone(t *testing.T) {
+	reg := testRegistry(t)
+	mgr := buildCveFixture(t, cveFixtureOpts{
+		insp: &stubCveInsp{enabled: true},
+		ec2:  &stubCveEC2{},
+		// No pods owned by "phantom".
+		pods: []corev1.Pod{
+			cvePodWithOwners("ns", "p",
+				"111.dkr.ecr.us-east-1.amazonaws.com/app:v1", "",
+				metav1.OwnerReference{Kind: "StatefulSet", Name: "other"}),
+		},
+	})
+	waitForCveLister(t, mgr, cveTestCluster, 1)
+
+	h := cveByWorkloadHandler(reg, mgr)
+	rec := invokeCveHandler(t, h, http.MethodGet,
+		"/cve/by-workload/StatefulSet/ns/phantom",
+		map[string]string{
+			"cluster": cveTestCluster, "kind": "StatefulSet",
+			"namespace": "ns", "name": "phantom",
+		}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var got cve.WorkloadCveResp
+	unmarshalJSON(t, rec.Body.Bytes(), &got)
+	if len(got.Pods) != 0 {
+		t.Errorf("want 0 pods, got %d", len(got.Pods))
+	}
+	if got.ScanCoverage != cve.CoverageNone {
+		t.Errorf("coverage: want none, got %q", got.ScanCoverage)
+	}
+}
+
+// buildCveFixtureWithRS is the workload-test variant: seeds the
+// fake clientset with the supplied ReplicaSets in addition to pods +
+// nodes, so the ReplicaSet informer started inside startPodInformer
+// can resolve Pod → ReplicaSet → Deployment lookups.
+func buildCveFixtureWithRS(t *testing.T, o cveFixtureOpts, rss []*appsv1.ReplicaSet) *cve.Manager {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	for i := range o.pods {
+		_, _ = cs.CoreV1().Pods(o.pods[i].Namespace).Create(context.Background(), &o.pods[i], metav1.CreateOptions{})
+	}
+	for i := range o.nodes {
+		_, _ = cs.CoreV1().Nodes().Create(context.Background(), &o.nodes[i], metav1.CreateOptions{})
+	}
+	for _, rs := range rss {
+		_, _ = cs.AppsV1().ReplicaSets(rs.Namespace).Create(context.Background(), rs, metav1.CreateOptions{})
+	}
+	factory := func(_ context.Context, _ clusters.Cluster) (kubernetes.Interface, error) {
+		return cs, nil
+	}
+	mgr := cve.NewManager(
+		o.insp, o.ec2, factory,
+		clockwork.NewFakeClock(),
+		cve.Config{
+			RefreshInterval:           time.Hour,
+			EvictAfter:                time.Hour,
+			TTLScanInterval:           time.Hour,
+			EvictionScanInterval:      time.Hour,
+			MaxConcurrentDeltaFetches: 1,
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	t.Cleanup(mgr.Stop)
+	if !o.skipHydrate {
+		if _, err := mgr.EnsureHydrated(context.Background(), clusters.Cluster{Name: cveTestCluster}); err != nil {
+			t.Fatalf("hydrate: %v", err)
+		}
+	}
+	return mgr
+}
+
+// waitForCveRSLister polls until the manager's ReplicaSetLister
+// returns a non-nil lister with at least min entries.
+func waitForCveRSLister(t *testing.T, mgr *cve.Manager, cluster string, minRS int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if l := mgr.ReplicaSetLister(cluster); l != nil {
+			rss, _ := l.List(labels.Everything())
+			if len(rss) >= minRS {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("ReplicaSet lister never indexed %d entries", minRS)
 }

--- a/cmd/periscope/cve_handler_test.go
+++ b/cmd/periscope/cve_handler_test.go
@@ -487,26 +487,6 @@ func cvePodWithOwners(ns, name, image, digest string, owners ...metav1.OwnerRefe
 	return p
 }
 
-// addReplicaSetToFixture seeds a ReplicaSet onto the manager's
-// ReplicaSet informer indexer so the owner walker can resolve a
-// two-hop Deployment lookup. Returns after waiting for the lister
-// to expose the RS.
-func addReplicaSetToFixture(t *testing.T, mgr *cve.Manager, cluster, ns, name, deploymentName string) {
-	t.Helper()
-	// The cve.Manager exposes the lister but not the underlying
-	// informer; tests reach into the lister-backing indexer via a
-	// known-shape approach: build the lister we want by populating
-	// the same fake clientset's ReplicaSet store before hydrate.
-	// In practice we ask the test author to seed it BEFORE
-	// buildCveFixture by extending fixtureOpts; see the test below.
-	_ = mgr
-	_ = cluster
-	_ = ns
-	_ = name
-	_ = deploymentName
-	// Body intentionally a no-op — tests use the rsFixtures field on
-	// cveFixtureOpts (added below) to seed the clientset directly.
-}
 
 func TestCveByWorkload_StatefulSet_DirectMatch(t *testing.T) {
 	reg := testRegistry(t)

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -438,6 +438,27 @@ func main() {
 	router.Delete("/api/clusters/{cluster}/eks/addons/{name}", credentials.Wrap(factory,
 		eksAddonDeleteHandler(registry, eksAddonsC, auditEmitter)))
 
+	// --- CVE / Inspector v2 surface (#165) ---
+	//
+	// Seven endpoints. Reads serve from the per-cluster cve.Store;
+	// /refresh emits an audit row. cveMgr is nil when Helm has
+	// inspector.enabled=false — handlers short-circuit to the
+	// empty-state envelope in that case.
+	router.Get("/api/clusters/{cluster}/cve/status",
+		credentials.Wrap(factory, cveStatusHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/by-instance",
+		credentials.Wrap(factory, cveByInstanceHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/by-instance/{instanceID}",
+		credentials.Wrap(factory, cveByInstanceOneHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/by-digest/{digest}",
+		credentials.Wrap(factory, cveByDigestHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/pods",
+		credentials.Wrap(factory, cvePodsHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/pods/{namespace}/{pod}",
+		credentials.Wrap(factory, cvePodsOneHandler(registry, cveMgr)))
+	router.Post("/api/clusters/{cluster}/cve/refresh",
+		credentials.Wrap(factory, cveRefreshHandler(registry, cveMgr, auditEmitter)))
+
 	// --- Overview / dashboard ---
 
 	router.Get("/api/clusters/{cluster}/dashboard", credentials.Wrap(factory,

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -456,6 +456,8 @@ func main() {
 		credentials.Wrap(factory, cvePodsHandler(registry, cveMgr)))
 	router.Get("/api/clusters/{cluster}/cve/pods/{namespace}/{pod}",
 		credentials.Wrap(factory, cvePodsOneHandler(registry, cveMgr)))
+	router.Get("/api/clusters/{cluster}/cve/by-workload/{kind}/{namespace}/{name}",
+		credentials.Wrap(factory, cveByWorkloadHandler(registry, cveMgr)))
 	router.Post("/api/clusters/{cluster}/cve/refresh",
 		credentials.Wrap(factory, cveRefreshHandler(registry, cveMgr, auditEmitter)))
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -646,6 +646,54 @@ shape as a single entry in `/cve/pods`; returns **404** if the
 pod isn't in the informer cache, **503** if the informer hasn't
 started yet (rare cold-path race).
 
+#### `GET /api/clusters/{cluster}/cve/by-workload/{kind}/{namespace}/{name}`
+
+Owner-aware aggregation: returns every pod owned (directly or
+transitively) by the named workload, plus the workload-wide
+rolled-up severity and scan coverage. The reason this exists as
+a separate endpoint instead of a `?ownerKind=` filter on
+`/cve/pods`: in production, operators reason in Deployments /
+StatefulSets / DaemonSets — the Pod is ephemeral, the workload
+is the stable identity. The SPA detail-pane Security tab calls
+this on workload selection.
+
+Supported `kind` values: `Deployment`, `StatefulSet`,
+`DaemonSet`, `ReplicaSet`, `Job`. `CronJob` is intentionally
+omitted (Pod → Job → CronJob is a three-hop ownerRef walk that
+would need a Job informer too; revisit in v1.2 if needed).
+Unsupported kinds return **400**.
+
+Ownership resolution:
+- Direct: pod ownerRef matches `(kind, name)`. Covers
+  StatefulSet, DaemonSet, ReplicaSet, Job.
+- Two-hop via ReplicaSet: pod owned by ReplicaSet R; R owned
+  by `(Deployment, name)`. Covers the Deployment case, since
+  the Deployment controller spawns a ReplicaSet which spawns
+  pods.
+
+```json
+{
+  "workload": { "kind": "Deployment", "namespace": "payments", "name": "checkout" },
+  "pods": [
+    { /* PodRow shape — same as /cve/pods entries */ },
+    ...
+  ],
+  "rolledUpSeverityCounts": { "critical": 0, "high": 3, "medium": 7, "low": 1, "informational": 0 },
+  "scanCoverage": "partial",
+  "inspectorEnabled": true,
+  "hydrated": true
+}
+```
+
+**No backend dedup.** A 20-replica Deployment with identical
+image digests across replicas returns 20 PodRow entries; the
+SPA collapses duplicate digests client-side via `useMemo` so
+the detail pane renders one canonical container row per
+digest with a "× 20 pods" annotation. (v1.1 design choice —
+if it bites at scale we can add `?dedup=true` server-side.)
+
+Same ETag + empty-state contract as the other read endpoints.
+
 #### `POST /api/clusters/{cluster}/cve/refresh`
 
 Force-fetch the listed digests/instances from Inspector, bypassing

--- a/docs/api.md
+++ b/docs/api.md
@@ -560,7 +560,13 @@ pre-built `inspectorUrl` deep-link for the AWS console.
       "title": "openssl vulnerability ...",
       "firstObservedAt": "2026-04-01T00:00:00Z",
       "lastObservedAt": "2026-05-10T12:00:00Z",
-      "inspectorUrl": "https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings?findingArn=..."
+      "inspectorUrl": "https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings?findingArn=...",
+      "description": "Buffer-overflow in libfoo lets a remote attacker crash the process. ...",
+      "remediation": "Upgrade openssl to 1.0.1 or later.",
+      "remediationUrl": "https://nvd.nist.gov/vuln/detail/CVE-2026-12345",
+      "epssScore": 0.87,
+      "exploitAvailable": "YES",
+      "fixAvailable": "YES"
     }
   ],
   "lastFetchedAt": "2026-05-11T08:14:32Z",
@@ -568,6 +574,16 @@ pre-built `inspectorUrl` deep-link for the AWS console.
   "hydrated": true
 }
 ```
+
+Operator-actionable detail beyond the chip surface:
+
+- `description` — long-form prose from Inspector ("what is this CVE").
+- `remediation` / `remediationUrl` — vendor-supplied "how to fix" guidance + link, when Inspector ships one.
+- `epssScore` — Exploit Prediction Scoring System probability (0.0-1.0). 0 when Inspector did not report one.
+- `exploitAvailable` — `YES` / `NO` / empty (unset).
+- `fixAvailable`     — `YES` / `NO` / `PARTIAL` / empty. Operators get the categorical flag alongside the concrete `fixedVersion` string.
+
+These fields are part of the cached Finding so the SPA detail drawer renders inline without a second Inspector round-trip.
 
 Returns **404** if the instance isn't in the cache (typo, terminated,
 or not yet hydrated).

--- a/docs/api.md
+++ b/docs/api.md
@@ -476,6 +476,193 @@ contract between server and `periscope-agent` only.
    even with a still-valid cert.
 
 
+### `/api/clusters/{cluster}/cve/*` — Inspector v2 CVE surface (v1.1+)
+
+Seven endpoints. All reads serve from the per-cluster local store
+(populated by the background Inspector v2 scanner, see
+[`docs/setup/cluster-rbac.md`](setup/cluster-rbac.md#aws-inspector-v2-optional-v11));
+the SPA never hits Inspector directly. Cold first-read blocks on the
+~10-30s hydrate; subsequent reads are O(1) map lookups.
+
+**Empty-state contract.** When the operator has `inspector.enabled:
+false` in Helm, OR the AWS account doesn't have Inspector v2 enabled
+/ the IAM grant is missing, every endpoint returns HTTP **200** with
+`{"inspectorEnabled": false, "hydrated": true, ...}`. There is no
+error envelope for this state — the SPA reads `inspectorEnabled` and
+renders the "Inspector v2 not enabled" hint. Don't script around
+transport errors for this case; check the flag.
+
+**Caching.** Read endpoints set:
+- `Cache-Control: no-store` — the SPA's TanStack Query layer handles
+  client-side cache.
+- `ETag: W/"<lastHydrate-nanos>-<digestCount>-<instanceCount>"` —
+  weak validator. Clients sending matching `If-None-Match` get **304
+  Not Modified**. The ETag changes when a hydrate or eviction
+  shifts the store; per-entry delta refreshes (a single digest
+  re-fetch from the watch hook) do NOT bump it — chips don't need
+  real-time accuracy. Operators who want immediate confirmation of a
+  fix should POST `/refresh` and re-read.
+
+#### `GET /api/clusters/{cluster}/cve/status`
+
+Cache state. Does NOT trigger a cold hydrate — the SPA polls this
+during the spinner state without forcing 30s of Inspector traffic.
+
+```json
+{
+  "inspectorEnabled": true,
+  "hydrated": true,
+  "lastHydrate": "2026-05-11T08:14:32Z",
+  "entryCounts": { "digests": 412, "instances": 47 }
+}
+```
+
+`lastHydrate` is omitted when `hydrated: false`.
+
+#### `GET /api/clusters/{cluster}/cve/by-instance`
+
+Per-instance severity counts joined to the instance's owner
+(managed nodegroup / Karpenter NodeClaim / unmanaged) and the
+underlying AMI. Ordered by `instanceId`.
+
+```json
+{
+  "instances": [
+    {
+      "instanceId": "i-0abc",
+      "owner": { "kind": "karpenter-nodeclaim", "name": "default-9f3kz" },
+      "ami": "ami-0xyz",
+      "severityCounts": { "critical": 2, "high": 5, "medium": 12, "low": 3, "informational": 0 },
+      "lastFetchedAt": "2026-05-11T08:14:32Z"
+    }
+  ],
+  "inspectorEnabled": true,
+  "hydrated": true
+}
+```
+
+#### `GET /api/clusters/{cluster}/cve/by-instance/{instanceID}`
+
+Full Inspector findings for one instance. Each `finding` carries the
+pre-built `inspectorUrl` deep-link for the AWS console.
+
+```json
+{
+  "findings": [
+    {
+      "resourceId": "i-0abc",
+      "cve": "CVE-2026-12345",
+      "severity": "HIGH",
+      "cvssV3Score": 7.5,
+      "packageName": "openssl",
+      "packageVersion": "1.0.0",
+      "fixedVersion": "1.0.1",
+      "title": "openssl vulnerability ...",
+      "firstObservedAt": "2026-04-01T00:00:00Z",
+      "lastObservedAt": "2026-05-10T12:00:00Z",
+      "inspectorUrl": "https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings?findingArn=..."
+    }
+  ],
+  "lastFetchedAt": "2026-05-11T08:14:32Z",
+  "inspectorEnabled": true,
+  "hydrated": true
+}
+```
+
+Returns **404** if the instance isn't in the cache (typo, terminated,
+or not yet hydrated).
+
+#### `GET /api/clusters/{cluster}/cve/by-digest/{digest}`
+
+Full findings for one ECR image digest. The `{digest}` segment is the
+bare `sha256:abc...` hash; chi unescapes the colon. Same response
+shape as `by-instance/{instanceID}` with the resource ID set to the
+digest. Returns **404** when the digest isn't in the cache.
+
+#### `GET /api/clusters/{cluster}/cve/pods?cursor=<b64>`
+
+Per-pod aggregate. Walks the long-lived pod informer's index;
+returns 100 pods per page (no override knob — frontend pages further
+locally if needed). `next` is `base64(namespace/podname)` of the last
+pod on the page; pass it back as `?cursor=...` for the next page.
+Returned `next` is empty when the last page is exhausted.
+
+```json
+{
+  "pods": [
+    {
+      "namespace": "payments",
+      "name": "checkout-7b9-xyz",
+      "containers": [
+        { "name": "app",     "image": "...dkr.ecr...amazonaws.com/app:v1", "digest": "sha256:abc", "scanState": "scanned", "severityCounts": { "critical": 0, "high": 3, "medium": 7, "low": 1, "informational": 0 } },
+        { "name": "sidecar", "image": "docker.io/foo:1.2",                                          "scanState": "non-ecr" }
+      ],
+      "rolledUpSeverityCounts": { "critical": 0, "high": 3, "medium": 7, "low": 1, "informational": 0 },
+      "scanCoverage": "partial"
+    }
+  ],
+  "next": "cGF5bWVudHMvY2hlY2tvdXQtN2I5LXh5eg",
+  "inspectorEnabled": true,
+  "hydrated": true
+}
+```
+
+**Container `scanState`**:
+- `scanned` — ECR image with a resolved digest; findings looked up.
+- `non-ecr` — image isn't in ECR (docker.io, ghcr.io, etc.); Inspector
+  v2 doesn't cover it.
+- `pending` — ECR image but `containerStatus.imageID` is empty (pod
+  mid-pull). A later poll resolves to `scanned`.
+
+**Pod `scanCoverage`**:
+- `full` — every container scanned.
+- `partial` — at least one scanned, at least one non-ecr/pending.
+- `none` — zero scanned.
+
+**Cursor stability.** A pod created between page 1 and page 2 can
+shift the lex order; under churn an operator may see a single
+skip/duplicate during paging. This is acceptable for v1.1.
+
+#### `GET /api/clusters/{cluster}/cve/pods/{namespace}/{pod}`
+
+Single pod, full per-container findings. Returns the same `PodRow`
+shape as a single entry in `/cve/pods`; returns **404** if the
+pod isn't in the informer cache, **503** if the informer hasn't
+started yet (rare cold-path race).
+
+#### `POST /api/clusters/{cluster}/cve/refresh`
+
+Force-fetch the listed digests/instances from Inspector, bypassing
+TTL. Synchronous: returns **200** when the refresh completes.
+
+```json
+{
+  "digests":     ["sha256:abc", "sha256:def"],
+  "instanceIds": ["i-0abc"]
+}
+```
+
+Both fields optional. An empty body is accepted (logs the operator's
+"I checked" intent without forcing a fetch).
+
+Returns **202** with `Next-Poll: 2` (seconds) when the cluster's cold
+hydrate is still in flight — the SPA polls `/cve/status` until
+`hydrated: true` and resubmits. The 202 response also emits the
+audit row.
+
+**Audit.** Each call emits exactly one audit row:
+
+```
+verb=cve_refresh outcome=success
+extra={ digests: [...], instanceIds: [...] }
+```
+
+Reads of the CVE surface do NOT emit audit rows — they are internal
+metadata reads. AWS CloudTrail records the underlying Inspector API
+calls against the periscope-server's role; that's the auditable
+trail for "what did the server fetch."
+
+
 ## 4. Tier 2 — SPA-coupled patterns
 
 The remaining ~130 endpoints follow eight patterns. Specific

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -200,6 +200,15 @@ const (
 	// are torn down with the addon.
 	VerbEKSAddonDeleteIntent Verb = "eks_addon_delete_intent"
 	VerbEKSAddonDelete       Verb = "eks_addon_delete"
+	// VerbCveRefresh records an operator-initiated CVE cache refresh
+	// (POST /api/clusters/{cluster}/cve/refresh, #165). Reads of the
+	// cache itself do NOT emit audit rows — they are internal metadata
+	// reads, with AWS CloudTrail covering the underlying Inspector
+	// calls under the periscope-server role. The refresh action is the
+	// one operator-initiated mutation in the CVE surface, so it lands
+	// in the audit log so a reviewer can see who forced a re-scan and
+	// what they targeted. Extra carries `digests` and `instanceIds`.
+	VerbCveRefresh Verb = "cve_refresh"
 )
 
 // Outcome is the result classification.

--- a/internal/awsec2/client.go
+++ b/internal/awsec2/client.go
@@ -20,6 +20,7 @@ import (
 // InstanceMeta is the projected EC2 metadata the owner resolver needs.
 type InstanceMeta struct {
 	InstanceID string
+	AMI        string
 	Tags       map[string]string
 }
 
@@ -80,6 +81,9 @@ func (c *Client) DescribeInstances(ctx context.Context, ids []string) ([]Instanc
 
 func projectInstance(in ec2types.Instance) InstanceMeta {
 	m := InstanceMeta{Tags: make(map[string]string, len(in.Tags))}
+	if in.ImageId != nil {
+		m.AMI = *in.ImageId
+	}
 	if in.InstanceId != nil {
 		m.InstanceID = *in.InstanceId
 	}

--- a/internal/awsinspector/client.go
+++ b/internal/awsinspector/client.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -32,12 +33,23 @@ const BatchSize = 50
 
 // Finding is the flat CVE record the CVE store keeps in memory. It is
 // the package's public DTO; callers should never touch the SDK types
-// directly. One Inspector finding may legitimately cover multiple
-// vulnerable packages — we keep the first one's name+version+fix to
-// avoid combinatorial explosion in the store; the API layer (#165) can
-// re-fetch full detail via BatchGetFindingDetails if a drill-down view
-// is needed in v1.2.
+// directly.
+//
+// ResourceID is the join key the cve store uses to bucket findings
+// into per-resource entries: the EC2 instance ID (i-…) for instance
+// findings, the bare ECR image hash (sha256:…) for image findings.
+// Without it, every entry would receive every finding (the very bug
+// the v1.1 review caught).
+//
+// PackageName / PackageVersion / FixedVersion summarise the
+// VulnerablePackages slice on the SDK finding. When a single finding
+// covers more than one package (e.g. openssl + libcrypto), package
+// names are concatenated with a comma so the chip surface does not
+// silently under-report; PackageVersion / FixedVersion track the
+// first package's values so the existing detail-drawer copy keeps
+// working.
 type Finding struct {
+	ResourceID      string
 	ARN             string
 	Title           string
 	CVE             string
@@ -101,29 +113,40 @@ func (c *Client) IsEnabled(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// ListFindingsByInstance returns findings keyed on EC2 instance ID.
+// ListFindingsByInstance returns findings grouped by EC2 instance ID.
 // Inputs are deduped and batched into BatchSize-sized chunks; each
-// chunk is paginated end-to-end before the next chunk starts. The
-// returned slice is the union of every page from every chunk.
-func (c *Client) ListFindingsByInstance(ctx context.Context, instanceIDs []string) ([]Finding, error) {
-	return c.listByIDs(ctx, dedup(instanceIDs), filterByInstance)
+// chunk is paginated end-to-end before the next chunk starts. Every
+// requested ID is present in the result map (with an empty slice
+// when Inspector returned no findings for it) so callers can iterate
+// the input list and trust the lookup.
+func (c *Client) ListFindingsByInstance(ctx context.Context, instanceIDs []string) (map[string][]Finding, error) {
+	ids := dedup(instanceIDs)
+	out, err := c.listByIDs(ctx, ids, filterByInstance)
+	ensureKeys(out, ids)
+	return out, err
 }
 
-// ListFindingsByImageDigest returns findings keyed on ECR image
-// digest (the sha256:... hash, not the docker-pullable:// URI). The
-// caller is responsible for stripping the prefix before calling —
-// see (k8s/imageid).Normalize.
-func (c *Client) ListFindingsByImageDigest(ctx context.Context, digests []string) ([]Finding, error) {
-	return c.listByIDs(ctx, dedup(digests), filterByDigest)
+// ListFindingsByImageDigest returns findings grouped by ECR image
+// digest (the bare sha256:... hash, not the docker-pullable:// URI).
+// The caller is responsible for stripping the prefix before calling
+// — see (cve).normalizeImageID. Same per-key guarantee as
+// ListFindingsByInstance.
+func (c *Client) ListFindingsByImageDigest(ctx context.Context, digests []string) (map[string][]Finding, error) {
+	ids := dedup(digests)
+	out, err := c.listByIDs(ctx, ids, filterByDigest)
+	ensureKeys(out, ids)
+	return out, err
 }
 
 // listByIDs is the shared batching + pagination loop. mkFilter builds
-// the FilterCriteria for a chunk of IDs.
-func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]string) *itypes.FilterCriteria) ([]Finding, error) {
+// the FilterCriteria for a chunk of IDs. Returns findings grouped by
+// their ResourceID (each SDK finding is fanned out across its
+// Resources[] entries, see projectFinding).
+func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]string) *itypes.FilterCriteria) (map[string][]Finding, error) {
+	out := make(map[string][]Finding)
 	if len(ids) == 0 {
-		return nil, nil
+		return out, nil
 	}
-	var out []Finding
 	for chunk := range chunked(ids, BatchSize) {
 		input := &inspector2.ListFindingsInput{FilterCriteria: mkFilter(chunk)}
 		paginator := inspector2.NewListFindingsPaginator(c.api, input)
@@ -137,11 +160,25 @@ func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]st
 				return out, fmt.Errorf("inspector list findings: %w", err)
 			}
 			for i := range page.Findings {
-				out = append(out, projectFinding(page.Findings[i], c.region))
+				for _, f := range projectFinding(page.Findings[i], c.region) {
+					out[f.ResourceID] = append(out[f.ResourceID], f)
+				}
 			}
 		}
 	}
 	return out, nil
+}
+
+// ensureKeys guarantees every requested ID is present in m, with an
+// empty slice when Inspector returned no findings. Callers iterating
+// the input list (for upserts) can then trust m[id] without a nil
+// check.
+func ensureKeys(m map[string][]Finding, ids []string) {
+	for _, id := range ids {
+		if _, ok := m[id]; !ok {
+			m[id] = nil
+		}
+	}
 }
 
 // filterByInstance builds a FilterCriteria matching findings whose
@@ -174,47 +211,90 @@ func filterByDigest(digests []string) *itypes.FilterCriteria {
 	return &itypes.FilterCriteria{EcrImageHash: filters}
 }
 
-// projectFinding flattens an Inspector v2 SDK finding into our DTO.
-// Missing optional fields collapse to zero-values — the store treats
-// them as "unknown" without special-casing.
-func projectFinding(f itypes.Finding, region string) Finding {
-	out := Finding{
+// projectFinding flattens an Inspector v2 SDK finding into our DTOs,
+// returning ONE Finding per Resources[] entry on the source. A
+// finding with two resources (rare, but happens when a CVE matches
+// the same package on two co-scanned images) yields two store rows
+// with the shared CVE metadata and per-resource ResourceID. Findings
+// with zero recognisable resources are skipped — the store has no
+// meaningful key to file them under.
+func projectFinding(f itypes.Finding, region string) []Finding {
+	if len(f.Resources) == 0 {
+		return nil
+	}
+	base := Finding{
 		ARN:      deref(f.FindingArn),
 		Title:    deref(f.Title),
 		Severity: string(f.Severity),
 	}
 	if f.FirstObservedAt != nil {
-		out.FirstObservedAt = *f.FirstObservedAt
+		base.FirstObservedAt = *f.FirstObservedAt
 	}
 	if f.LastObservedAt != nil {
-		out.LastObservedAt = *f.LastObservedAt
+		base.LastObservedAt = *f.LastObservedAt
 	}
 	if vd := f.PackageVulnerabilityDetails; vd != nil {
-		out.CVE = deref(vd.VulnerabilityId)
-		if len(vd.Cvss) > 0 {
-			// Pick the highest score across reported sources so the
-			// store keeps the worst case — operators want the chip
-			// to reflect "how bad is this", not "what does NVD think
-			// specifically". Source-attribution lives on the detail
-			// drawer in v1.2.
-			for _, s := range vd.Cvss {
-				if s.BaseScore == nil {
-					continue
-				}
-				if *s.BaseScore > out.CVSSv3Score {
-					out.CVSSv3Score = *s.BaseScore
-				}
+		base.CVE = deref(vd.VulnerabilityId)
+		// Pick the highest score across reported sources so the
+		// store keeps the worst case — operators want the chip to
+		// reflect "how bad is this", not "what does NVD think
+		// specifically". Source-attribution lives on the detail
+		// drawer in v1.2.
+		for _, s := range vd.Cvss {
+			if s.BaseScore == nil {
+				continue
+			}
+			if *s.BaseScore > base.CVSSv3Score {
+				base.CVSSv3Score = *s.BaseScore
 			}
 		}
+		// One finding can list multiple vulnerable packages; concat
+		// names with a comma so the chip surface doesn't silently
+		// hide co-vulnerable libs (e.g. openssl + libcrypto). Keep
+		// the first package's version + fix on the flat fields so
+		// the existing single-package UI still renders.
 		if len(vd.VulnerablePackages) > 0 {
-			p := vd.VulnerablePackages[0]
-			out.PackageName = deref(p.Name)
-			out.PackageVersion = deref(p.Version)
-			out.FixedVersion = deref(p.FixedInVersion)
+			names := make([]string, 0, len(vd.VulnerablePackages))
+			for _, p := range vd.VulnerablePackages {
+				if n := deref(p.Name); n != "" {
+					names = append(names, n)
+				}
+			}
+			base.PackageName = strings.Join(names, ", ")
+			first := vd.VulnerablePackages[0]
+			base.PackageVersion = deref(first.Version)
+			base.FixedVersion = deref(first.FixedInVersion)
 		}
 	}
-	out.InspectorURL = buildConsoleURL(region, deref(f.FindingArn))
+	base.InspectorURL = buildConsoleURL(region, deref(f.FindingArn))
+
+	out := make([]Finding, 0, len(f.Resources))
+	for _, r := range f.Resources {
+		id := resourceJoinKey(r)
+		if id == "" {
+			continue
+		}
+		c := base
+		c.ResourceID = id
+		out = append(out, c)
+	}
 	return out
+}
+
+// resourceJoinKey returns the cve-store join key for an Inspector
+// resource entry: instance ID for EC2, bare image hash for ECR,
+// empty otherwise (caller skips). Mirrors the Resource.Type → store
+// bucket the cve module already uses.
+func resourceJoinKey(r itypes.Resource) string {
+	switch r.Type {
+	case itypes.ResourceTypeAwsEcrContainerImage:
+		if r.Details != nil && r.Details.AwsEcrContainerImage != nil {
+			return deref(r.Details.AwsEcrContainerImage.ImageHash)
+		}
+	case itypes.ResourceTypeAwsEc2Instance:
+		return deref(r.Id)
+	}
+	return ""
 }
 
 // buildConsoleURL produces an AWS console deep-link to the finding.

--- a/internal/awsinspector/client.go
+++ b/internal/awsinspector/client.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -33,23 +32,12 @@ const BatchSize = 50
 
 // Finding is the flat CVE record the CVE store keeps in memory. It is
 // the package's public DTO; callers should never touch the SDK types
-// directly.
-//
-// ResourceID is the join key the cve store uses to bucket findings
-// into per-resource entries: the EC2 instance ID (i-…) for instance
-// findings, the bare ECR image hash (sha256:…) for image findings.
-// Without it, every entry would receive every finding (the very bug
-// the v1.1 review caught).
-//
-// PackageName / PackageVersion / FixedVersion summarise the
-// VulnerablePackages slice on the SDK finding. When a single finding
-// covers more than one package (e.g. openssl + libcrypto), package
-// names are concatenated with a comma so the chip surface does not
-// silently under-report; PackageVersion / FixedVersion track the
-// first package's values so the existing detail-drawer copy keeps
-// working.
+// directly. One Inspector finding may legitimately cover multiple
+// vulnerable packages — we keep the first one's name+version+fix to
+// avoid combinatorial explosion in the store; the API layer (#165) can
+// re-fetch full detail via BatchGetFindingDetails if a drill-down view
+// is needed in v1.2.
 type Finding struct {
-	ResourceID      string
 	ARN             string
 	Title           string
 	CVE             string
@@ -113,40 +101,29 @@ func (c *Client) IsEnabled(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// ListFindingsByInstance returns findings grouped by EC2 instance ID.
+// ListFindingsByInstance returns findings keyed on EC2 instance ID.
 // Inputs are deduped and batched into BatchSize-sized chunks; each
-// chunk is paginated end-to-end before the next chunk starts. Every
-// requested ID is present in the result map (with an empty slice
-// when Inspector returned no findings for it) so callers can iterate
-// the input list and trust the lookup.
-func (c *Client) ListFindingsByInstance(ctx context.Context, instanceIDs []string) (map[string][]Finding, error) {
-	ids := dedup(instanceIDs)
-	out, err := c.listByIDs(ctx, ids, filterByInstance)
-	ensureKeys(out, ids)
-	return out, err
+// chunk is paginated end-to-end before the next chunk starts. The
+// returned slice is the union of every page from every chunk.
+func (c *Client) ListFindingsByInstance(ctx context.Context, instanceIDs []string) ([]Finding, error) {
+	return c.listByIDs(ctx, dedup(instanceIDs), filterByInstance)
 }
 
-// ListFindingsByImageDigest returns findings grouped by ECR image
-// digest (the bare sha256:... hash, not the docker-pullable:// URI).
-// The caller is responsible for stripping the prefix before calling
-// — see (cve).normalizeImageID. Same per-key guarantee as
-// ListFindingsByInstance.
-func (c *Client) ListFindingsByImageDigest(ctx context.Context, digests []string) (map[string][]Finding, error) {
-	ids := dedup(digests)
-	out, err := c.listByIDs(ctx, ids, filterByDigest)
-	ensureKeys(out, ids)
-	return out, err
+// ListFindingsByImageDigest returns findings keyed on ECR image
+// digest (the sha256:... hash, not the docker-pullable:// URI). The
+// caller is responsible for stripping the prefix before calling —
+// see (k8s/imageid).Normalize.
+func (c *Client) ListFindingsByImageDigest(ctx context.Context, digests []string) ([]Finding, error) {
+	return c.listByIDs(ctx, dedup(digests), filterByDigest)
 }
 
 // listByIDs is the shared batching + pagination loop. mkFilter builds
-// the FilterCriteria for a chunk of IDs. Returns findings grouped by
-// their ResourceID (each SDK finding is fanned out across its
-// Resources[] entries, see projectFinding).
-func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]string) *itypes.FilterCriteria) (map[string][]Finding, error) {
-	out := make(map[string][]Finding)
+// the FilterCriteria for a chunk of IDs.
+func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]string) *itypes.FilterCriteria) ([]Finding, error) {
 	if len(ids) == 0 {
-		return out, nil
+		return nil, nil
 	}
+	var out []Finding
 	for chunk := range chunked(ids, BatchSize) {
 		input := &inspector2.ListFindingsInput{FilterCriteria: mkFilter(chunk)}
 		paginator := inspector2.NewListFindingsPaginator(c.api, input)
@@ -160,25 +137,11 @@ func (c *Client) listByIDs(ctx context.Context, ids []string, mkFilter func([]st
 				return out, fmt.Errorf("inspector list findings: %w", err)
 			}
 			for i := range page.Findings {
-				for _, f := range projectFinding(page.Findings[i], c.region) {
-					out[f.ResourceID] = append(out[f.ResourceID], f)
-				}
+				out = append(out, projectFinding(page.Findings[i], c.region))
 			}
 		}
 	}
 	return out, nil
-}
-
-// ensureKeys guarantees every requested ID is present in m, with an
-// empty slice when Inspector returned no findings. Callers iterating
-// the input list (for upserts) can then trust m[id] without a nil
-// check.
-func ensureKeys(m map[string][]Finding, ids []string) {
-	for _, id := range ids {
-		if _, ok := m[id]; !ok {
-			m[id] = nil
-		}
-	}
 }
 
 // filterByInstance builds a FilterCriteria matching findings whose
@@ -211,90 +174,47 @@ func filterByDigest(digests []string) *itypes.FilterCriteria {
 	return &itypes.FilterCriteria{EcrImageHash: filters}
 }
 
-// projectFinding flattens an Inspector v2 SDK finding into our DTOs,
-// returning ONE Finding per Resources[] entry on the source. A
-// finding with two resources (rare, but happens when a CVE matches
-// the same package on two co-scanned images) yields two store rows
-// with the shared CVE metadata and per-resource ResourceID. Findings
-// with zero recognisable resources are skipped — the store has no
-// meaningful key to file them under.
-func projectFinding(f itypes.Finding, region string) []Finding {
-	if len(f.Resources) == 0 {
-		return nil
-	}
-	base := Finding{
+// projectFinding flattens an Inspector v2 SDK finding into our DTO.
+// Missing optional fields collapse to zero-values — the store treats
+// them as "unknown" without special-casing.
+func projectFinding(f itypes.Finding, region string) Finding {
+	out := Finding{
 		ARN:      deref(f.FindingArn),
 		Title:    deref(f.Title),
 		Severity: string(f.Severity),
 	}
 	if f.FirstObservedAt != nil {
-		base.FirstObservedAt = *f.FirstObservedAt
+		out.FirstObservedAt = *f.FirstObservedAt
 	}
 	if f.LastObservedAt != nil {
-		base.LastObservedAt = *f.LastObservedAt
+		out.LastObservedAt = *f.LastObservedAt
 	}
 	if vd := f.PackageVulnerabilityDetails; vd != nil {
-		base.CVE = deref(vd.VulnerabilityId)
-		// Pick the highest score across reported sources so the
-		// store keeps the worst case — operators want the chip to
-		// reflect "how bad is this", not "what does NVD think
-		// specifically". Source-attribution lives on the detail
-		// drawer in v1.2.
-		for _, s := range vd.Cvss {
-			if s.BaseScore == nil {
-				continue
-			}
-			if *s.BaseScore > base.CVSSv3Score {
-				base.CVSSv3Score = *s.BaseScore
-			}
-		}
-		// One finding can list multiple vulnerable packages; concat
-		// names with a comma so the chip surface doesn't silently
-		// hide co-vulnerable libs (e.g. openssl + libcrypto). Keep
-		// the first package's version + fix on the flat fields so
-		// the existing single-package UI still renders.
-		if len(vd.VulnerablePackages) > 0 {
-			names := make([]string, 0, len(vd.VulnerablePackages))
-			for _, p := range vd.VulnerablePackages {
-				if n := deref(p.Name); n != "" {
-					names = append(names, n)
+		out.CVE = deref(vd.VulnerabilityId)
+		if len(vd.Cvss) > 0 {
+			// Pick the highest score across reported sources so the
+			// store keeps the worst case — operators want the chip
+			// to reflect "how bad is this", not "what does NVD think
+			// specifically". Source-attribution lives on the detail
+			// drawer in v1.2.
+			for _, s := range vd.Cvss {
+				if s.BaseScore == nil {
+					continue
+				}
+				if *s.BaseScore > out.CVSSv3Score {
+					out.CVSSv3Score = *s.BaseScore
 				}
 			}
-			base.PackageName = strings.Join(names, ", ")
-			first := vd.VulnerablePackages[0]
-			base.PackageVersion = deref(first.Version)
-			base.FixedVersion = deref(first.FixedInVersion)
+		}
+		if len(vd.VulnerablePackages) > 0 {
+			p := vd.VulnerablePackages[0]
+			out.PackageName = deref(p.Name)
+			out.PackageVersion = deref(p.Version)
+			out.FixedVersion = deref(p.FixedInVersion)
 		}
 	}
-	base.InspectorURL = buildConsoleURL(region, deref(f.FindingArn))
-
-	out := make([]Finding, 0, len(f.Resources))
-	for _, r := range f.Resources {
-		id := resourceJoinKey(r)
-		if id == "" {
-			continue
-		}
-		c := base
-		c.ResourceID = id
-		out = append(out, c)
-	}
+	out.InspectorURL = buildConsoleURL(region, deref(f.FindingArn))
 	return out
-}
-
-// resourceJoinKey returns the cve-store join key for an Inspector
-// resource entry: instance ID for EC2, bare image hash for ECR,
-// empty otherwise (caller skips). Mirrors the Resource.Type → store
-// bucket the cve module already uses.
-func resourceJoinKey(r itypes.Resource) string {
-	switch r.Type {
-	case itypes.ResourceTypeAwsEcrContainerImage:
-		if r.Details != nil && r.Details.AwsEcrContainerImage != nil {
-			return deref(r.Details.AwsEcrContainerImage.ImageHash)
-		}
-	case itypes.ResourceTypeAwsEc2Instance:
-		return deref(r.Id)
-	}
-	return ""
 }
 
 // buildConsoleURL produces an AWS console deep-link to the finding.

--- a/internal/awsinspector/client.go
+++ b/internal/awsinspector/client.go
@@ -48,19 +48,31 @@ const BatchSize = 50
 // silently under-report; PackageVersion / FixedVersion track the
 // first package's values so the existing detail-drawer copy keeps
 // working.
+//
+// Description / Remediation / EPSSScore / ExploitAvailable / FixAvailable
+// carry the operator-actionable detail Inspector ships beyond the chip
+// surface — surfaced by the drill-down endpoints (#165) so the SPA can
+// render "what is this CVE" + "how do I fix it" inline without a second
+// Inspector round-trip.
 type Finding struct {
-	ResourceID      string
-	ARN             string
-	Title           string
-	CVE             string
-	Severity        string
-	CVSSv3Score     float64
-	PackageName     string
-	PackageVersion  string
-	FixedVersion    string
-	FirstObservedAt time.Time
-	LastObservedAt  time.Time
-	InspectorURL    string
+	ResourceID      string    `json:"resourceId"`
+	ARN             string    `json:"arn"`
+	Title           string    `json:"title"`
+	CVE             string    `json:"cve"`
+	Severity        string    `json:"severity"`
+	CVSSv3Score     float64   `json:"cvssV3Score"`
+	PackageName     string    `json:"packageName"`
+	PackageVersion  string    `json:"packageVersion"`
+	FixedVersion    string    `json:"fixedVersion"`
+	FirstObservedAt time.Time `json:"firstObservedAt"`
+	LastObservedAt  time.Time `json:"lastObservedAt"`
+	Description     string    `json:"description,omitempty"`
+	Remediation     string    `json:"remediation,omitempty"`     // Inspector recommendation text
+	RemediationURL  string    `json:"remediationUrl,omitempty"`  // CVE vendor / NVD link
+	EPSSScore       float64   `json:"epssScore,omitempty"`       // Exploit Prediction Scoring System probability
+	ExploitAvailable string   `json:"exploitAvailable,omitempty"` // YES / NO / empty
+	FixAvailable    string    `json:"fixAvailable,omitempty"`    // YES / NO / PARTIAL / empty
+	InspectorURL    string    `json:"inspectorUrl"`
 }
 
 // API is the subset of the Inspector v2 client surface this package
@@ -267,6 +279,18 @@ func projectFinding(f itypes.Finding, region string) []Finding {
 		}
 	}
 	base.InspectorURL = buildConsoleURL(region, deref(f.FindingArn))
+
+	// Operator-actionable detail beyond the chip surface.
+	base.Description = deref(f.Description)
+	if f.Remediation != nil && f.Remediation.Recommendation != nil {
+		base.Remediation = deref(f.Remediation.Recommendation.Text)
+		base.RemediationURL = deref(f.Remediation.Recommendation.Url)
+	}
+	if f.Epss != nil {
+		base.EPSSScore = f.Epss.Score
+	}
+	base.ExploitAvailable = string(f.ExploitAvailable)
+	base.FixAvailable = string(f.FixAvailable)
 
 	out := make([]Finding, 0, len(f.Resources))
 	for _, r := range f.Resources {

--- a/internal/awsinspector/client_test.go
+++ b/internal/awsinspector/client_test.go
@@ -83,49 +83,34 @@ func TestIsEnabled_OtherErrorPropagates(t *testing.T) {
 	}
 }
 
-// instanceFinding builds a stub SDK finding pinned to an EC2
-// instance resource so batching/pagination tests exercise the new
-// per-resource projection.
-func instanceFinding(instanceID string) itypes.Finding {
-	id := instanceID
-	arn := "arn:aws:inspector2:us-east-1:111:finding/" + instanceID
-	title := "t"
-	first := time.Unix(0, 0)
-	last := time.Unix(1, 0)
-	cve := "CVE-2026-0001"
-	vd := &itypes.PackageVulnerabilityDetails{VulnerabilityId: &cve}
-	return itypes.Finding{
-		FindingArn:                  &arn,
-		Title:                       &title,
-		FirstObservedAt:             &first,
-		LastObservedAt:              &last,
-		Severity:                    itypes.SeverityHigh,
-		PackageVulnerabilityDetails: vd,
-		Resources: []itypes.Resource{{
-			Type: itypes.ResourceTypeAwsEc2Instance,
-			Id:   &id,
-		}},
-	}
-}
-
 func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
-	// 120 instance IDs → 3 chunks of 50/50/20. Findings on each
-	// page are pinned to the first instance in the input list so
-	// the per-resource projection has a stable join key for the
-	// assertion at the end.
+	// 120 instance IDs → 3 chunks of 50/50/20. Each chunk paginates
+	// across 2 pages to exercise the paginator loop.
 	ids := make([]string, 120)
 	for i := range ids {
 		ids[i] = "i-" + strings.Repeat("0", 8-len(itoa(i))) + itoa(i)
 	}
 	page := func(n int) []itypes.Finding {
 		out := make([]itypes.Finding, n)
+		arn := "arn:aws:inspector2:us-east-1:111:finding/x"
+		title := "t"
+		first := time.Unix(0, 0)
+		last := time.Unix(1, 0)
+		cve := "CVE-2026-0001"
+		vd := &itypes.PackageVulnerabilityDetails{VulnerabilityId: &cve}
 		for i := range out {
-			out[i] = instanceFinding(ids[0])
+			out[i] = itypes.Finding{
+				FindingArn:                  &arn,
+				Title:                       &title,
+				FirstObservedAt:             &first,
+				LastObservedAt:              &last,
+				Severity:                    itypes.SeverityHigh,
+				PackageVulnerabilityDetails: vd,
+			}
 		}
 		return out
 	}
-	// 6 pages of 10 findings each: 60 results total — all attributed
-	// to ids[0] by the stub.
+	// 6 pages of 10 findings each: 60 results total.
 	api := &stubAPI{pages: [][]itypes.Finding{
 		page(10), page(10), page(10), page(10), page(10), page(10),
 	}}
@@ -134,13 +119,8 @@ func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFindingsByInstance: %v", err)
 	}
-	if total := len(got[ids[0]]); total != 60 {
-		t.Errorf("findings on ids[0]: want 60, got %d", total)
-	}
-	// Every requested ID is present in the map (nil slice when no
-	// findings).
-	if len(got) != 120 {
-		t.Errorf("map size: want 120 (all keys present), got %d", len(got))
+	if len(got) != 60 {
+		t.Errorf("findings: want 60, got %d", len(got))
 	}
 	// 3 chunks expected (50+50+20). The 6 seeded pages all drain
 	// inside chunk 1 (paginator keeps calling until NextToken is
@@ -149,11 +129,12 @@ func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
 	if got, want := len(api.captureFilters), 8; got != want {
 		t.Errorf("ListFindings calls: want %d, got %d", want, got)
 	}
+	// Chunk-boundary filter widths: 50 / 50 / 20.
 	chunkSizes := []int{50, 50, 50, 50, 50, 50, 50, 20}
 	for i, want := range chunkSizes {
-		f := api.captureFilters[i]
-		if f == nil || len(f.ResourceId) != want {
-			t.Errorf("call %d: want %d IDs in filter, got %d", i, want, len(f.ResourceId))
+		got := api.captureFilters[i]
+		if got == nil || len(got.ResourceId) != want {
+			t.Errorf("call %d: want %d IDs in filter, got %d", i, want, len(got.ResourceId))
 		}
 	}
 }
@@ -164,8 +145,7 @@ func TestListFindingsByDigest_DedupsAndSkipsEmpty(t *testing.T) {
 	}
 	api := &stubAPI{}
 	c := NewWithAPI(api, "us-east-1")
-	got, err := c.ListFindingsByImageDigest(context.Background(), digests)
-	if err != nil {
+	if _, err := c.ListFindingsByImageDigest(context.Background(), digests); err != nil {
 		t.Fatalf("ListFindingsByImageDigest: %v", err)
 	}
 	if len(api.captureFilters) != 1 {
@@ -174,24 +154,15 @@ func TestListFindingsByDigest_DedupsAndSkipsEmpty(t *testing.T) {
 	if got := api.captureFilters[0].EcrImageHash; len(got) != 2 {
 		t.Errorf("dedup: want 2 filters, got %d", len(got))
 	}
-	if _, ok := got["sha256:aaaa"]; !ok {
-		t.Errorf("ensureKeys missed sha256:aaaa: %v", got)
-	}
-	if _, ok := got["sha256:bbbb"]; !ok {
-		t.Errorf("ensureKeys missed sha256:bbbb: %v", got)
-	}
 }
 
 func TestProjectFinding_PicksHighestCVSS(t *testing.T) {
 	arn := "arn:test"
 	cve := "CVE-2026-9999"
-	name1 := "openssl"
-	name2 := "libcrypto"
+	name := "openssl"
 	ver := "1.0.0"
 	fix := "1.0.1"
 	score1, score2, score3 := 7.4, 9.1, 5.5
-	hash := "sha256:imagehash"
-
 	vd := &itypes.PackageVulnerabilityDetails{
 		VulnerabilityId: &cve,
 		Cvss: []itypes.CvssScore{
@@ -200,82 +171,22 @@ func TestProjectFinding_PicksHighestCVSS(t *testing.T) {
 			{BaseScore: &score3},
 		},
 		VulnerablePackages: []itypes.VulnerablePackage{
-			{Name: &name1, Version: &ver, FixedInVersion: &fix},
-			{Name: &name2, Version: &ver, FixedInVersion: &fix},
+			{Name: &name, Version: &ver, FixedInVersion: &fix},
 		},
 	}
-	resources := []itypes.Resource{{
-		Type: itypes.ResourceTypeAwsEcrContainerImage,
-		Id:   &hash,
-		Details: &itypes.ResourceDetails{
-			AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: &hash},
-		},
-	}}
-	projected := projectFinding(itypes.Finding{
+	got := projectFinding(itypes.Finding{
 		FindingArn:                  &arn,
 		Severity:                    itypes.SeverityCritical,
 		PackageVulnerabilityDetails: vd,
-		Resources:                   resources,
 	}, "eu-west-1")
-	if len(projected) != 1 {
-		t.Fatalf("projectFinding: want 1, got %d", len(projected))
-	}
-	got := projected[0]
 	if got.CVSSv3Score != 9.1 {
 		t.Errorf("cvss: want 9.1, got %v", got.CVSSv3Score)
 	}
-	if got.CVE != "CVE-2026-9999" {
-		t.Errorf("cve: got %q", got.CVE)
-	}
-	// Multi-package findings concatenate names so chips don't
-	// silently under-report.
-	if got.PackageName != "openssl, libcrypto" {
-		t.Errorf("package name: want %q, got %q", "openssl, libcrypto", got.PackageName)
-	}
-	if got.FixedVersion != "1.0.1" {
-		t.Errorf("fixed: got %q", got.FixedVersion)
-	}
-	if got.ResourceID != hash {
-		t.Errorf("resource id: want %q, got %q", hash, got.ResourceID)
+	if got.CVE != "CVE-2026-9999" || got.PackageName != "openssl" || got.FixedVersion != "1.0.1" {
+		t.Errorf("project: got %+v", got)
 	}
 	if !strings.Contains(got.InspectorURL, "eu-west-1") || !strings.Contains(got.InspectorURL, "arn:test") {
 		t.Errorf("inspector url: %q", got.InspectorURL)
-	}
-}
-
-func TestProjectFinding_FansOutAcrossResources(t *testing.T) {
-	// One SDK finding with two resources → two store rows. Mirrors
-	// the rare case where Inspector reports a CVE that matches the
-	// same package on two co-scanned resources.
-	arn := "arn:test"
-	hashA := "sha256:aaaa"
-	hashB := "sha256:bbbb"
-	mk := func(h *string) itypes.Resource {
-		return itypes.Resource{
-			Type: itypes.ResourceTypeAwsEcrContainerImage,
-			Id:   h,
-			Details: &itypes.ResourceDetails{
-				AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: h},
-			},
-		}
-	}
-	got := projectFinding(itypes.Finding{
-		FindingArn: &arn,
-		Severity:   itypes.SeverityHigh,
-		Resources:  []itypes.Resource{mk(&hashA), mk(&hashB)},
-	}, "us-east-1")
-	if len(got) != 2 {
-		t.Fatalf("want 2 projections, got %d", len(got))
-	}
-	if got[0].ResourceID != hashA || got[1].ResourceID != hashB {
-		t.Errorf("resource ids: %q, %q", got[0].ResourceID, got[1].ResourceID)
-	}
-}
-
-func TestProjectFinding_SkipsResourcelessFindings(t *testing.T) {
-	arn := "arn:test"
-	if got := projectFinding(itypes.Finding{FindingArn: &arn}, "us-east-1"); got != nil {
-		t.Errorf("findings without Resources must be skipped, got %v", got)
 	}
 }
 

--- a/internal/awsinspector/client_test.go
+++ b/internal/awsinspector/client_test.go
@@ -315,3 +315,82 @@ func itoa(n int) string {
 	}
 	return string(digits)
 }
+
+func TestProjectFinding_OperatorActionableFields(t *testing.T) {
+	arn := "arn:test"
+	hash := "sha256:imagehash"
+	desc := "Buffer overflow in libfoo lets a remote attacker crash the process."
+	remText := "Upgrade libfoo to >= 1.2.5"
+	remURL := "https://nvd.nist.gov/vuln/detail/CVE-2026-9999"
+	resources := []itypes.Resource{{
+		Type: itypes.ResourceTypeAwsEcrContainerImage,
+		Id:   &hash,
+		Details: &itypes.ResourceDetails{
+			AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: &hash},
+		},
+	}}
+	got := projectFinding(itypes.Finding{
+		FindingArn:       &arn,
+		Severity:         itypes.SeverityHigh,
+		Description:      &desc,
+		Remediation:      &itypes.Remediation{Recommendation: &itypes.Recommendation{Text: &remText, Url: &remURL}},
+		Epss:             &itypes.EpssDetails{Score: 0.87},
+		ExploitAvailable: itypes.ExploitAvailableYes,
+		FixAvailable:     itypes.FixAvailableYes,
+		Resources:        resources,
+	}, "us-east-1")
+	if len(got) != 1 {
+		t.Fatalf("want 1 projection, got %d", len(got))
+	}
+	f := got[0]
+	if f.Description != desc {
+		t.Errorf("description: got %q", f.Description)
+	}
+	if f.Remediation != remText {
+		t.Errorf("remediation text: got %q", f.Remediation)
+	}
+	if f.RemediationURL != remURL {
+		t.Errorf("remediation url: got %q", f.RemediationURL)
+	}
+	if f.EPSSScore != 0.87 {
+		t.Errorf("epss: got %v", f.EPSSScore)
+	}
+	if f.ExploitAvailable != string(itypes.ExploitAvailableYes) {
+		t.Errorf("exploit: got %q", f.ExploitAvailable)
+	}
+	if f.FixAvailable != string(itypes.FixAvailableYes) {
+		t.Errorf("fix: got %q", f.FixAvailable)
+	}
+}
+
+func TestProjectFinding_OptionalFieldsSafeOnNil(t *testing.T) {
+	// SDK guarantees Description/Remediation/Resources are required
+	// on real findings, but we still defend against nil pointers so
+	// future SDK changes or fuzz inputs can't panic projectFinding.
+	arn := "arn:test"
+	hash := "sha256:safe"
+	got := projectFinding(itypes.Finding{
+		FindingArn: &arn,
+		Severity:   itypes.SeverityLow,
+		Resources: []itypes.Resource{{
+			Type: itypes.ResourceTypeAwsEcrContainerImage,
+			Id:   &hash,
+			Details: &itypes.ResourceDetails{
+				AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: &hash},
+			},
+		}},
+	}, "us-east-1")
+	if len(got) != 1 {
+		t.Fatalf("want 1 projection, got %d", len(got))
+	}
+	f := got[0]
+	if f.Description != "" || f.Remediation != "" || f.RemediationURL != "" {
+		t.Errorf("missing optional fields should be empty strings, got %+v", f)
+	}
+	if f.EPSSScore != 0 {
+		t.Errorf("missing EPSS should be 0, got %v", f.EPSSScore)
+	}
+	if f.ExploitAvailable != "" || f.FixAvailable != "" {
+		t.Errorf("missing enums should be empty, got exploit=%q fix=%q", f.ExploitAvailable, f.FixAvailable)
+	}
+}

--- a/internal/awsinspector/client_test.go
+++ b/internal/awsinspector/client_test.go
@@ -83,34 +83,49 @@ func TestIsEnabled_OtherErrorPropagates(t *testing.T) {
 	}
 }
 
+// instanceFinding builds a stub SDK finding pinned to an EC2
+// instance resource so batching/pagination tests exercise the new
+// per-resource projection.
+func instanceFinding(instanceID string) itypes.Finding {
+	id := instanceID
+	arn := "arn:aws:inspector2:us-east-1:111:finding/" + instanceID
+	title := "t"
+	first := time.Unix(0, 0)
+	last := time.Unix(1, 0)
+	cve := "CVE-2026-0001"
+	vd := &itypes.PackageVulnerabilityDetails{VulnerabilityId: &cve}
+	return itypes.Finding{
+		FindingArn:                  &arn,
+		Title:                       &title,
+		FirstObservedAt:             &first,
+		LastObservedAt:              &last,
+		Severity:                    itypes.SeverityHigh,
+		PackageVulnerabilityDetails: vd,
+		Resources: []itypes.Resource{{
+			Type: itypes.ResourceTypeAwsEc2Instance,
+			Id:   &id,
+		}},
+	}
+}
+
 func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
-	// 120 instance IDs → 3 chunks of 50/50/20. Each chunk paginates
-	// across 2 pages to exercise the paginator loop.
+	// 120 instance IDs → 3 chunks of 50/50/20. Findings on each
+	// page are pinned to the first instance in the input list so
+	// the per-resource projection has a stable join key for the
+	// assertion at the end.
 	ids := make([]string, 120)
 	for i := range ids {
 		ids[i] = "i-" + strings.Repeat("0", 8-len(itoa(i))) + itoa(i)
 	}
 	page := func(n int) []itypes.Finding {
 		out := make([]itypes.Finding, n)
-		arn := "arn:aws:inspector2:us-east-1:111:finding/x"
-		title := "t"
-		first := time.Unix(0, 0)
-		last := time.Unix(1, 0)
-		cve := "CVE-2026-0001"
-		vd := &itypes.PackageVulnerabilityDetails{VulnerabilityId: &cve}
 		for i := range out {
-			out[i] = itypes.Finding{
-				FindingArn:                  &arn,
-				Title:                       &title,
-				FirstObservedAt:             &first,
-				LastObservedAt:              &last,
-				Severity:                    itypes.SeverityHigh,
-				PackageVulnerabilityDetails: vd,
-			}
+			out[i] = instanceFinding(ids[0])
 		}
 		return out
 	}
-	// 6 pages of 10 findings each: 60 results total.
+	// 6 pages of 10 findings each: 60 results total — all attributed
+	// to ids[0] by the stub.
 	api := &stubAPI{pages: [][]itypes.Finding{
 		page(10), page(10), page(10), page(10), page(10), page(10),
 	}}
@@ -119,8 +134,13 @@ func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFindingsByInstance: %v", err)
 	}
-	if len(got) != 60 {
-		t.Errorf("findings: want 60, got %d", len(got))
+	if total := len(got[ids[0]]); total != 60 {
+		t.Errorf("findings on ids[0]: want 60, got %d", total)
+	}
+	// Every requested ID is present in the map (nil slice when no
+	// findings).
+	if len(got) != 120 {
+		t.Errorf("map size: want 120 (all keys present), got %d", len(got))
 	}
 	// 3 chunks expected (50+50+20). The 6 seeded pages all drain
 	// inside chunk 1 (paginator keeps calling until NextToken is
@@ -129,12 +149,11 @@ func TestListFindingsByInstance_BatchingAndPagination(t *testing.T) {
 	if got, want := len(api.captureFilters), 8; got != want {
 		t.Errorf("ListFindings calls: want %d, got %d", want, got)
 	}
-	// Chunk-boundary filter widths: 50 / 50 / 20.
 	chunkSizes := []int{50, 50, 50, 50, 50, 50, 50, 20}
 	for i, want := range chunkSizes {
-		got := api.captureFilters[i]
-		if got == nil || len(got.ResourceId) != want {
-			t.Errorf("call %d: want %d IDs in filter, got %d", i, want, len(got.ResourceId))
+		f := api.captureFilters[i]
+		if f == nil || len(f.ResourceId) != want {
+			t.Errorf("call %d: want %d IDs in filter, got %d", i, want, len(f.ResourceId))
 		}
 	}
 }
@@ -145,7 +164,8 @@ func TestListFindingsByDigest_DedupsAndSkipsEmpty(t *testing.T) {
 	}
 	api := &stubAPI{}
 	c := NewWithAPI(api, "us-east-1")
-	if _, err := c.ListFindingsByImageDigest(context.Background(), digests); err != nil {
+	got, err := c.ListFindingsByImageDigest(context.Background(), digests)
+	if err != nil {
 		t.Fatalf("ListFindingsByImageDigest: %v", err)
 	}
 	if len(api.captureFilters) != 1 {
@@ -154,15 +174,24 @@ func TestListFindingsByDigest_DedupsAndSkipsEmpty(t *testing.T) {
 	if got := api.captureFilters[0].EcrImageHash; len(got) != 2 {
 		t.Errorf("dedup: want 2 filters, got %d", len(got))
 	}
+	if _, ok := got["sha256:aaaa"]; !ok {
+		t.Errorf("ensureKeys missed sha256:aaaa: %v", got)
+	}
+	if _, ok := got["sha256:bbbb"]; !ok {
+		t.Errorf("ensureKeys missed sha256:bbbb: %v", got)
+	}
 }
 
 func TestProjectFinding_PicksHighestCVSS(t *testing.T) {
 	arn := "arn:test"
 	cve := "CVE-2026-9999"
-	name := "openssl"
+	name1 := "openssl"
+	name2 := "libcrypto"
 	ver := "1.0.0"
 	fix := "1.0.1"
 	score1, score2, score3 := 7.4, 9.1, 5.5
+	hash := "sha256:imagehash"
+
 	vd := &itypes.PackageVulnerabilityDetails{
 		VulnerabilityId: &cve,
 		Cvss: []itypes.CvssScore{
@@ -171,22 +200,82 @@ func TestProjectFinding_PicksHighestCVSS(t *testing.T) {
 			{BaseScore: &score3},
 		},
 		VulnerablePackages: []itypes.VulnerablePackage{
-			{Name: &name, Version: &ver, FixedInVersion: &fix},
+			{Name: &name1, Version: &ver, FixedInVersion: &fix},
+			{Name: &name2, Version: &ver, FixedInVersion: &fix},
 		},
 	}
-	got := projectFinding(itypes.Finding{
+	resources := []itypes.Resource{{
+		Type: itypes.ResourceTypeAwsEcrContainerImage,
+		Id:   &hash,
+		Details: &itypes.ResourceDetails{
+			AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: &hash},
+		},
+	}}
+	projected := projectFinding(itypes.Finding{
 		FindingArn:                  &arn,
 		Severity:                    itypes.SeverityCritical,
 		PackageVulnerabilityDetails: vd,
+		Resources:                   resources,
 	}, "eu-west-1")
+	if len(projected) != 1 {
+		t.Fatalf("projectFinding: want 1, got %d", len(projected))
+	}
+	got := projected[0]
 	if got.CVSSv3Score != 9.1 {
 		t.Errorf("cvss: want 9.1, got %v", got.CVSSv3Score)
 	}
-	if got.CVE != "CVE-2026-9999" || got.PackageName != "openssl" || got.FixedVersion != "1.0.1" {
-		t.Errorf("project: got %+v", got)
+	if got.CVE != "CVE-2026-9999" {
+		t.Errorf("cve: got %q", got.CVE)
+	}
+	// Multi-package findings concatenate names so chips don't
+	// silently under-report.
+	if got.PackageName != "openssl, libcrypto" {
+		t.Errorf("package name: want %q, got %q", "openssl, libcrypto", got.PackageName)
+	}
+	if got.FixedVersion != "1.0.1" {
+		t.Errorf("fixed: got %q", got.FixedVersion)
+	}
+	if got.ResourceID != hash {
+		t.Errorf("resource id: want %q, got %q", hash, got.ResourceID)
 	}
 	if !strings.Contains(got.InspectorURL, "eu-west-1") || !strings.Contains(got.InspectorURL, "arn:test") {
 		t.Errorf("inspector url: %q", got.InspectorURL)
+	}
+}
+
+func TestProjectFinding_FansOutAcrossResources(t *testing.T) {
+	// One SDK finding with two resources → two store rows. Mirrors
+	// the rare case where Inspector reports a CVE that matches the
+	// same package on two co-scanned resources.
+	arn := "arn:test"
+	hashA := "sha256:aaaa"
+	hashB := "sha256:bbbb"
+	mk := func(h *string) itypes.Resource {
+		return itypes.Resource{
+			Type: itypes.ResourceTypeAwsEcrContainerImage,
+			Id:   h,
+			Details: &itypes.ResourceDetails{
+				AwsEcrContainerImage: &itypes.AwsEcrContainerImageDetails{ImageHash: h},
+			},
+		}
+	}
+	got := projectFinding(itypes.Finding{
+		FindingArn: &arn,
+		Severity:   itypes.SeverityHigh,
+		Resources:  []itypes.Resource{mk(&hashA), mk(&hashB)},
+	}, "us-east-1")
+	if len(got) != 2 {
+		t.Fatalf("want 2 projections, got %d", len(got))
+	}
+	if got[0].ResourceID != hashA || got[1].ResourceID != hashB {
+		t.Errorf("resource ids: %q, %q", got[0].ResourceID, got[1].ResourceID)
+	}
+}
+
+func TestProjectFinding_SkipsResourcelessFindings(t *testing.T) {
+	arn := "arn:test"
+	if got := projectFinding(itypes.Finding{FindingArn: &arn}, "us-east-1"); got != nil {
+		t.Errorf("findings without Resources must be skipped, got %v", got)
 	}
 }
 

--- a/internal/cve/hydrate.go
+++ b/internal/cve/hydrate.go
@@ -2,11 +2,13 @@ package cve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/gnana997/periscope/internal/awsec2"
 	"github.com/gnana997/periscope/internal/clusters"
 )
 
@@ -15,11 +17,11 @@ import (
 //  1. Probe Inspector v2 enablement; if disabled, mark store +
 //     return without touching the rest.
 //  2. List EC2 instances tagged to this cluster, batch-fetch
-//     instance findings (grouped per-instance), classify owners,
-//     and populate the store's instance entries.
+//     instance findings, classify owners, and populate the store's
+//     instance entries.
 //  3. List Pods in the cluster, extract image digests, batch-fetch
-//     image findings (grouped per-digest), and populate the store's
-//     digest entries with correct PodRef counts.
+//     image findings, and populate the store's digest entries with
+//     correct PodRef counts.
 //  4. Start the long-lived pod informer that keeps the digest set
 //     and ref counts in sync as pods roll.
 //  5. MarkHydrated (or MarkDisabled).
@@ -55,9 +57,12 @@ func (m *Manager) hydrate(ctx context.Context, cluster clusters.Cluster, st *clu
 	}
 
 	// Phase 1: nodes → instance IDs → Inspector instance findings.
-	if err := m.hydrateInstances(ctx, cluster, cs, st); err != nil {
+	instanceIDs, instanceFindings, err := m.hydrateInstances(ctx, cluster, cs, st)
+	if err != nil {
 		m.log.Warn("cve hydrate instances", "cluster", cluster.Name, "err", err)
 	}
+	_ = instanceIDs
+	_ = instanceFindings
 
 	// Phase 2: pods → digests → Inspector image findings.
 	if err := m.hydratePods(ctx, cluster, cs, st); err != nil {
@@ -74,30 +79,34 @@ func (m *Manager) hydrate(ctx context.Context, cluster clusters.Cluster, st *clu
 
 // hydrateInstances reads K8s Nodes, extracts EC2 instance IDs from
 // their Spec.ProviderID, classifies each instance via the owner
-// resolver, and bulk-fetches Inspector findings for them. Findings
-// are grouped per-instance by the Inspector client so each row gets
-// its own subset (not the union, as the v1.1-review caught).
-func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster, cs kubernetes.Interface, st *clusterState) error {
+// resolver, and bulk-fetches Inspector findings for them. Returns
+// the deduped instance ID list and the flat findings list (currently
+// shared across all instances — see fetchInstances TODO).
+func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster, cs kubernetes.Interface, st *clusterState) ([]string, []Finding, error) {
 	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("list nodes: %w", err)
+		return nil, nil, fmt.Errorf("list nodes: %w", err)
 	}
 	if len(nodes.Items) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	instanceIDs := make([]string, 0, len(nodes.Items))
+	idToNode := make(map[string]string, len(nodes.Items))
 	for _, n := range nodes.Items {
-		if id := instanceIDFromProviderID(n.Spec.ProviderID); id != "" {
-			instanceIDs = append(instanceIDs, id)
+		id := instanceIDFromProviderID(n.Spec.ProviderID)
+		if id == "" {
+			continue
 		}
+		instanceIDs = append(instanceIDs, id)
+		idToNode[id] = n.Name
 	}
 	if len(instanceIDs) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	// Owner classification needs the EC2 instance tags.
-	resolver := NewOwnerResolver(func(_ context.Context) (kubernetes.Interface, error) { return cs, nil })
+	resolver := NewOwnerResolver(asEC2Client(m.ec2), func(_ context.Context) (kubernetes.Interface, error) { return cs, nil })
 	metas, err := m.ec2.DescribeInstances(ctx, instanceIDs)
 	if err != nil {
 		// We can still register Inspector findings against instance
@@ -107,12 +116,12 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 	}
 	kinds, names, _ := resolver.Resolve(ctx, metas)
 
-	grouped, err := m.inspector.ListFindingsByInstance(ctx, instanceIDs)
+	findings, err := m.inspector.ListFindingsByInstance(ctx, instanceIDs)
 	if err != nil {
-		// AccessDenied mid-fetch matches the "Inspector got
-		// disabled" race; surface the error, leave instance findings
-		// empty.
-		return err
+		// Inspector AccessDenied mid-hydrate flips us to disabled.
+		// We don't have a clean signal for that without re-checking;
+		// best-effort: surface the error, leave instances empty.
+		return instanceIDs, nil, err
 	}
 
 	now := m.clock.Now()
@@ -121,10 +130,10 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 		if kind == "" {
 			kind = OwnerUnmanaged
 		}
-		st.store.UpsertInstance(id, grouped[id], kind, names[id], now)
+		st.store.UpsertInstance(id, findings, kind, names[id], now)
 		st.store.IncInstanceRef(id)
 	}
-	return nil
+	return instanceIDs, findings, nil
 }
 
 // hydratePods reads K8s Pods, extracts image digests via the
@@ -155,13 +164,36 @@ func (m *Manager) hydratePods(ctx context.Context, cluster clusters.Cluster, cs 
 
 	// Second pass: fetch + upsert. Refs are already in place from
 	// the first pass so UpsertDigest preserves them.
-	grouped, err := m.inspector.ListFindingsByImageDigest(ctx, digestList)
+	findings, err := m.inspector.ListFindingsByImageDigest(ctx, digestList)
 	if err != nil {
 		return err
 	}
 	now := m.clock.Now()
+	// Without per-resource attribution on Finding (see
+	// fetchInstances TODO), we currently store the shared findings
+	// list per digest. The API layer (#165) filters on the digest
+	// it cares about.
 	for _, d := range digestList {
-		st.store.UpsertDigest(d, grouped[d], now)
+		st.store.UpsertDigest(d, findings, now)
 	}
 	return nil
 }
+
+// asEC2Client wraps the EC2API the manager holds into the concrete
+// *awsec2.Client the OwnerResolver expects. In tests the manager
+// can be given a stub for EC2API; if a test path reaches the owner
+// resolver and the underlying client isn't the concrete type, the
+// resolver still works because its only EC2 use is DescribeInstances
+// — which we already fetched above and pass in directly. The
+// adapter is here to satisfy the constructor signature.
+func asEC2Client(api EC2API) *awsec2.Client {
+	if c, ok := api.(*awsec2.Client); ok {
+		return c
+	}
+	return nil
+}
+
+// errClientNotAvailable is returned when m.clientFor is unset (only
+// possible in malformed test setups; production wiring always sets
+// it).
+var errClientNotAvailable = errors.New("k8s client factory not configured")

--- a/internal/cve/hydrate.go
+++ b/internal/cve/hydrate.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/gnana997/periscope/internal/awsec2"
 	"github.com/gnana997/periscope/internal/clusters"
 )
 
@@ -16,11 +15,11 @@ import (
 //  1. Probe Inspector v2 enablement; if disabled, mark store +
 //     return without touching the rest.
 //  2. List EC2 instances tagged to this cluster, batch-fetch
-//     instance findings, classify owners, and populate the store's
-//     instance entries.
+//     instance findings (grouped per-instance), classify owners,
+//     and populate the store's instance entries.
 //  3. List Pods in the cluster, extract image digests, batch-fetch
-//     image findings, and populate the store's digest entries with
-//     correct PodRef counts.
+//     image findings (grouped per-digest), and populate the store's
+//     digest entries with correct PodRef counts.
 //  4. Start the long-lived pod informer that keeps the digest set
 //     and ref counts in sync as pods roll.
 //  5. MarkHydrated (or MarkDisabled).
@@ -56,12 +55,9 @@ func (m *Manager) hydrate(ctx context.Context, cluster clusters.Cluster, st *clu
 	}
 
 	// Phase 1: nodes → instance IDs → Inspector instance findings.
-	instanceIDs, instanceFindings, err := m.hydrateInstances(ctx, cluster, cs, st)
-	if err != nil {
+	if err := m.hydrateInstances(ctx, cluster, cs, st); err != nil {
 		m.log.Warn("cve hydrate instances", "cluster", cluster.Name, "err", err)
 	}
-	_ = instanceIDs
-	_ = instanceFindings
 
 	// Phase 2: pods → digests → Inspector image findings.
 	if err := m.hydratePods(ctx, cluster, cs, st); err != nil {
@@ -78,34 +74,30 @@ func (m *Manager) hydrate(ctx context.Context, cluster clusters.Cluster, st *clu
 
 // hydrateInstances reads K8s Nodes, extracts EC2 instance IDs from
 // their Spec.ProviderID, classifies each instance via the owner
-// resolver, and bulk-fetches Inspector findings for them. Returns
-// the deduped instance ID list and the flat findings list (currently
-// shared across all instances — see fetchInstances TODO).
-func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster, cs kubernetes.Interface, st *clusterState) ([]string, []Finding, error) {
+// resolver, and bulk-fetches Inspector findings for them. Findings
+// are grouped per-instance by the Inspector client so each row gets
+// its own subset (not the union, as the v1.1-review caught).
+func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster, cs kubernetes.Interface, st *clusterState) error {
 	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("list nodes: %w", err)
+		return fmt.Errorf("list nodes: %w", err)
 	}
 	if len(nodes.Items) == 0 {
-		return nil, nil, nil
+		return nil
 	}
 
 	instanceIDs := make([]string, 0, len(nodes.Items))
-	idToNode := make(map[string]string, len(nodes.Items))
 	for _, n := range nodes.Items {
-		id := instanceIDFromProviderID(n.Spec.ProviderID)
-		if id == "" {
-			continue
+		if id := instanceIDFromProviderID(n.Spec.ProviderID); id != "" {
+			instanceIDs = append(instanceIDs, id)
 		}
-		instanceIDs = append(instanceIDs, id)
-		idToNode[id] = n.Name
 	}
 	if len(instanceIDs) == 0 {
-		return nil, nil, nil
+		return nil
 	}
 
 	// Owner classification needs the EC2 instance tags.
-	resolver := NewOwnerResolver(asEC2Client(m.ec2), func(_ context.Context) (kubernetes.Interface, error) { return cs, nil })
+	resolver := NewOwnerResolver(func(_ context.Context) (kubernetes.Interface, error) { return cs, nil })
 	metas, err := m.ec2.DescribeInstances(ctx, instanceIDs)
 	if err != nil {
 		// We can still register Inspector findings against instance
@@ -115,12 +107,12 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 	}
 	kinds, names, _ := resolver.Resolve(ctx, metas)
 
-	findings, err := m.inspector.ListFindingsByInstance(ctx, instanceIDs)
+	grouped, err := m.inspector.ListFindingsByInstance(ctx, instanceIDs)
 	if err != nil {
-		// Inspector AccessDenied mid-hydrate flips us to disabled.
-		// We don't have a clean signal for that without re-checking;
-		// best-effort: surface the error, leave instances empty.
-		return instanceIDs, nil, err
+		// AccessDenied mid-fetch matches the "Inspector got
+		// disabled" race; surface the error, leave instance findings
+		// empty.
+		return err
 	}
 
 	now := m.clock.Now()
@@ -129,10 +121,10 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 		if kind == "" {
 			kind = OwnerUnmanaged
 		}
-		st.store.UpsertInstance(id, findings, kind, names[id], now)
+		st.store.UpsertInstance(id, grouped[id], kind, names[id], now)
 		st.store.IncInstanceRef(id)
 	}
-	return instanceIDs, findings, nil
+	return nil
 }
 
 // hydratePods reads K8s Pods, extracts image digests via the
@@ -163,32 +155,13 @@ func (m *Manager) hydratePods(ctx context.Context, cluster clusters.Cluster, cs 
 
 	// Second pass: fetch + upsert. Refs are already in place from
 	// the first pass so UpsertDigest preserves them.
-	findings, err := m.inspector.ListFindingsByImageDigest(ctx, digestList)
+	grouped, err := m.inspector.ListFindingsByImageDigest(ctx, digestList)
 	if err != nil {
 		return err
 	}
 	now := m.clock.Now()
-	// Without per-resource attribution on Finding (see
-	// fetchInstances TODO), we currently store the shared findings
-	// list per digest. The API layer (#165) filters on the digest
-	// it cares about.
 	for _, d := range digestList {
-		st.store.UpsertDigest(d, findings, now)
+		st.store.UpsertDigest(d, grouped[d], now)
 	}
 	return nil
 }
-
-// asEC2Client wraps the EC2API the manager holds into the concrete
-// *awsec2.Client the OwnerResolver expects. In tests the manager
-// can be given a stub for EC2API; if a test path reaches the owner
-// resolver and the underlying client isn't the concrete type, the
-// resolver still works because its only EC2 use is DescribeInstances
-// — which we already fetched above and pass in directly. The
-// adapter is here to satisfy the constructor signature.
-func asEC2Client(api EC2API) *awsec2.Client {
-	if c, ok := api.(*awsec2.Client); ok {
-		return c
-	}
-	return nil
-}
-

--- a/internal/cve/hydrate.go
+++ b/internal/cve/hydrate.go
@@ -2,7 +2,6 @@ package cve
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -193,7 +192,3 @@ func asEC2Client(api EC2API) *awsec2.Client {
 	return nil
 }
 
-// errClientNotAvailable is returned when m.clientFor is unset (only
-// possible in malformed test setups; production wiring always sets
-// it).
-var errClientNotAvailable = errors.New("k8s client factory not configured")

--- a/internal/cve/hydrate.go
+++ b/internal/cve/hydrate.go
@@ -35,19 +35,19 @@ func (m *Manager) hydrate(ctx context.Context, cluster clusters.Cluster, st *clu
 		// The store stays empty but un-disabled; the next manual
 		// refresh or a future SIGHUP can retry. Mark hydrated so
 		// readers don't deadlock.
-		st.store.MarkHydrated()
+		st.store.MarkHydrated(m.clock.Now())
 		return err
 	}
 	if !enabled {
 		m.log.Info("cve hydrate: inspector v2 not enabled", "cluster", cluster.Name)
-		st.store.MarkDisabled()
+		st.store.MarkDisabled(m.clock.Now())
 		return nil
 	}
 
 	// Defer the MarkHydrated so an early-return from instance- or
 	// pod-side hydration still unblocks waiters with whatever data
 	// we managed to collect.
-	defer st.store.MarkHydrated()
+	defer st.store.MarkHydrated(m.clock.Now())
 
 	cs, err := m.clientFor(ctx, cluster)
 	if err != nil {
@@ -106,6 +106,10 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 		m.log.Warn("cve hydrate: ec2 describe instances", "cluster", cluster.Name, "err", err)
 	}
 	kinds, names, _ := resolver.Resolve(ctx, metas)
+	amiByID := make(map[string]string, len(metas))
+	for _, mt := range metas {
+		amiByID[mt.InstanceID] = mt.AMI
+	}
 
 	grouped, err := m.inspector.ListFindingsByInstance(ctx, instanceIDs)
 	if err != nil {
@@ -121,7 +125,7 @@ func (m *Manager) hydrateInstances(ctx context.Context, cluster clusters.Cluster
 		if kind == "" {
 			kind = OwnerUnmanaged
 		}
-		st.store.UpsertInstance(id, grouped[id], kind, names[id], now)
+		st.store.UpsertInstance(id, grouped[id], kind, names[id], amiByID[id], now)
 		st.store.IncInstanceRef(id)
 	}
 	return nil

--- a/internal/cve/image_classify.go
+++ b/internal/cve/image_classify.go
@@ -1,0 +1,57 @@
+package cve
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ScanState classifies a single container image for the /cve/pods
+// surface. The three values map 1:1 to the SPA chip states:
+//
+//   - ScanStateScanned: ECR image, Periscope has the digest, the
+//     digest is (or will be) in the cve store.
+//   - ScanStateNonECR : image is not in ECR — Inspector v2 doesn't
+//     cover it, so the chip surface renders "not scanned" with a
+//     docs link rather than zero counts.
+//   - ScanStatePending: image is ECR but the pod's containerStatus
+//     does not yet expose an imageID (pod is mid-pull, or the digest
+//     entry hasn't been populated yet). Subsequent refetches will
+//     resolve to scanned.
+type ScanState string
+
+const (
+	ScanStateScanned ScanState = "scanned"
+	ScanStateNonECR  ScanState = "non-ecr"
+	ScanStatePending ScanState = "pending"
+)
+
+// ecrImagePattern matches the standard ECR image reference shape:
+//
+//	<acct>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag|@sha256:...]
+//
+// The leading account id and region are anchored to host-segment
+// boundaries so a hostile registry can't masquerade by including the
+// substring (e.g. "evil.com/.dkr.ecr.us-east-1.amazonaws.com/foo").
+var ecrImagePattern = regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/`)
+
+// IsECRImage reports whether image (the operator-written tag from
+// spec.containers[].image) is an ECR reference. Used by the /cve/pods
+// surface to bucket containers into scanned vs non-ecr without
+// having to consult the digest.
+func IsECRImage(image string) bool {
+	return ecrImagePattern.MatchString(strings.TrimSpace(image))
+}
+
+// ImageScanState classifies a container by joining the operator-
+// written image string with the runtime-resolved imageID. The digest
+// return value is the bare sha256:... (empty when scanState != scanned).
+func ImageScanState(image, imageID string) (digest string, state ScanState) {
+	if !IsECRImage(image) {
+		return "", ScanStateNonECR
+	}
+	d := normalizeImageID(imageID)
+	if d == "" {
+		return "", ScanStatePending
+	}
+	return d, ScanStateScanned
+}

--- a/internal/cve/image_classify_test.go
+++ b/internal/cve/image_classify_test.go
@@ -1,0 +1,63 @@
+package cve
+
+import "testing"
+
+func TestIsECRImage(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag", true},
+		{"123456789012.dkr.ecr.us-east-1.amazonaws.com/repo@sha256:abc", true},
+		{"999999999999.dkr.ecr.eu-west-2.amazonaws.com/team/app", true},
+		{"nginx:latest", false},
+		{"docker.io/library/nginx", false},
+		{"ghcr.io/user/app:1.0", false},
+		// Anti-spoof: substring elsewhere does not match.
+		{"evil.com/.dkr.ecr.us-east-1.amazonaws.com/foo", false},
+		{"", false},
+		{"   ", false},
+	}
+	for _, c := range cases {
+		if got := IsECRImage(c.in); got != c.want {
+			t.Errorf("IsECRImage(%q): want %v, got %v", c.in, c.want, got)
+		}
+	}
+}
+
+func TestImageScanState(t *testing.T) {
+	cases := []struct {
+		image, imageID string
+		wantDigest     string
+		wantState      ScanState
+	}{
+		{
+			image:      "111.dkr.ecr.us-east-1.amazonaws.com/app:v1",
+			imageID:    "docker-pullable://111.dkr.ecr.us-east-1.amazonaws.com/app@sha256:abcd",
+			wantDigest: "sha256:abcd",
+			wantState:  ScanStateScanned,
+		},
+		{
+			image:     "111.dkr.ecr.us-east-1.amazonaws.com/app:v1",
+			imageID:   "", // ECR but pod has not yet pulled
+			wantState: ScanStatePending,
+		},
+		{
+			image:     "docker.io/library/nginx",
+			imageID:   "docker-pullable://nginx@sha256:abcd",
+			wantState: ScanStateNonECR,
+		},
+		{
+			image:     "",
+			imageID:   "",
+			wantState: ScanStateNonECR,
+		},
+	}
+	for i, c := range cases {
+		d, s := ImageScanState(c.image, c.imageID)
+		if d != c.wantDigest || s != c.wantState {
+			t.Errorf("case %d (image=%q imageID=%q): want (%q,%q), got (%q,%q)",
+				i, c.image, c.imageID, c.wantDigest, c.wantState, d, s)
+		}
+	}
+}

--- a/internal/cve/manager.go
+++ b/internal/cve/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/singleflight"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 
 	"github.com/gnana997/periscope/internal/awsec2"
 	"github.com/gnana997/periscope/internal/clusters"
@@ -92,6 +93,7 @@ type clusterState struct {
 	once              sync.Once
 	hydrateErr        error
 	podInformerCancel context.CancelFunc
+	podLister         corelisters.PodLister
 	clusterRef        clusters.Cluster
 }
 
@@ -426,13 +428,15 @@ func (m *Manager) fetchInstances(ctx context.Context, st *clusterState, ids []st
 			existing := st.store.GetInstance(id)
 			var kind OwnerKind
 			var name string
+			var ami string
 			if existing != nil {
 				kind = existing.OwnerKind
 				name = existing.OwnerName
+				ami = existing.AMI
 			} else {
 				kind = OwnerUnmanaged
 			}
-			st.store.UpsertInstance(id, grouped[id], kind, name, now)
+			st.store.UpsertInstance(id, grouped[id], kind, name, ami, now)
 		}
 		return nil, nil
 	})
@@ -495,4 +499,21 @@ func sortedJoin(sorted []string) string {
 		out += "\x1f" + s
 	}
 	return out
+}
+
+// PodLister returns the lister backing the long-lived pod informer
+// for cluster, or nil if the informer has not started yet (the
+// cluster has never been hydrated, or hydrate failed before the
+// informer came up). The API layer (#165) uses this to power
+// /cve/pods without a fresh apiserver list per request.
+//
+// Returns the interface, not the concrete implementation, so the
+// manager can swap the informer machinery without breaking callers.
+func (m *Manager) PodLister(cluster string) corelisters.PodLister {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if st, ok := m.clusters[cluster]; ok {
+		return st.podLister
+	}
+	return nil
 }

--- a/internal/cve/manager.go
+++ b/internal/cve/manager.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/singleflight"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	appslisters "k8s.io/client-go/listers/apps/v1"
 
 	"github.com/gnana997/periscope/internal/awsec2"
 	"github.com/gnana997/periscope/internal/clusters"
@@ -94,6 +95,7 @@ type clusterState struct {
 	hydrateErr        error
 	podInformerCancel context.CancelFunc
 	podLister         corelisters.PodLister
+	rsLister          appslisters.ReplicaSetLister
 	clusterRef        clusters.Cluster
 }
 
@@ -514,6 +516,24 @@ func (m *Manager) PodLister(cluster string) corelisters.PodLister {
 	defer m.mu.Unlock()
 	if st, ok := m.clusters[cluster]; ok {
 		return st.podLister
+	}
+	return nil
+}
+
+// ReplicaSetLister returns the lister backing the long-lived
+// ReplicaSet informer for cluster, or nil if the informer has not
+// started yet. Used by the /cve/by-workload handler to walk the
+// Pod → ReplicaSet → Deployment ownerRef chain (Pods only ever
+// reference their direct owner, so a separate lister is needed to
+// resolve the two-hop Deployment case).
+//
+// Returns the interface, not the concrete implementation, so the
+// manager can swap informer machinery without breaking callers.
+func (m *Manager) ReplicaSetLister(cluster string) appslisters.ReplicaSetLister {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if st, ok := m.clusters[cluster]; ok {
+		return st.rsLister
 	}
 	return nil
 }

--- a/internal/cve/manager.go
+++ b/internal/cve/manager.go
@@ -2,7 +2,6 @@ package cve
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -353,11 +352,6 @@ func (m *Manager) scanEvict() {
 		}
 	}
 }
-
-// errInspectorDisabled is sentinelled (not exported) so fetch helpers
-// can short-circuit cleanly when the store has been marked disabled
-// mid-flight.
-var errInspectorDisabled = errors.New("inspector v2 disabled")
 
 // fetchDigest fetches a single digest via single-flight. The
 // single-flight key namespaces digests under "d:" so a digest that

--- a/internal/cve/manager.go
+++ b/internal/cve/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -17,11 +18,14 @@ import (
 
 // InspectorAPI is the subset of awsinspector.Client the manager needs.
 // Defined here so tests can substitute a stub without depending on the
-// SDK.
+// SDK. The map-keyed return shape is the load-bearing contract: each
+// requested ID must appear in the result so the caller can iterate
+// the input list and trust the lookup (see ensureKeys in
+// awsinspector).
 type InspectorAPI interface {
 	IsEnabled(ctx context.Context) (bool, error)
-	ListFindingsByInstance(ctx context.Context, instanceIDs []string) ([]Finding, error)
-	ListFindingsByImageDigest(ctx context.Context, digests []string) ([]Finding, error)
+	ListFindingsByInstance(ctx context.Context, instanceIDs []string) (map[string][]Finding, error)
+	ListFindingsByImageDigest(ctx context.Context, digests []string) (map[string][]Finding, error)
 }
 
 // EC2API is the subset of awsec2.Client the manager needs.
@@ -59,17 +63,24 @@ type Config struct {
 	// manager defaults to 1 minute (TTL) / 5 minutes (eviction).
 	TTLScanInterval      time.Duration
 	EvictionScanInterval time.Duration
+
+	// MaxConcurrentDeltaFetches caps the goroutine count for
+	// watch-driven async refreshes. A rolling deploy of a 200-pod
+	// workload could otherwise spawn hundreds of goroutines, each
+	// holding an Inspector socket. Default 8.
+	MaxConcurrentDeltaFetches int
 }
 
 // DefaultConfig returns the production defaults. Mirrors the issue's
 // spec; main.go fills any unset field with these values.
 func DefaultConfig() Config {
 	return Config{
-		RefreshInterval:      6 * time.Hour,
-		EvictAfter:           24 * time.Hour,
-		HydrateBatchSize:     50,
-		TTLScanInterval:      1 * time.Minute,
-		EvictionScanInterval: 5 * time.Minute,
+		RefreshInterval:           6 * time.Hour,
+		EvictAfter:                24 * time.Hour,
+		HydrateBatchSize:          50,
+		TTLScanInterval:           1 * time.Minute,
+		EvictionScanInterval:      5 * time.Minute,
+		MaxConcurrentDeltaFetches: 8,
 	}
 }
 
@@ -98,7 +109,15 @@ type Manager struct {
 	mu       sync.Mutex
 	clusters map[string]*clusterState
 
+	// sf collapses concurrent fetches of the same digest / instance
+	// batch into a single Inspector call. Inspector data is account-
+	// scoped, not cluster-scoped, so the keys deliberately omit the
+	// cluster name — a digest seen in cluster A's TTL scan and
+	// cluster B's manual refresh resolves to the same Inspector call.
 	sf singleflight.Group
+
+	// deltaSem caps concurrent watch-driven async refreshes.
+	deltaSem chan struct{}
 
 	stopOnce sync.Once
 	cancel   context.CancelFunc
@@ -130,6 +149,9 @@ func NewManager(inspector InspectorAPI, ec2 EC2API, clientFor ClientFactory, clo
 	if cfg.EvictionScanInterval == 0 {
 		cfg.EvictionScanInterval = DefaultConfig().EvictionScanInterval
 	}
+	if cfg.MaxConcurrentDeltaFetches <= 0 {
+		cfg.MaxConcurrentDeltaFetches = DefaultConfig().MaxConcurrentDeltaFetches
+	}
 	return &Manager{
 		inspector: inspector,
 		ec2:       ec2,
@@ -138,6 +160,7 @@ func NewManager(inspector InspectorAPI, ec2 EC2API, clientFor ClientFactory, clo
 		cfg:       cfg,
 		log:       log,
 		clusters:  map[string]*clusterState{},
+		deltaSem:  make(chan struct{}, cfg.MaxConcurrentDeltaFetches),
 		doneCh:    make(chan struct{}),
 	}
 }
@@ -229,23 +252,21 @@ func (m *Manager) Get(cluster string) *Store {
 // concurrent watch-hook fetch of the same digest will share the
 // in-flight call rather than firing a second Inspector request.
 func (m *Manager) Refresh(ctx context.Context, cluster clusters.Cluster, digests []string, instanceIDs []string) error {
-	st, err := m.EnsureHydrated(ctx, cluster)
+	store, err := m.EnsureHydrated(ctx, cluster)
 	if err != nil {
 		return err
 	}
-	if st.Disabled() {
+	if store.Disabled() {
 		return nil
 	}
 	var firstErr error
-	for _, d := range digests {
-		if err := m.fetchDigest(ctx, cluster, st, d); err != nil && firstErr == nil {
+	if len(digests) > 0 {
+		if err := m.fetchDigests(ctx, m.stateFor(cluster), digests); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	if len(instanceIDs) > 0 {
-		// Instance fetches are batched, not per-id like digests, so
-		// the single-flight key is the sorted list of IDs joined.
-		if err := m.fetchInstances(ctx, cluster, st, instanceIDs); err != nil && firstErr == nil {
+		if err := m.fetchInstances(ctx, m.stateFor(cluster), instanceIDs); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -292,9 +313,10 @@ func (m *Manager) runLoops(ctx context.Context) {
 }
 
 // scanTTL re-fetches any entry whose LastFetched is older than
-// RefreshInterval. Iterates per cluster, calling fetchDigest /
-// fetchInstances which are single-flight protected, so concurrent
-// manual refreshes won't double-fire.
+// RefreshInterval. Stale digests and instances are batched into one
+// Inspector call per cluster (chunked internally by awsinspector to
+// BatchSize); this keeps a 500-stale-digest cluster at ~10 Inspector
+// calls instead of 500.
 func (m *Manager) scanTTL(ctx context.Context) {
 	m.mu.Lock()
 	snapshot := make([]*clusterState, 0, len(m.clusters))
@@ -309,14 +331,14 @@ func (m *Manager) scanTTL(ctx context.Context) {
 	for _, st := range snapshot {
 		now := m.clock.Now()
 		digests, instances := st.store.IterStale(now, m.cfg.RefreshInterval)
-		for _, d := range digests {
-			if err := m.fetchDigest(ctx, st.clusterRef, st.store, d); err != nil {
-				m.log.Debug("cve ttl digest refresh", "cluster", st.clusterRef.Name, "digest", d, "err", err)
+		if len(digests) > 0 {
+			if err := m.fetchDigests(ctx, st, digests); err != nil {
+				m.log.Debug("cve ttl digest refresh", "cluster", st.clusterRef.Name, "n", len(digests), "err", err)
 			}
 		}
 		if len(instances) > 0 {
-			if err := m.fetchInstances(ctx, st.clusterRef, st.store, instances); err != nil {
-				m.log.Debug("cve ttl instance refresh", "cluster", st.clusterRef.Name, "err", err)
+			if err := m.fetchInstances(ctx, st, instances); err != nil {
+				m.log.Debug("cve ttl instance refresh", "cluster", st.clusterRef.Name, "n", len(instances), "err", err)
 			}
 		}
 	}
@@ -353,57 +375,55 @@ func (m *Manager) scanEvict() {
 	}
 }
 
-// fetchDigest fetches a single digest via single-flight. The
-// single-flight key namespaces digests under "d:" so a digest that
-// happens to share a string with an instance ID can't collide.
-func (m *Manager) fetchDigest(ctx context.Context, cluster clusters.Cluster, store *Store, digest string) error {
-	if digest == "" {
+// fetchDigests batches a digest set into one Inspector call (further
+// chunked by awsinspector.BatchSize). Single-flight collapsing keys
+// off the sorted-and-joined ID list so two concurrent callers asking
+// for the same set share the result. Inspector data is account-
+// scoped, so the cluster name is intentionally NOT in the key.
+func (m *Manager) fetchDigests(ctx context.Context, st *clusterState, digests []string) error {
+	if len(digests) == 0 || st.store.Disabled() {
 		return nil
 	}
-	if store.Disabled() {
+	keys := dedupSorted(digests)
+	if len(keys) == 0 {
 		return nil
 	}
-	key := "d:" + cluster.Name + ":" + digest
-	_, err, _ := m.sf.Do(key, func() (any, error) {
-		findings, err := m.inspector.ListFindingsByImageDigest(ctx, []string{digest})
+	sfKey := "d:" + joinKey(keys)
+	_, err, _ := m.sf.Do(sfKey, func() (any, error) {
+		grouped, err := m.inspector.ListFindingsByImageDigest(ctx, keys)
 		if err != nil {
 			return nil, err
 		}
-		store.UpsertDigest(digest, findings, m.clock.Now())
+		now := m.clock.Now()
+		for _, d := range keys {
+			st.store.UpsertDigest(d, grouped[d], now)
+		}
 		return nil, nil
 	})
 	return err
 }
 
-// fetchInstances re-fetches a set of instance entries in one
-// Inspector call. Owner classification is preserved across the
-// upsert (we read the existing entry first); a fresh cold-path
-// hydrate is the only branch that reassigns OwnerKind/Name.
-func (m *Manager) fetchInstances(ctx context.Context, cluster clusters.Cluster, store *Store, ids []string) error {
-	if len(ids) == 0 || store.Disabled() {
+// fetchInstances batches an instance set into one Inspector call.
+// Owner classification is preserved across the upsert (the existing
+// entry's OwnerKind/Name carries through); only the cold-path
+// hydrate reassigns ownership.
+func (m *Manager) fetchInstances(ctx context.Context, st *clusterState, ids []string) error {
+	if len(ids) == 0 || st.store.Disabled() {
 		return nil
 	}
-	key := fmt.Sprintf("i:%s:%d:%s", cluster.Name, len(ids), ids[0])
-	_, err, _ := m.sf.Do(key, func() (any, error) {
-		findings, err := m.inspector.ListFindingsByInstance(ctx, ids)
+	keys := dedupSorted(ids)
+	if len(keys) == 0 {
+		return nil
+	}
+	sfKey := "i:" + joinKey(keys)
+	_, err, _ := m.sf.Do(sfKey, func() (any, error) {
+		grouped, err := m.inspector.ListFindingsByInstance(ctx, keys)
 		if err != nil {
 			return nil, err
 		}
-		// Group findings by instance ID. Inspector returns a flat
-		// finding list with the resource ID embedded; we need to
-		// re-bucket here so each instance's row gets the right
-		// subset. The SDK's awsinspector.Finding doesn't expose the
-		// resource ID directly because the cve.Finding DTO is
-		// intentionally flat — see the trade-off note in
-		// awsinspector/client.go projectFinding. For now we bulk-
-		// assign the same finding list to every requested instance
-		// and let the API layer (#165) filter by resource on read.
-		// TODO(#165): teach awsinspector.Finding to carry the
-		// originating resource ID so per-instance assignment is
-		// exact.
 		now := m.clock.Now()
-		for _, id := range ids {
-			existing := store.GetInstance(id)
+		for _, id := range keys {
+			existing := st.store.GetInstance(id)
 			var kind OwnerKind
 			var name string
 			if existing != nil {
@@ -412,9 +432,67 @@ func (m *Manager) fetchInstances(ctx context.Context, cluster clusters.Cluster, 
 			} else {
 				kind = OwnerUnmanaged
 			}
-			store.UpsertInstance(id, findings, kind, name, now)
+			st.store.UpsertInstance(id, grouped[id], kind, name, now)
 		}
 		return nil, nil
 	})
 	return err
+}
+
+// runDelta executes fn under the delta-fetch semaphore so a
+// rolling-deploy storm doesn't spawn unbounded goroutines, each with
+// an Inspector socket. Drops the work (logs at debug) if ctx is
+// cancelled while waiting for a slot.
+func (m *Manager) runDelta(ctx context.Context, fn func()) {
+	select {
+	case m.deltaSem <- struct{}{}:
+		defer func() { <-m.deltaSem }()
+		fn()
+	case <-ctx.Done():
+		return
+	}
+}
+
+// dedupSorted returns the input deduped + sorted. Used for stable
+// singleflight keys.
+func dedupSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// joinKey produces a stable singleflight key from a deduped+sorted ID
+// list. The leading length+`:` byte makes "ab","c" and "a","bc"
+// collisions impossible.
+func joinKey(sorted []string) string {
+	return fmt.Sprintf("%d:", len(sorted)) + sortedJoin(sorted)
+}
+
+// sortedJoin is strings.Join with a separator that cannot appear in
+// either ECR digests (sha256:hex) or EC2 instance IDs (i-hex).
+func sortedJoin(sorted []string) string {
+	if len(sorted) == 0 {
+		return ""
+	}
+	// '\x1f' is the ASCII unit separator; not present in any
+	// Inspector resource ID we accept.
+	out := sorted[0]
+	for _, s := range sorted[1:] {
+		out += "\x1f" + s
+	}
+	return out
 }

--- a/internal/cve/manager.go
+++ b/internal/cve/manager.go
@@ -2,9 +2,9 @@ package cve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 	"time"
 
@@ -18,14 +18,11 @@ import (
 
 // InspectorAPI is the subset of awsinspector.Client the manager needs.
 // Defined here so tests can substitute a stub without depending on the
-// SDK. The map-keyed return shape is the load-bearing contract: each
-// requested ID must appear in the result so the caller can iterate
-// the input list and trust the lookup (see ensureKeys in
-// awsinspector).
+// SDK.
 type InspectorAPI interface {
 	IsEnabled(ctx context.Context) (bool, error)
-	ListFindingsByInstance(ctx context.Context, instanceIDs []string) (map[string][]Finding, error)
-	ListFindingsByImageDigest(ctx context.Context, digests []string) (map[string][]Finding, error)
+	ListFindingsByInstance(ctx context.Context, instanceIDs []string) ([]Finding, error)
+	ListFindingsByImageDigest(ctx context.Context, digests []string) ([]Finding, error)
 }
 
 // EC2API is the subset of awsec2.Client the manager needs.
@@ -63,24 +60,17 @@ type Config struct {
 	// manager defaults to 1 minute (TTL) / 5 minutes (eviction).
 	TTLScanInterval      time.Duration
 	EvictionScanInterval time.Duration
-
-	// MaxConcurrentDeltaFetches caps the goroutine count for
-	// watch-driven async refreshes. A rolling deploy of a 200-pod
-	// workload could otherwise spawn hundreds of goroutines, each
-	// holding an Inspector socket. Default 8.
-	MaxConcurrentDeltaFetches int
 }
 
 // DefaultConfig returns the production defaults. Mirrors the issue's
 // spec; main.go fills any unset field with these values.
 func DefaultConfig() Config {
 	return Config{
-		RefreshInterval:           6 * time.Hour,
-		EvictAfter:                24 * time.Hour,
-		HydrateBatchSize:          50,
-		TTLScanInterval:           1 * time.Minute,
-		EvictionScanInterval:      5 * time.Minute,
-		MaxConcurrentDeltaFetches: 8,
+		RefreshInterval:      6 * time.Hour,
+		EvictAfter:           24 * time.Hour,
+		HydrateBatchSize:     50,
+		TTLScanInterval:      1 * time.Minute,
+		EvictionScanInterval: 5 * time.Minute,
 	}
 }
 
@@ -109,15 +99,7 @@ type Manager struct {
 	mu       sync.Mutex
 	clusters map[string]*clusterState
 
-	// sf collapses concurrent fetches of the same digest / instance
-	// batch into a single Inspector call. Inspector data is account-
-	// scoped, not cluster-scoped, so the keys deliberately omit the
-	// cluster name — a digest seen in cluster A's TTL scan and
-	// cluster B's manual refresh resolves to the same Inspector call.
 	sf singleflight.Group
-
-	// deltaSem caps concurrent watch-driven async refreshes.
-	deltaSem chan struct{}
 
 	stopOnce sync.Once
 	cancel   context.CancelFunc
@@ -149,9 +131,6 @@ func NewManager(inspector InspectorAPI, ec2 EC2API, clientFor ClientFactory, clo
 	if cfg.EvictionScanInterval == 0 {
 		cfg.EvictionScanInterval = DefaultConfig().EvictionScanInterval
 	}
-	if cfg.MaxConcurrentDeltaFetches <= 0 {
-		cfg.MaxConcurrentDeltaFetches = DefaultConfig().MaxConcurrentDeltaFetches
-	}
 	return &Manager{
 		inspector: inspector,
 		ec2:       ec2,
@@ -160,7 +139,6 @@ func NewManager(inspector InspectorAPI, ec2 EC2API, clientFor ClientFactory, clo
 		cfg:       cfg,
 		log:       log,
 		clusters:  map[string]*clusterState{},
-		deltaSem:  make(chan struct{}, cfg.MaxConcurrentDeltaFetches),
 		doneCh:    make(chan struct{}),
 	}
 }
@@ -252,21 +230,23 @@ func (m *Manager) Get(cluster string) *Store {
 // concurrent watch-hook fetch of the same digest will share the
 // in-flight call rather than firing a second Inspector request.
 func (m *Manager) Refresh(ctx context.Context, cluster clusters.Cluster, digests []string, instanceIDs []string) error {
-	store, err := m.EnsureHydrated(ctx, cluster)
+	st, err := m.EnsureHydrated(ctx, cluster)
 	if err != nil {
 		return err
 	}
-	if store.Disabled() {
+	if st.Disabled() {
 		return nil
 	}
 	var firstErr error
-	if len(digests) > 0 {
-		if err := m.fetchDigests(ctx, m.stateFor(cluster), digests); err != nil && firstErr == nil {
+	for _, d := range digests {
+		if err := m.fetchDigest(ctx, cluster, st, d); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	if len(instanceIDs) > 0 {
-		if err := m.fetchInstances(ctx, m.stateFor(cluster), instanceIDs); err != nil && firstErr == nil {
+		// Instance fetches are batched, not per-id like digests, so
+		// the single-flight key is the sorted list of IDs joined.
+		if err := m.fetchInstances(ctx, cluster, st, instanceIDs); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -313,10 +293,9 @@ func (m *Manager) runLoops(ctx context.Context) {
 }
 
 // scanTTL re-fetches any entry whose LastFetched is older than
-// RefreshInterval. Stale digests and instances are batched into one
-// Inspector call per cluster (chunked internally by awsinspector to
-// BatchSize); this keeps a 500-stale-digest cluster at ~10 Inspector
-// calls instead of 500.
+// RefreshInterval. Iterates per cluster, calling fetchDigest /
+// fetchInstances which are single-flight protected, so concurrent
+// manual refreshes won't double-fire.
 func (m *Manager) scanTTL(ctx context.Context) {
 	m.mu.Lock()
 	snapshot := make([]*clusterState, 0, len(m.clusters))
@@ -331,14 +310,14 @@ func (m *Manager) scanTTL(ctx context.Context) {
 	for _, st := range snapshot {
 		now := m.clock.Now()
 		digests, instances := st.store.IterStale(now, m.cfg.RefreshInterval)
-		if len(digests) > 0 {
-			if err := m.fetchDigests(ctx, st, digests); err != nil {
-				m.log.Debug("cve ttl digest refresh", "cluster", st.clusterRef.Name, "n", len(digests), "err", err)
+		for _, d := range digests {
+			if err := m.fetchDigest(ctx, st.clusterRef, st.store, d); err != nil {
+				m.log.Debug("cve ttl digest refresh", "cluster", st.clusterRef.Name, "digest", d, "err", err)
 			}
 		}
 		if len(instances) > 0 {
-			if err := m.fetchInstances(ctx, st, instances); err != nil {
-				m.log.Debug("cve ttl instance refresh", "cluster", st.clusterRef.Name, "n", len(instances), "err", err)
+			if err := m.fetchInstances(ctx, st.clusterRef, st.store, instances); err != nil {
+				m.log.Debug("cve ttl instance refresh", "cluster", st.clusterRef.Name, "err", err)
 			}
 		}
 	}
@@ -375,55 +354,62 @@ func (m *Manager) scanEvict() {
 	}
 }
 
-// fetchDigests batches a digest set into one Inspector call (further
-// chunked by awsinspector.BatchSize). Single-flight collapsing keys
-// off the sorted-and-joined ID list so two concurrent callers asking
-// for the same set share the result. Inspector data is account-
-// scoped, so the cluster name is intentionally NOT in the key.
-func (m *Manager) fetchDigests(ctx context.Context, st *clusterState, digests []string) error {
-	if len(digests) == 0 || st.store.Disabled() {
+// errInspectorDisabled is sentinelled (not exported) so fetch helpers
+// can short-circuit cleanly when the store has been marked disabled
+// mid-flight.
+var errInspectorDisabled = errors.New("inspector v2 disabled")
+
+// fetchDigest fetches a single digest via single-flight. The
+// single-flight key namespaces digests under "d:" so a digest that
+// happens to share a string with an instance ID can't collide.
+func (m *Manager) fetchDigest(ctx context.Context, cluster clusters.Cluster, store *Store, digest string) error {
+	if digest == "" {
 		return nil
 	}
-	keys := dedupSorted(digests)
-	if len(keys) == 0 {
+	if store.Disabled() {
 		return nil
 	}
-	sfKey := "d:" + joinKey(keys)
-	_, err, _ := m.sf.Do(sfKey, func() (any, error) {
-		grouped, err := m.inspector.ListFindingsByImageDigest(ctx, keys)
+	key := "d:" + cluster.Name + ":" + digest
+	_, err, _ := m.sf.Do(key, func() (any, error) {
+		findings, err := m.inspector.ListFindingsByImageDigest(ctx, []string{digest})
 		if err != nil {
 			return nil, err
 		}
-		now := m.clock.Now()
-		for _, d := range keys {
-			st.store.UpsertDigest(d, grouped[d], now)
-		}
+		store.UpsertDigest(digest, findings, m.clock.Now())
 		return nil, nil
 	})
 	return err
 }
 
-// fetchInstances batches an instance set into one Inspector call.
-// Owner classification is preserved across the upsert (the existing
-// entry's OwnerKind/Name carries through); only the cold-path
-// hydrate reassigns ownership.
-func (m *Manager) fetchInstances(ctx context.Context, st *clusterState, ids []string) error {
-	if len(ids) == 0 || st.store.Disabled() {
+// fetchInstances re-fetches a set of instance entries in one
+// Inspector call. Owner classification is preserved across the
+// upsert (we read the existing entry first); a fresh cold-path
+// hydrate is the only branch that reassigns OwnerKind/Name.
+func (m *Manager) fetchInstances(ctx context.Context, cluster clusters.Cluster, store *Store, ids []string) error {
+	if len(ids) == 0 || store.Disabled() {
 		return nil
 	}
-	keys := dedupSorted(ids)
-	if len(keys) == 0 {
-		return nil
-	}
-	sfKey := "i:" + joinKey(keys)
-	_, err, _ := m.sf.Do(sfKey, func() (any, error) {
-		grouped, err := m.inspector.ListFindingsByInstance(ctx, keys)
+	key := fmt.Sprintf("i:%s:%d:%s", cluster.Name, len(ids), ids[0])
+	_, err, _ := m.sf.Do(key, func() (any, error) {
+		findings, err := m.inspector.ListFindingsByInstance(ctx, ids)
 		if err != nil {
 			return nil, err
 		}
+		// Group findings by instance ID. Inspector returns a flat
+		// finding list with the resource ID embedded; we need to
+		// re-bucket here so each instance's row gets the right
+		// subset. The SDK's awsinspector.Finding doesn't expose the
+		// resource ID directly because the cve.Finding DTO is
+		// intentionally flat — see the trade-off note in
+		// awsinspector/client.go projectFinding. For now we bulk-
+		// assign the same finding list to every requested instance
+		// and let the API layer (#165) filter by resource on read.
+		// TODO(#165): teach awsinspector.Finding to carry the
+		// originating resource ID so per-instance assignment is
+		// exact.
 		now := m.clock.Now()
-		for _, id := range keys {
-			existing := st.store.GetInstance(id)
+		for _, id := range ids {
+			existing := store.GetInstance(id)
 			var kind OwnerKind
 			var name string
 			if existing != nil {
@@ -432,67 +418,9 @@ func (m *Manager) fetchInstances(ctx context.Context, st *clusterState, ids []st
 			} else {
 				kind = OwnerUnmanaged
 			}
-			st.store.UpsertInstance(id, grouped[id], kind, name, now)
+			store.UpsertInstance(id, findings, kind, name, now)
 		}
 		return nil, nil
 	})
 	return err
-}
-
-// runDelta executes fn under the delta-fetch semaphore so a
-// rolling-deploy storm doesn't spawn unbounded goroutines, each with
-// an Inspector socket. Drops the work (logs at debug) if ctx is
-// cancelled while waiting for a slot.
-func (m *Manager) runDelta(ctx context.Context, fn func()) {
-	select {
-	case m.deltaSem <- struct{}{}:
-		defer func() { <-m.deltaSem }()
-		fn()
-	case <-ctx.Done():
-		return
-	}
-}
-
-// dedupSorted returns the input deduped + sorted. Used for stable
-// singleflight keys.
-func dedupSorted(in []string) []string {
-	if len(in) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(in))
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if s == "" {
-			continue
-		}
-		if _, ok := seen[s]; ok {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	sort.Strings(out)
-	return out
-}
-
-// joinKey produces a stable singleflight key from a deduped+sorted ID
-// list. The leading length+`:` byte makes "ab","c" and "a","bc"
-// collisions impossible.
-func joinKey(sorted []string) string {
-	return fmt.Sprintf("%d:", len(sorted)) + sortedJoin(sorted)
-}
-
-// sortedJoin is strings.Join with a separator that cannot appear in
-// either ECR digests (sha256:hex) or EC2 instance IDs (i-hex).
-func sortedJoin(sorted []string) string {
-	if len(sorted) == 0 {
-		return ""
-	}
-	// '\x1f' is the ASCII unit separator; not present in any
-	// Inspector resource ID we accept.
-	out := sorted[0]
-	for _, s := range sorted[1:] {
-		out += "\x1f" + s
-	}
-	return out
 }

--- a/internal/cve/manager_test.go
+++ b/internal/cve/manager_test.go
@@ -167,13 +167,13 @@ func TestManager_TTL_RefreshesStale(t *testing.T) {
 	}
 	baselineDigestCalls := insp.digestCalls.Load()
 
-	// Fast-forward 2 hours past TTL. The next tick should re-fetch.
-	clock.Advance(2 * time.Hour)
-	// Allow the ticker goroutine to wake up. clockwork's FakeClock
-	// requires waiting on tickers; we drive a tick by advancing
-	// enough to trigger one and then waiting briefly.
-	clock.Advance(2 * time.Minute) // past two TTLScanInterval ticks
-	deadline := time.Now().Add(2 * time.Second)
+	// runLoops registers two waiters on the fake clock (the TTL +
+	// eviction tickers). Block until both are in place before
+	// advancing — otherwise Advance can race the goroutine and
+	// silently drop the tick.
+	clock.BlockUntil(2)
+	clock.Advance(2 * time.Hour) // past TTL boundary, fires both ticks
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if insp.digestCalls.Load() > baselineDigestCalls {
 			break
@@ -206,10 +206,12 @@ func TestManager_Eviction_DropsZeroRefStale(t *testing.T) {
 	st.IncDigestRef("evict-me")
 	st.DecDigestRef("evict-me")
 
-	clock.Advance(2 * time.Hour)   // past EvictAfter
-	clock.Advance(2 * time.Minute) // past two EvictionScanInterval ticks
+	// Wait until both tickers (TTL + eviction) are registered with
+	// the fake clock so Advance reliably fires them.
+	clock.BlockUntil(2)
+	clock.Advance(2 * time.Hour) // past EvictAfter
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if st.GetDigest("evict-me") == nil {
 			return

--- a/internal/cve/manager_test.go
+++ b/internal/cve/manager_test.go
@@ -171,7 +171,12 @@ func TestManager_TTL_RefreshesStale(t *testing.T) {
 	// eviction tickers). Block until both are in place before
 	// advancing — otherwise Advance can race the goroutine and
 	// silently drop the tick.
-	clock.BlockUntil(2)
+	blockCtx, blockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := clock.BlockUntilContext(blockCtx, 2); err != nil {
+		blockCancel()
+		t.Fatalf("BlockUntilContext: %v", err)
+	}
+	blockCancel()
 	clock.Advance(2 * time.Hour) // past TTL boundary, fires both ticks
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -208,7 +213,12 @@ func TestManager_Eviction_DropsZeroRefStale(t *testing.T) {
 
 	// Wait until both tickers (TTL + eviction) are registered with
 	// the fake clock so Advance reliably fires them.
-	clock.BlockUntil(2)
+	blockCtx, blockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := clock.BlockUntilContext(blockCtx, 2); err != nil {
+		blockCancel()
+		t.Fatalf("BlockUntilContext: %v", err)
+	}
+	blockCancel()
 	clock.Advance(2 * time.Hour) // past EvictAfter
 
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/cve/manager_test.go
+++ b/internal/cve/manager_test.go
@@ -35,20 +35,20 @@ func (s *stubInspector) IsEnabled(_ context.Context) (bool, error) {
 	return s.enabled, nil
 }
 
-func (s *stubInspector) ListFindingsByInstance(_ context.Context, ids []string) ([]Finding, error) {
+func (s *stubInspector) ListFindingsByInstance(_ context.Context, ids []string) (map[string][]Finding, error) {
 	s.instanceCalls.Add(1)
-	var out []Finding
+	out := make(map[string][]Finding, len(ids))
 	for _, id := range ids {
-		out = append(out, s.instanceFindings[id]...)
+		out[id] = append(out[id], s.instanceFindings[id]...)
 	}
 	return out, nil
 }
 
-func (s *stubInspector) ListFindingsByImageDigest(_ context.Context, digests []string) ([]Finding, error) {
+func (s *stubInspector) ListFindingsByImageDigest(_ context.Context, digests []string) (map[string][]Finding, error) {
 	s.digestCalls.Add(1)
-	var out []Finding
+	out := make(map[string][]Finding, len(digests))
 	for _, d := range digests {
-		out = append(out, s.digestFindings[d]...)
+		out[d] = append(out[d], s.digestFindings[d]...)
 	}
 	return out, nil
 }

--- a/internal/cve/manager_test.go
+++ b/internal/cve/manager_test.go
@@ -19,9 +19,9 @@ import (
 // --- stub clients shared across tests ---
 
 type stubInspector struct {
-	enabled      bool
-	enabledErr   error
-	digestCalls  atomic.Int32
+	enabled       bool
+	enabledErr    error
+	digestCalls   atomic.Int32
 	instanceCalls atomic.Int32
 
 	digestFindings   map[string][]Finding
@@ -35,20 +35,20 @@ func (s *stubInspector) IsEnabled(_ context.Context) (bool, error) {
 	return s.enabled, nil
 }
 
-func (s *stubInspector) ListFindingsByInstance(_ context.Context, ids []string) (map[string][]Finding, error) {
+func (s *stubInspector) ListFindingsByInstance(_ context.Context, ids []string) ([]Finding, error) {
 	s.instanceCalls.Add(1)
-	out := make(map[string][]Finding, len(ids))
+	var out []Finding
 	for _, id := range ids {
-		out[id] = append(out[id], s.instanceFindings[id]...)
+		out = append(out, s.instanceFindings[id]...)
 	}
 	return out, nil
 }
 
-func (s *stubInspector) ListFindingsByImageDigest(_ context.Context, digests []string) (map[string][]Finding, error) {
+func (s *stubInspector) ListFindingsByImageDigest(_ context.Context, digests []string) ([]Finding, error) {
 	s.digestCalls.Add(1)
-	out := make(map[string][]Finding, len(digests))
+	var out []Finding
 	for _, d := range digests {
-		out[d] = append(out[d], s.digestFindings[d]...)
+		out = append(out, s.digestFindings[d]...)
 	}
 	return out, nil
 }
@@ -167,18 +167,13 @@ func TestManager_TTL_RefreshesStale(t *testing.T) {
 	}
 	baselineDigestCalls := insp.digestCalls.Load()
 
-	// runLoops registers two waiters on the fake clock (the TTL +
-	// eviction tickers). Block until both are in place before
-	// advancing — otherwise Advance can race the goroutine and
-	// silently drop the tick.
-	blockCtx, blockCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	if err := clock.BlockUntilContext(blockCtx, 2); err != nil {
-		blockCancel()
-		t.Fatalf("BlockUntilContext: %v", err)
-	}
-	blockCancel()
-	clock.Advance(2 * time.Hour) // past TTL boundary, fires both ticks
-	deadline := time.Now().Add(5 * time.Second)
+	// Fast-forward 2 hours past TTL. The next tick should re-fetch.
+	clock.Advance(2 * time.Hour)
+	// Allow the ticker goroutine to wake up. clockwork's FakeClock
+	// requires waiting on tickers; we drive a tick by advancing
+	// enough to trigger one and then waiting briefly.
+	clock.Advance(2 * time.Minute) // past two TTLScanInterval ticks
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if insp.digestCalls.Load() > baselineDigestCalls {
 			break
@@ -211,17 +206,10 @@ func TestManager_Eviction_DropsZeroRefStale(t *testing.T) {
 	st.IncDigestRef("evict-me")
 	st.DecDigestRef("evict-me")
 
-	// Wait until both tickers (TTL + eviction) are registered with
-	// the fake clock so Advance reliably fires them.
-	blockCtx, blockCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	if err := clock.BlockUntilContext(blockCtx, 2); err != nil {
-		blockCancel()
-		t.Fatalf("BlockUntilContext: %v", err)
-	}
-	blockCancel()
-	clock.Advance(2 * time.Hour) // past EvictAfter
+	clock.Advance(2 * time.Hour)   // past EvictAfter
+	clock.Advance(2 * time.Minute) // past two EvictionScanInterval ticks
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if st.GetDigest("evict-me") == nil {
 			return

--- a/internal/cve/owner_resolver.go
+++ b/internal/cve/owner_resolver.go
@@ -37,7 +37,6 @@ import (
 // returns OwnerKarpenter with an empty OwnerName rather than failing
 // the whole hydrate.
 type OwnerResolver struct {
-	ec2    *awsec2.Client
 	listFn func(ctx context.Context, cs kubernetes.Interface) ([]nodeClaimRef, error) // overridable for tests
 	getCS  func(ctx context.Context) (kubernetes.Interface, error)
 }
@@ -56,9 +55,8 @@ type nodeClaimRef struct {
 // client. getCS returns a K8s clientset for the cluster being
 // resolved; the resolver calls it lazily, and only when a Karpenter
 // instance is detected.
-func NewOwnerResolver(ec2 *awsec2.Client, getCS func(ctx context.Context) (kubernetes.Interface, error)) *OwnerResolver {
+func NewOwnerResolver(getCS func(ctx context.Context) (kubernetes.Interface, error)) *OwnerResolver {
 	return &OwnerResolver{
-		ec2:    ec2,
 		getCS:  getCS,
 		listFn: listKarpenterNodeClaims,
 	}

--- a/internal/cve/owner_resolver.go
+++ b/internal/cve/owner_resolver.go
@@ -37,8 +37,9 @@ import (
 // returns OwnerKarpenter with an empty OwnerName rather than failing
 // the whole hydrate.
 type OwnerResolver struct {
-	listFn  func(ctx context.Context, cs kubernetes.Interface) ([]nodeClaimRef, error) // overridable for tests
-	getCS   func(ctx context.Context) (kubernetes.Interface, error)
+	ec2    *awsec2.Client
+	listFn func(ctx context.Context, cs kubernetes.Interface) ([]nodeClaimRef, error) // overridable for tests
+	getCS  func(ctx context.Context) (kubernetes.Interface, error)
 }
 
 // nodeClaimRef is the projected shape of a Karpenter NodeClaim that
@@ -55,8 +56,9 @@ type nodeClaimRef struct {
 // client. getCS returns a K8s clientset for the cluster being
 // resolved; the resolver calls it lazily, and only when a Karpenter
 // instance is detected.
-func NewOwnerResolver(getCS func(ctx context.Context) (kubernetes.Interface, error)) *OwnerResolver {
+func NewOwnerResolver(ec2 *awsec2.Client, getCS func(ctx context.Context) (kubernetes.Interface, error)) *OwnerResolver {
 	return &OwnerResolver{
+		ec2:    ec2,
 		getCS:  getCS,
 		listFn: listKarpenterNodeClaims,
 	}

--- a/internal/cve/owner_walk.go
+++ b/internal/cve/owner_walk.go
@@ -1,0 +1,73 @@
+package cve
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+)
+
+// SupportedWorkloadKinds is the closed set of workload kinds the
+// /cve/by-workload endpoint accepts. CronJob is intentionally
+// omitted: Pod → Job → CronJob is a three-hop walk that would need a
+// Job informer too, and CronJob CVE surfacing matters far less than
+// the long-running Deployment / STS / DS case. Revisit in v1.2 if
+// operators ask.
+var SupportedWorkloadKinds = []string{
+	"Deployment",
+	"StatefulSet",
+	"DaemonSet",
+	"ReplicaSet",
+	"Job",
+}
+
+// IsSupportedWorkloadKind reports whether kind is in the supported
+// set. Handler-side validation gate.
+func IsSupportedWorkloadKind(kind string) bool {
+	for _, k := range SupportedWorkloadKinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// PodOwnedBy reports whether pod is (directly or transitively) owned
+// by a workload (kind, namespace, name). Walks the ownerRef chain:
+//
+//   - Direct: pod.ownerReferences contains a match. Covers
+//     StatefulSet, DaemonSet, ReplicaSet, Job, and self-owned pods.
+//
+//   - Two-hop via ReplicaSet: pod is owned by a ReplicaSet R; R is
+//     owned by (kind, name). Covers Deployment, since the Deployment
+//     controller spawns a ReplicaSet which spawns the pods.
+//
+// rsLister may be nil when the caller knows kind != "Deployment"; in
+// that case only the direct match is attempted, and a query for a
+// Deployment returns false (with no panic).
+//
+// Namespace must match — owners are namespaced; a Deployment in
+// `payments` cannot own a pod in `default`.
+func PodOwnedBy(pod *corev1.Pod, kind, namespace, name string, rsLister appslisters.ReplicaSetLister) bool {
+	if pod == nil || pod.Namespace != namespace {
+		return false
+	}
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == kind && ref.Name == name {
+			return true
+		}
+		// Two-hop: pod -> ReplicaSet -> kind. Only relevant when the
+		// caller is asking about a Deployment (RS direct match was
+		// already covered above for kind=ReplicaSet).
+		if kind == "Deployment" && ref.Kind == "ReplicaSet" && rsLister != nil {
+			rs, err := rsLister.ReplicaSets(namespace).Get(ref.Name)
+			if err != nil || rs == nil {
+				continue
+			}
+			for _, rsOwner := range rs.OwnerReferences {
+				if rsOwner.Kind == "Deployment" && rsOwner.Name == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/cve/owner_walk_test.go
+++ b/internal/cve/owner_walk_test.go
@@ -1,0 +1,132 @@
+package cve
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+)
+
+// buildRSLister returns an apps/v1 ReplicaSet lister seeded with the
+// given replicasets. Uses a SharedInformer's indexer so the lister
+// matches the production code path 1:1.
+func buildRSLister(t *testing.T, rss ...*appsv1.ReplicaSet) appslisters.ReplicaSetLister {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(cs, 0)
+	rsInf := factory.Apps().V1().ReplicaSets()
+	for _, rs := range rss {
+		if err := rsInf.Informer().GetIndexer().Add(rs); err != nil {
+			t.Fatalf("seed indexer: %v", err)
+		}
+	}
+	return rsInf.Lister()
+}
+
+func pod(ns, name string, owners ...metav1.OwnerReference) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, OwnerReferences: owners},
+	}
+}
+
+func TestPodOwnedBy_DirectStatefulSet(t *testing.T) {
+	p := pod("ns", "my-sts-0",
+		metav1.OwnerReference{Kind: "StatefulSet", Name: "my-sts"})
+	if !PodOwnedBy(p, "StatefulSet", "ns", "my-sts", nil) {
+		t.Error("StatefulSet direct match should return true")
+	}
+}
+
+func TestPodOwnedBy_DirectDaemonSet(t *testing.T) {
+	p := pod("kube-system", "fluentd-abc",
+		metav1.OwnerReference{Kind: "DaemonSet", Name: "fluentd"})
+	if !PodOwnedBy(p, "DaemonSet", "kube-system", "fluentd", nil) {
+		t.Error("DaemonSet direct match should return true")
+	}
+}
+
+func TestPodOwnedBy_DirectJob(t *testing.T) {
+	p := pod("ns", "batch-x", metav1.OwnerReference{Kind: "Job", Name: "batch"})
+	if !PodOwnedBy(p, "Job", "ns", "batch", nil) {
+		t.Error("Job direct match should return true")
+	}
+}
+
+func TestPodOwnedBy_TwoHopDeployment(t *testing.T) {
+	// Pod owned by ReplicaSet that's owned by Deployment.
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "my-app-abc123",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "my-app"}},
+		},
+	}
+	rsLister := buildRSLister(t, rs)
+	p := pod("ns", "my-app-abc123-xyz",
+		metav1.OwnerReference{Kind: "ReplicaSet", Name: "my-app-abc123"})
+
+	if !PodOwnedBy(p, "Deployment", "ns", "my-app", rsLister) {
+		t.Error("two-hop Deployment match should return true")
+	}
+	// And the direct ReplicaSet query should still hit.
+	if !PodOwnedBy(p, "ReplicaSet", "ns", "my-app-abc123", rsLister) {
+		t.Error("direct ReplicaSet match should return true")
+	}
+}
+
+func TestPodOwnedBy_TwoHopMissingLister_NoMatch(t *testing.T) {
+	// Caller asked for Deployment but didn't pass an rsLister. The
+	// direct-match branch can't see Deployment kind on the pod
+	// owner, so the result must be false (and must not panic).
+	p := pod("ns", "p",
+		metav1.OwnerReference{Kind: "ReplicaSet", Name: "rs-1"})
+	if PodOwnedBy(p, "Deployment", "ns", "my-app", nil) {
+		t.Error("Deployment query without rsLister must not match")
+	}
+}
+
+func TestPodOwnedBy_TwoHopWrongDeployment_NoMatch(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "other-app-xyz",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "other-app"}},
+		},
+	}
+	rsLister := buildRSLister(t, rs)
+	p := pod("ns", "p",
+		metav1.OwnerReference{Kind: "ReplicaSet", Name: "other-app-xyz"})
+	if PodOwnedBy(p, "Deployment", "ns", "my-app", rsLister) {
+		t.Error("different Deployment must not match")
+	}
+}
+
+func TestPodOwnedBy_NamespaceMismatch(t *testing.T) {
+	p := pod("other-ns", "p",
+		metav1.OwnerReference{Kind: "StatefulSet", Name: "my-sts"})
+	if PodOwnedBy(p, "StatefulSet", "ns", "my-sts", nil) {
+		t.Error("namespace mismatch must not match")
+	}
+}
+
+func TestPodOwnedBy_OwnerlessPod_NoMatch(t *testing.T) {
+	p := pod("ns", "standalone")
+	if PodOwnedBy(p, "Deployment", "ns", "anything", nil) {
+		t.Error("ownerless pod must not match any workload")
+	}
+}
+
+func TestIsSupportedWorkloadKind(t *testing.T) {
+	for _, k := range []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"} {
+		if !IsSupportedWorkloadKind(k) {
+			t.Errorf("%s should be supported", k)
+		}
+	}
+	for _, k := range []string{"CronJob", "Pod", "", "deployment", "Service"} {
+		if IsSupportedWorkloadKind(k) {
+			t.Errorf("%q should NOT be supported", k)
+		}
+	}
+}

--- a/internal/cve/severity.go
+++ b/internal/cve/severity.go
@@ -1,0 +1,50 @@
+package cve
+
+import "strings"
+
+// SeverityCounts is the per-severity histogram surfaced on chip
+// rows. Pure data shape — no JSON tags here; the wire DTOs in
+// types.go add the tags so the in-memory aggregation can stay
+// representation-agnostic.
+type SeverityCounts struct {
+	Critical      int
+	High          int
+	Medium        int
+	Low           int
+	Informational int
+}
+
+// CountSeverities folds a finding slice into a severity histogram.
+// Inspector reports the severity string in upper case
+// (CRITICAL/HIGH/MEDIUM/LOW/INFORMATIONAL); we accept any case so
+// future projections that lower-case the field still work.
+// Unknown severities are silently ignored — defensive against
+// future Inspector additions we haven't mapped yet.
+func CountSeverities(findings []Finding) SeverityCounts {
+	var c SeverityCounts
+	for _, f := range findings {
+		switch strings.ToUpper(f.Severity) {
+		case "CRITICAL":
+			c.Critical++
+		case "HIGH":
+			c.High++
+		case "MEDIUM":
+			c.Medium++
+		case "LOW":
+			c.Low++
+		case "INFORMATIONAL", "INFO":
+			c.Informational++
+		}
+	}
+	return c
+}
+
+// Add folds another set of counts into c. Used by the per-pod
+// roll-up that sums across container digests.
+func (c *SeverityCounts) Add(o SeverityCounts) {
+	c.Critical += o.Critical
+	c.High += o.High
+	c.Medium += o.Medium
+	c.Low += o.Low
+	c.Informational += o.Informational
+}

--- a/internal/cve/severity_test.go
+++ b/internal/cve/severity_test.go
@@ -1,0 +1,35 @@
+package cve
+
+import "testing"
+
+func TestCountSeverities_Mix(t *testing.T) {
+	got := CountSeverities([]Finding{
+		{Severity: "CRITICAL"},
+		{Severity: "HIGH"},
+		{Severity: "HIGH"},
+		{Severity: "medium"}, // case-insensitive
+		{Severity: "LOW"},
+		{Severity: "INFORMATIONAL"},
+		{Severity: "INFO"}, // alias
+		{Severity: "unknown"},
+	})
+	want := SeverityCounts{Critical: 1, High: 2, Medium: 1, Low: 1, Informational: 2}
+	if got != want {
+		t.Errorf("CountSeverities: got %+v want %+v", got, want)
+	}
+}
+
+func TestCountSeverities_Empty(t *testing.T) {
+	if got := CountSeverities(nil); got != (SeverityCounts{}) {
+		t.Errorf("nil findings should yield zero counts, got %+v", got)
+	}
+}
+
+func TestSeverityCounts_Add(t *testing.T) {
+	a := SeverityCounts{Critical: 1, High: 2}
+	a.Add(SeverityCounts{Critical: 3, Low: 4})
+	want := SeverityCounts{Critical: 4, High: 2, Low: 4}
+	if a != want {
+		t.Errorf("Add: got %+v want %+v", a, want)
+	}
+}

--- a/internal/cve/store.go
+++ b/internal/cve/store.go
@@ -49,6 +49,7 @@ type InstanceEntry struct {
 	LastFetched time.Time
 	NodeRefs    int
 	OwnerKind   OwnerKind
+	AMI         string
 	OwnerName   string
 }
 
@@ -70,7 +71,8 @@ type Store struct {
 	digests   map[string]*DigestEntry
 	instances map[string]*InstanceEntry
 
-	hydrated  bool
+	hydrated    bool
+	lastHydrate time.Time
 	hydrating chan struct{} // closed when hydrate completes
 	disabled  bool
 }
@@ -109,12 +111,13 @@ func (s *Store) WaitHydrated(ctx context.Context) error {
 // MarkHydrated flips the store to ready state and unblocks waiters.
 // Idempotent so a re-hydrate (e.g. cluster reconnect) doesn't panic
 // on a double-close.
-func (s *Store) MarkHydrated() {
+func (s *Store) MarkHydrated(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.hydrated {
 		return
 	}
+	s.lastHydrate = now
 	s.hydrated = true
 	close(s.hydrating)
 }
@@ -122,13 +125,14 @@ func (s *Store) MarkHydrated() {
 // MarkDisabled flips the store to "Inspector v2 not enabled" and
 // unblocks waiters with disabled=true. Same idempotency guarantee as
 // MarkHydrated.
-func (s *Store) MarkDisabled() {
+func (s *Store) MarkDisabled(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.hydrated {
 		return
 	}
 	s.disabled = true
+	s.lastHydrate = now
 	s.hydrated = true
 	close(s.hydrating)
 }
@@ -168,7 +172,7 @@ func (s *Store) UpsertDigest(digest string, findings []Finding, now time.Time) {
 
 // UpsertInstance stores findings + owner for an instance. NodeRefs
 // is preserved across upserts.
-func (s *Store) UpsertInstance(instanceID string, findings []Finding, ownerKind OwnerKind, ownerName string, now time.Time) {
+func (s *Store) UpsertInstance(instanceID string, findings []Finding, ownerKind OwnerKind, ownerName string, ami string, now time.Time) {
 	if instanceID == "" {
 		return
 	}
@@ -183,6 +187,7 @@ func (s *Store) UpsertInstance(instanceID string, findings []Finding, ownerKind 
 	e.LastFetched = now
 	e.OwnerKind = ownerKind
 	e.OwnerName = ownerName
+	e.AMI = ami
 }
 
 // GetDigest returns the entry for a digest, or nil if absent. The
@@ -349,4 +354,23 @@ func (s *Store) Snapshot() (digests map[string]*DigestEntry, instances map[strin
 		instances[k] = &c
 	}
 	return digests, instances
+}
+
+// LastHydrate returns the time of the most recent MarkHydrated /
+// MarkDisabled call. Zero before the first hydrate completes.
+// Surfaced on the `/cve/status` endpoint and used as the ETag base
+// for read endpoints.
+func (s *Store) LastHydrate() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastHydrate
+}
+
+// EntryCounts returns the current number of digest + instance cache
+// entries. Surfaced on `/cve/status` and used as the ETag basis for
+// read endpoints.
+func (s *Store) EntryCounts() (digests, instances int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.digests), len(s.instances)
 }

--- a/internal/cve/store_test.go
+++ b/internal/cve/store_test.go
@@ -51,8 +51,8 @@ func TestStore_IterStale(t *testing.T) {
 	fresh := time.Now()
 	s.UpsertDigest("old-d", nil, old)
 	s.UpsertDigest("fresh-d", nil, fresh)
-	s.UpsertInstance("old-i", nil, OwnerUnmanaged, "", old)
-	s.UpsertInstance("fresh-i", nil, OwnerUnmanaged, "", fresh)
+	s.UpsertInstance("old-i", nil, OwnerUnmanaged, "", "", old)
+	s.UpsertInstance("fresh-i", nil, OwnerUnmanaged, "", "", fresh)
 	d, i := s.IterStale(time.Now(), 1*time.Hour)
 	if len(d) != 1 || d[0] != "old-d" {
 		t.Errorf("stale digests: %v", d)
@@ -84,12 +84,12 @@ func TestStore_DisabledState(t *testing.T) {
 	if s.Hydrated() || s.Disabled() {
 		t.Fatal("fresh store should be neither hydrated nor disabled")
 	}
-	s.MarkDisabled()
+	s.MarkDisabled(time.Now())
 	if !s.Hydrated() || !s.Disabled() {
 		t.Fatal("after MarkDisabled: want hydrated && disabled")
 	}
 	// Idempotent: a second call must not panic.
-	s.MarkDisabled()
+	s.MarkDisabled(time.Now())
 }
 
 func TestStore_WaitHydratedUnblocks(t *testing.T) {
@@ -100,7 +100,7 @@ func TestStore_WaitHydratedUnblocks(t *testing.T) {
 	go func() { done <- s.WaitHydrated(ctx) }()
 	// Give the goroutine a moment to enter the select.
 	time.Sleep(10 * time.Millisecond)
-	s.MarkHydrated()
+	s.MarkHydrated(time.Now())
 	select {
 	case err := <-done:
 		if err != nil {
@@ -113,7 +113,7 @@ func TestStore_WaitHydratedUnblocks(t *testing.T) {
 
 func TestStore_WaitHydrated_AlreadyHydrated(t *testing.T) {
 	s := NewStore()
-	s.MarkHydrated()
+	s.MarkHydrated(time.Now())
 	if err := s.WaitHydrated(context.Background()); err != nil {
 		t.Fatalf("WaitHydrated: %v", err)
 	}

--- a/internal/cve/types.go
+++ b/internal/cve/types.go
@@ -19,16 +19,12 @@ type WireSeverityCounts struct {
 	Informational int `json:"informational"`
 }
 
-// WireSeverity returns a WireSeverityCounts copy of c for direct
-// JSON encoding.
+// WireSeverity returns a WireSeverityCounts view of c for direct JSON
+// encoding. The two types share field layout — they intentionally do, so
+// the wire shape can pick up its JSON tags without the aggregator having
+// to know about them — so a plain conversion is sufficient.
 func WireSeverity(c SeverityCounts) WireSeverityCounts {
-	return WireSeverityCounts{
-		Critical:      c.Critical,
-		High:          c.High,
-		Medium:        c.Medium,
-		Low:           c.Low,
-		Informational: c.Informational,
-	}
+	return WireSeverityCounts(c)
 }
 
 // OwnerRef is the projection of (OwnerKind, OwnerName) used on the

--- a/internal/cve/types.go
+++ b/internal/cve/types.go
@@ -1,0 +1,133 @@
+package cve
+
+import "time"
+
+// Wire-only DTOs for the HTTP API. The store's internal types
+// (ref counts, channels, embedded mutex on Store) never serialise —
+// these struct fields have JSON tags and only carry what the SPA
+// reads.
+
+// WireSeverityCounts is the JSON envelope around the in-memory
+// SeverityCounts aggregator. Splitting it lets the aggregator stay
+// representation-agnostic (severity.go) while the wire type carries
+// JSON tags compatible with the SPA's existing chip code.
+type WireSeverityCounts struct {
+	Critical      int `json:"critical"`
+	High          int `json:"high"`
+	Medium        int `json:"medium"`
+	Low           int `json:"low"`
+	Informational int `json:"informational"`
+}
+
+// WireSeverity returns a WireSeverityCounts copy of c for direct
+// JSON encoding.
+func WireSeverity(c SeverityCounts) WireSeverityCounts {
+	return WireSeverityCounts{
+		Critical:      c.Critical,
+		High:          c.High,
+		Medium:        c.Medium,
+		Low:           c.Low,
+		Informational: c.Informational,
+	}
+}
+
+// OwnerRef is the projection of (OwnerKind, OwnerName) used on the
+// wire so the SPA can render "managed-nodegroup: ng-prod" or
+// "karpenter-nodeclaim: default-9f3kz" without re-deriving the kind.
+type OwnerRef struct {
+	Kind OwnerKind `json:"kind"`
+	Name string    `json:"name,omitempty"`
+}
+
+// InstanceRow is the per-EC2-instance wire row for /cve/by-instance.
+type InstanceRow struct {
+	InstanceID     string             `json:"instanceId"`
+	Owner          OwnerRef           `json:"owner"`
+	AMI            string             `json:"ami,omitempty"`
+	SeverityCounts WireSeverityCounts `json:"severityCounts"`
+	LastFetchedAt  time.Time          `json:"lastFetchedAt"`
+}
+
+// InstancesResp is the envelope for /cve/by-instance. inspectorEnabled
+// + hydrated mirror the /cve/status flags so the SPA can render the
+// empty-state hint from a single response.
+type InstancesResp struct {
+	Instances        []InstanceRow `json:"instances"`
+	InspectorEnabled bool          `json:"inspectorEnabled"`
+	Hydrated         bool          `json:"hydrated"`
+}
+
+// FindingsResp is the envelope for /cve/by-instance/{id} and
+// /cve/by-digest/{digest}. Each Finding already carries its own
+// pre-built Inspector deep-link URL (see awsinspector.Finding).
+type FindingsResp struct {
+	Findings         []Finding `json:"findings"`
+	LastFetchedAt    time.Time `json:"lastFetchedAt"`
+	InspectorEnabled bool      `json:"inspectorEnabled"`
+	Hydrated         bool      `json:"hydrated"`
+}
+
+// ContainerRow is the per-container wire row inside a PodRow.
+// SeverityCounts is a pointer so containers in ScanStateNonECR /
+// ScanStatePending can omit the field entirely (the SPA renders a
+// "not scanned" pill instead of zeros).
+type ContainerRow struct {
+	Name           string              `json:"name"`
+	Image          string              `json:"image"`
+	Digest         string              `json:"digest,omitempty"`
+	ScanState      ScanState           `json:"scanState"`
+	SeverityCounts *WireSeverityCounts `json:"severityCounts,omitempty"`
+}
+
+// ScanCoverage classifies a pod's overall scan completeness for the
+// /cve/pods surface. Computed by rollupCoverage in cve_handler.go.
+type ScanCoverage string
+
+const (
+	CoverageFull    ScanCoverage = "full"    // every container is scanned ECR
+	CoveragePartial ScanCoverage = "partial" // at least one scanned + at least one non-ecr/pending
+	CoverageNone    ScanCoverage = "none"    // zero containers scanned
+)
+
+// PodRow is the per-pod wire row for /cve/pods.
+type PodRow struct {
+	Namespace              string             `json:"namespace"`
+	Name                   string             `json:"name"`
+	Containers             []ContainerRow     `json:"containers"`
+	RolledUpSeverityCounts WireSeverityCounts `json:"rolledUpSeverityCounts"`
+	ScanCoverage           ScanCoverage       `json:"scanCoverage"`
+}
+
+// PodsResp is the envelope for /cve/pods. Next is a base64-encoded
+// "namespace/name" cursor; the SPA round-trips it via the ?cursor=
+// query param.
+type PodsResp struct {
+	Pods             []PodRow `json:"pods"`
+	Next             string   `json:"next,omitempty"`
+	InspectorEnabled bool     `json:"inspectorEnabled"`
+	Hydrated         bool     `json:"hydrated"`
+}
+
+// EntryCountsWire is the JSON projection of (Store.EntryCounts()).
+type EntryCountsWire struct {
+	Digests   int `json:"digests"`
+	Instances int `json:"instances"`
+}
+
+// StatusResp is the envelope for /cve/status. LastHydrate is zero
+// (and omitted) when the store has not been hydrated yet.
+type StatusResp struct {
+	InspectorEnabled bool            `json:"inspectorEnabled"`
+	Hydrated         bool            `json:"hydrated"`
+	LastHydrate      time.Time       `json:"lastHydrate,omitempty"`
+	EntryCounts      EntryCountsWire `json:"entryCounts"`
+}
+
+// RefreshReq is the POST body for /cve/refresh. Both fields are
+// optional; an empty request is a no-op that still emits one audit
+// row (operator may want to log "I checked CVE state" without forcing
+// a fetch).
+type RefreshReq struct {
+	Digests     []string `json:"digests"`
+	InstanceIDs []string `json:"instanceIds"`
+}

--- a/internal/cve/types.go
+++ b/internal/cve/types.go
@@ -127,3 +127,27 @@ type RefreshReq struct {
 	Digests     []string `json:"digests"`
 	InstanceIDs []string `json:"instanceIds"`
 }
+
+// WorkloadRef is the echoed identity of the queried workload on
+// /cve/by-workload responses. Lets the SPA assert it got data back
+// for the right entity without re-parsing the URL.
+type WorkloadRef struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// WorkloadCveResp is the envelope for /cve/by-workload. Pods is one
+// PodRow per matched pod (no server-side dedup — the SPA collapses
+// duplicate digests across replicas client-side via useMemo, per the
+// v1.1 design decision). RolledUpSeverityCounts + ScanCoverage are
+// the workload-level aggregates so the chip surface on the workload
+// row can render without re-walking pods.
+type WorkloadCveResp struct {
+	Workload               WorkloadRef        `json:"workload"`
+	Pods                   []PodRow           `json:"pods"`
+	RolledUpSeverityCounts WireSeverityCounts `json:"rolledUpSeverityCounts"`
+	ScanCoverage           ScanCoverage       `json:"scanCoverage"`
+	InspectorEnabled       bool               `json:"inspectorEnabled"`
+	Hydrated               bool               `json:"hydrated"`
+}

--- a/internal/cve/watch_hook.go
+++ b/internal/cve/watch_hook.go
@@ -2,7 +2,6 @@ package cve
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,18 +48,12 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 	}
 
 	factory.Start(ctx.Done())
-	// Cold-path hydrate already populated digest entries + ref
-	// counts from a direct pod list. The informer's initial sync
-	// will then replay an Add for every existing pod; we set
-	// hook.syncDone only AFTER that replay completes so the Add
-	// handler can suppress its double-count of refs during replay.
-	// Once syncDone flips true, post-startup Adds (new pods) bump
-	// refs normally.
-	go func() {
-		if cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
-			hook.syncDone.Store(true)
-		}
-	}()
+	// Don't block hydrate on the initial sync — the cold path has
+	// already pre-populated the digest set + ref counts. The
+	// informer's purpose from here on is deltas; missing the first
+	// sync is harmless because hydratePods already did one
+	// equivalent.
+	go factory.WaitForCacheSync(ctx.Done())
 
 	m.log.Info("cve pod informer started", "cluster", cluster.Name)
 	return nil
@@ -69,40 +62,28 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 // podHook is the bridge between informer events and the manager's
 // fetch path. Carries the cluster + store so the event handlers can
 // fire async refresh without router-style plumbing.
-//
-// syncDone flips to true once the SharedInformer's initial cache
-// sync finishes (see startPodInformer). Until then, Add events are
-// replay of pods the cold-path hydrate already counted, so the Add
-// handler must NOT bump refs again.
 type podHook struct {
-	state    *clusterState
-	ctx      context.Context
-	mgr      *Manager
-	cluster  clusters.Cluster
-	store    *Store
-	syncDone atomic.Bool
+	ctx     context.Context
+	mgr     *Manager
+	cluster clusters.Cluster
+	store   *Store
 }
 
 func newPodHook(ctx context.Context, mgr *Manager, cluster clusters.Cluster, st *clusterState) *podHook {
-	return &podHook{ctx: ctx, mgr: mgr, cluster: cluster, store: st.store, state: st}
+	return &podHook{ctx: ctx, mgr: mgr, cluster: cluster, store: st.store}
 }
 
-// onAdd: every container's imageID gets a Ref bump and an async
-// refresh kicked off if findings are missing. During the initial
-// informer sync (syncDone == false), the ref bump is suppressed —
-// hydratePods already counted these pods, and double-counting would
-// off-by-one every digest until the next pod delete.
+// onAdd: every container's imageID gets a Ref bump. If we already
+// hold findings for that digest, the existing entry is reused; if
+// not, we kick off an async refresh so the next read sees data.
 func (h *podHook) onAdd(obj any) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		return
 	}
-	skipInc := !h.syncDone.Load()
 	for _, d := range PodImageDigests(pod) {
-		if !skipInc {
-			h.store.IncDigestRef(d)
-		}
-		if e := h.store.GetDigest(d); e == nil || len(e.Findings) == 0 {
+		h.store.IncDigestRef(d)
+		if h.store.GetDigest(d) == nil || len(h.store.GetDigest(d).Findings) == 0 {
 			h.enqueueDigest(d)
 		}
 	}
@@ -154,17 +135,14 @@ func (h *podHook) onDelete(obj any) {
 	}
 }
 
-// enqueueDigest fires an async refresh for a single digest. Runs
-// under the manager-wide delta semaphore so a rolling deploy of
-// many pods does not spawn unbounded goroutines, each with an
-// Inspector socket. Errors are logged and swallowed — the TTL
-// loop will retry eventually.
+// enqueueDigest fires an async Refresh for a single digest. Errors
+// are logged and swallowed — the TTL loop will retry eventually.
 func (h *podHook) enqueueDigest(d string) {
-	go h.mgr.runDelta(h.ctx, func() {
-		if err := h.mgr.fetchDigests(h.ctx, h.state, []string{d}); err != nil {
+	go func() {
+		if err := h.mgr.fetchDigest(h.ctx, h.cluster, h.store, d); err != nil {
 			h.mgr.log.Debug("cve delta refresh", "cluster", h.cluster.Name, "digest", d, "err", err)
 		}
-	})
+	}()
 }
 
 func digestSet(in []string) map[string]struct{} {

--- a/internal/cve/watch_hook.go
+++ b/internal/cve/watch_hook.go
@@ -34,7 +34,9 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 	st.podInformerCancel = cancel
 
 	factory := informers.NewSharedInformerFactory(cs, podInformerResyncPeriod)
-	podInformer := factory.Core().V1().Pods().Informer()
+	podIface := factory.Core().V1().Pods()
+	lister := podIface.Lister()
+	podInformer := podIface.Informer()
 
 	hook := newPodHook(ctx, m, cluster, st)
 	_, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -48,6 +50,9 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 		return err
 	}
 
+	m.mu.Lock()
+	st.podLister = lister
+	m.mu.Unlock()
 	factory.Start(ctx.Done())
 	// Cold-path hydrate already populated digest entries + ref
 	// counts from a direct pod list. The informer's initial sync

--- a/internal/cve/watch_hook.go
+++ b/internal/cve/watch_hook.go
@@ -75,6 +75,7 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 // replay of pods the cold-path hydrate already counted, so the Add
 // handler must NOT bump refs again.
 type podHook struct {
+	state    *clusterState
 	ctx      context.Context
 	mgr      *Manager
 	cluster  clusters.Cluster
@@ -83,7 +84,7 @@ type podHook struct {
 }
 
 func newPodHook(ctx context.Context, mgr *Manager, cluster clusters.Cluster, st *clusterState) *podHook {
-	return &podHook{ctx: ctx, mgr: mgr, cluster: cluster, store: st.store}
+	return &podHook{ctx: ctx, mgr: mgr, cluster: cluster, store: st.store, state: st}
 }
 
 // onAdd: every container's imageID gets a Ref bump and an async
@@ -153,14 +154,17 @@ func (h *podHook) onDelete(obj any) {
 	}
 }
 
-// enqueueDigest fires an async Refresh for a single digest. Errors
-// are logged and swallowed — the TTL loop will retry eventually.
+// enqueueDigest fires an async refresh for a single digest. Runs
+// under the manager-wide delta semaphore so a rolling deploy of
+// many pods does not spawn unbounded goroutines, each with an
+// Inspector socket. Errors are logged and swallowed — the TTL
+// loop will retry eventually.
 func (h *podHook) enqueueDigest(d string) {
-	go func() {
-		if err := h.mgr.fetchDigest(h.ctx, h.cluster, h.store, d); err != nil {
+	go h.mgr.runDelta(h.ctx, func() {
+		if err := h.mgr.fetchDigests(h.ctx, h.state, []string{d}); err != nil {
 			h.mgr.log.Debug("cve delta refresh", "cluster", h.cluster.Name, "digest", d, "err", err)
 		}
-	}()
+	})
 }
 
 func digestSet(in []string) map[string]struct{} {

--- a/internal/cve/watch_hook.go
+++ b/internal/cve/watch_hook.go
@@ -35,6 +35,9 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 
 	factory := informers.NewSharedInformerFactory(cs, podInformerResyncPeriod)
 	podIface := factory.Core().V1().Pods()
+	rsIface := factory.Apps().V1().ReplicaSets()
+	rsLister := rsIface.Lister()
+	rsInformer := rsIface.Informer()
 	lister := podIface.Lister()
 	podInformer := podIface.Informer()
 
@@ -52,6 +55,7 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 
 	m.mu.Lock()
 	st.podLister = lister
+	st.rsLister = rsLister
 	m.mu.Unlock()
 	factory.Start(ctx.Done())
 	// Cold-path hydrate already populated digest entries + ref
@@ -62,7 +66,7 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 	// Once syncDone flips true, post-startup Adds (new pods) bump
 	// refs normally.
 	go func() {
-		if cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+		if cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced, rsInformer.HasSynced) {
 			hook.syncDone.Store(true)
 		}
 	}()

--- a/internal/cve/watch_hook.go
+++ b/internal/cve/watch_hook.go
@@ -2,6 +2,7 @@ package cve
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,12 +49,18 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 	}
 
 	factory.Start(ctx.Done())
-	// Don't block hydrate on the initial sync — the cold path has
-	// already pre-populated the digest set + ref counts. The
-	// informer's purpose from here on is deltas; missing the first
-	// sync is harmless because hydratePods already did one
-	// equivalent.
-	go factory.WaitForCacheSync(ctx.Done())
+	// Cold-path hydrate already populated digest entries + ref
+	// counts from a direct pod list. The informer's initial sync
+	// will then replay an Add for every existing pod; we set
+	// hook.syncDone only AFTER that replay completes so the Add
+	// handler can suppress its double-count of refs during replay.
+	// Once syncDone flips true, post-startup Adds (new pods) bump
+	// refs normally.
+	go func() {
+		if cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+			hook.syncDone.Store(true)
+		}
+	}()
 
 	m.log.Info("cve pod informer started", "cluster", cluster.Name)
 	return nil
@@ -62,28 +69,39 @@ func (m *Manager) startPodInformer(parent context.Context, cluster clusters.Clus
 // podHook is the bridge between informer events and the manager's
 // fetch path. Carries the cluster + store so the event handlers can
 // fire async refresh without router-style plumbing.
+//
+// syncDone flips to true once the SharedInformer's initial cache
+// sync finishes (see startPodInformer). Until then, Add events are
+// replay of pods the cold-path hydrate already counted, so the Add
+// handler must NOT bump refs again.
 type podHook struct {
-	ctx     context.Context
-	mgr     *Manager
-	cluster clusters.Cluster
-	store   *Store
+	ctx      context.Context
+	mgr      *Manager
+	cluster  clusters.Cluster
+	store    *Store
+	syncDone atomic.Bool
 }
 
 func newPodHook(ctx context.Context, mgr *Manager, cluster clusters.Cluster, st *clusterState) *podHook {
 	return &podHook{ctx: ctx, mgr: mgr, cluster: cluster, store: st.store}
 }
 
-// onAdd: every container's imageID gets a Ref bump. If we already
-// hold findings for that digest, the existing entry is reused; if
-// not, we kick off an async refresh so the next read sees data.
+// onAdd: every container's imageID gets a Ref bump and an async
+// refresh kicked off if findings are missing. During the initial
+// informer sync (syncDone == false), the ref bump is suppressed —
+// hydratePods already counted these pods, and double-counting would
+// off-by-one every digest until the next pod delete.
 func (h *podHook) onAdd(obj any) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		return
 	}
+	skipInc := !h.syncDone.Load()
 	for _, d := range PodImageDigests(pod) {
-		h.store.IncDigestRef(d)
-		if h.store.GetDigest(d) == nil || len(h.store.GetDigest(d).Findings) == 0 {
+		if !skipInc {
+			h.store.IncDigestRef(d)
+		}
+		if e := h.store.GetDigest(d); e == nil || len(e.Findings) == 0 {
 			h.enqueueDigest(d)
 		}
 	}

--- a/internal/cve/watch_hook_test.go
+++ b/internal/cve/watch_hook_test.go
@@ -104,7 +104,7 @@ func newHookFixture(t *testing.T) (*Manager, *podHook, *Store) {
 		EvictionScanInterval: time.Hour,
 	}, nil)
 	store := NewStore()
-	store.MarkHydrated()
+	store.MarkHydrated(time.Now())
 	st := &clusterState{store: store}
 	hook := newPodHook(context.Background(), mgr, dummyCluster(), st)
 	// Watch-hook unit tests exercise the steady-state delta path:

--- a/internal/cve/watch_hook_test.go
+++ b/internal/cve/watch_hook_test.go
@@ -107,6 +107,11 @@ func newHookFixture(t *testing.T) (*Manager, *podHook, *Store) {
 	store.MarkHydrated()
 	st := &clusterState{store: store}
 	hook := newPodHook(context.Background(), mgr, dummyCluster(), st)
+	// Watch-hook unit tests exercise the steady-state delta path:
+	// the initial informer sync has completed, so Add/Update events
+	// represent real pod churn (not cache replay) and should bump
+	// refs.
+	hook.syncDone.Store(true)
 	return mgr, hook, store
 }
 

--- a/internal/cve/watch_hook_test.go
+++ b/internal/cve/watch_hook_test.go
@@ -107,11 +107,6 @@ func newHookFixture(t *testing.T) (*Manager, *podHook, *Store) {
 	store.MarkHydrated()
 	st := &clusterState{store: store}
 	hook := newPodHook(context.Background(), mgr, dummyCluster(), st)
-	// Watch-hook unit tests exercise the steady-state delta path:
-	// the initial informer sync has completed, so Add/Update events
-	// represent real pod churn (not cache replay) and should bump
-	// refs.
-	hook.syncDone.Store(true)
 	return mgr, hook, store
 }
 


### PR DESCRIPTION
## Summary

HTTP API on top of the per-cluster CVE cache landed in #167. Seven endpoints under `/api/clusters/{cluster}/cve/...` that read from the local store (never call Inspector during a SPA request), one POST endpoint that triggers a synchronous refresh and emits a `cve_refresh` audit row, and a status endpoint the SPA polls to gate the "Inspector v2 not enabled" empty state.

## Related issue / RFC

Closes #165. Depends on #167 (sub-issue #164). See epic #163 for architecture. UI integration follows in #166.

> Branch is cut from `claude/review-issue-164-xvTrd` (PR #167) because this PR depends on the store/manager extensions from that branch. After #167 merges to main, this branch rebases cleanly.

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation

## Surfaces touched

- [x] HTTP API — seven new endpoints under `/api/clusters/{cluster}/cve/`
- [x] Audit log — new `cve_refresh` verb (snake_case, matches existing convention)
- [x] Documentation — `docs/api.md` Tier 1 subsection with all response shapes

No Helm values changed; no UI changed (deferred to #166).

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/cve/status` | store flags + entry counts (does NOT trigger hydrate) |
| `GET` | `/cve/by-instance` | list instances + severity counts + AMI + owner |
| `GET` | `/cve/by-instance/{id}` | full findings for one instance |
| `GET` | `/cve/by-digest/{digest}` | full findings for one ECR digest |
| `GET` | `/cve/pods?cursor=` | per-pod aggregate, paginated 100/page |
| `GET` | `/cve/pods/{ns}/{name}` | full per-container findings |
| `POST` | `/cve/refresh` | sync force-refresh, emits one audit row |
| `GET` | `/cve/by-workload/{kind}/{ns}/{name}` | owner-aware aggregation (Deployment/STS/DS/RS/Job) |

## Contracts

**Empty-state.** When `cveMgr == nil` (Helm-disabled) OR `store.Disabled()` (AWS account not enabled / missing IAM), every read returns **HTTP 200** with `{inspectorEnabled:false, hydrated:true, ...}`. The SPA reads the flag and renders the "Inspector v2 not enabled" hint without special-casing transport errors.

**ETag.** `W/"<lastHydrate-nanos>-<digestCount>-<instanceCount>"` — weak validator. Matching `If-None-Match` returns 304. Delta refreshes don't bump it; only hydrate / eviction do (TTL-grained accuracy is fine for chips).

**Pagination.** `next` is `base64(namespace/podname)`; pods lex-sorted before paging. Cursor stability under pod churn: a one-off skip/duplicate is possible if a pod is created/deleted between pages — acceptable for v1.1.

**Container `scanState`.**
- `scanned` — ECR image with resolved digest; findings looked up.
- `non-ecr` — image isn't in ECR; Inspector v2 doesn't cover it.
- `pending` — ECR image but containerStatus.imageID is empty (mid-pull).

**Pod `scanCoverage`.**
- `full` — every container scanned.
- `partial` — at least one scanned + at least one non-ecr/pending.
- `none` — zero scanned.

**Audit.** Reads do NOT emit audit rows — internal metadata, CloudTrail covers the underlying Inspector API calls. POST `/refresh` emits exactly one `cve_refresh` row with `digests` + `instanceIds` in `Extra`.

## Store / manager extensions

The cache-side primitives the handlers need:

- `Store.LastHydrate()` + `EntryCounts()` for `/status` + the ETag base.
- `MarkHydrated` / `MarkDisabled` now take `time.Time` so the manager's clock is the single source of truth (testable via clockwork).
- `InstanceEntry` + `awsec2.InstanceMeta` gain `AMI`; `projectInstance` reads `ec2types.Instance.ImageId`.
- `Manager.PodLister(cluster)` exposes the long-lived informer's `corelisters.PodLister` so `/cve/pods` doesn't re-list pods from the apiserver per request.

## How was this tested?

- **Handler tests** (8 cases): nil-manager empty state, hydrated `/status`, severity roll-up + AMI surfacing on `/by-instance`, `/by-instance/{id}` 404, 250-pod pagination across 3 pages, scanCoverage full/partial/none mix on `/pods`, audit emission on `/refresh`, 202 + `Next-Poll` on hydrate-in-flight, ETag 304 conditional read.
- **Unit tests**: `CountSeverities` mix + edge cases; `IsECRImage` including anti-spoof for substrings (e.g. `evil.com/.dkr.ecr.us-east-1.amazonaws.com/foo`); `ImageScanState` across scanned/pending/non-ecr.
- `go test -race ./...` clean across `cve`, `awsinspector`, `awsec2`, `audit`, `cmd/periscope`.
- `go vet ./...` clean.

End-to-end smoke (after demo cluster is back up):
1. `helm upgrade periscope ... --set inspector.enabled=true` after granting `inspector2:*` IAM.
2. `curl ... /cve/status` — first poll returns `hydrated:false`; the SPA spinner stays.
3. `curl ... /cve/by-instance` — first call blocks 10-30s, then returns N instances with severity counts + AMI IDs.
4. `curl ... /cve/pods` — follow `next` cursor across pages; confirm the pod set exhausts.
5. `curl -X POST .../cve/refresh -d '{"digests":["sha256:abc"]}'` — returns 200; tail audit log to confirm one `cve_refresh` row.
6. `helm upgrade ... --set inspector.enabled=false` → every endpoint returns `{inspectorEnabled:false, hydrated:true, ...}` HTTP 200.

## Owner-aware aggregation

Added mid-review on operator feedback: in production people work at the workload level (Deployment/STS/DS), not the pod level. The Pod is ephemeral; the workload is the stable identity.

- New `GET /cve/by-workload/{kind}/{ns}/{name}` endpoint. Returns the matched pods (one `PodRow` per pod), plus workload-wide rolled-up severity + scan coverage. No server-side dedup — SPA collapses duplicate digests across replicas client-side via `useMemo`.
- Supports `Deployment`, `StatefulSet`, `DaemonSet`, `ReplicaSet`, `Job`. `CronJob` deferred (three-hop walk needs a Job informer too).
- Backend: ReplicaSet informer started alongside the pod informer (same `SharedInformerFactory`); `Manager.ReplicaSetLister(cluster)` accessor mirrors `PodLister`. `PodOwnedBy` helper handles direct + two-hop owner walks.
- Same ETag + empty-state contract as the other read endpoints. Unsupported kinds return 400.

## Out of scope (next sub-issue)

- SPA chip surfaces on Nodes / Pods / Workloads pages → #166
- Refresh button + Inspector v2-disabled empty-state UI → #166

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] Tests added or updated where it makes sense.
- [x] Docs updated (`docs/api.md` CVE subsection).
- [x] No secrets, real cluster names, or real OIDC client IDs in committed files.

