### PR TITLE
Retained-ownership SSA patches + form-mode action-bar parity (closes #181)

### DIFF
--- a/internal/k8s/apply_test.go
+++ b/internal/k8s/apply_test.go
@@ -299,3 +299,81 @@ func TestApplyResource_EmptyBodyRejected(t *testing.T) {
 		t.Fatalf("expected 'apply: ' prefixed error, got %v", err)
 	}
 }
+
+// TestApplyResource_RetainsCoOwnedAnnotations is the backend half of
+// the issue #181 regression. The SPA's retained-ownership builder
+// (web/src/lib/applyBodyBuilder.ts) now re-asserts every path
+// periscope-spa already claimed alongside the user's edit. This test
+// proves the apply handler doesn't strip those re-asserted paths on
+// the way to the dynamic client: a Deployment body containing kubectl-
+// owned annotations + a periscope-spa scale edit must round-trip
+// through ApplyResource without the annotations being filtered.
+//
+// (The fake dynamic client's reactor doesn't model real SSA field-
+// manager merge — that requires a real apiserver. What this test
+// guards against is regressions in stripDisallowedMetadata or
+// elsewhere in apply.go that would silently strip metadata.annotations
+// before the dynamic client sees it.)
+func TestApplyResource_RetainsCoOwnedAnnotations(t *testing.T) {
+	const retainedBody = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: prod
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kubectl.kubernetes.io/restartedAt: "2026-05-01T00:00:00Z"
+spec:
+  replicas: 3
+`
+	// Seed the tracker so the reactor's Update branch fires (mirrors
+	// the production case where the resource pre-exists).
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "nginx",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(1)},
+		},
+	}
+	fake := fakeDynamicWithApplyReactor(t, nil, existing)
+	installFakeDynamicClient(t, fake)
+
+	args := ApplyResourceArgs{
+		Cluster:   applyTestCluster,
+		Group:     "apps",
+		Version:   "v1",
+		Resource:  "deployments",
+		Namespace: "prod",
+		Name:      "nginx",
+		Body:      []byte(retainedBody),
+		DryRun:    false,
+	}
+	if _, err := ApplyResource(context.Background(), stubProvider{}, args); err != nil {
+		t.Fatalf("ApplyResource: %v", err)
+	}
+
+	stored, err := fake.Tracker().Get(deploymentGVR, "prod", "nginx")
+	if err != nil {
+		t.Fatalf("tracker Get: %v", err)
+	}
+	u := stored.(*unstructured.Unstructured)
+	annotations, found, err := unstructured.NestedStringMap(u.Object, "metadata", "annotations")
+	if err != nil {
+		t.Fatalf("NestedStringMap: %v", err)
+	}
+	if !found {
+		t.Fatalf("metadata.annotations missing from stored object — apply handler stripped them")
+	}
+	for _, key := range []string{
+		"deployment.kubernetes.io/revision",
+		"kubectl.kubernetes.io/restartedAt",
+	} {
+		if _, ok := annotations[key]; !ok {
+			t.Errorf("annotation %q missing from stored object — handler stripped it from the patch body", key)
+		}
+	}
+}

--- a/web/src/components/detail/yaml/ActionBar.tsx
+++ b/web/src/components/detail/yaml/ActionBar.tsx
@@ -33,12 +33,33 @@ interface ActionBarProps {
    * needs managedFields to decide which paths to re-assert.
    */
   metaPending?: boolean;
+  /**
+   * Hide the diff toggle button. Form mode passes this because it has
+   * no Monaco surface to overlay a diff on — the structured patch view
+   * (which IS visible in form mode) carries the same semantic info.
+   */
+  hideDiff?: boolean;
+  /**
+   * Hide the "errors N" indicator + the "fix N schema errors first"
+   * apply gate. Form mode doesn't surface monaco-style markers; its
+   * own validation lives inside the form component and gates the
+   * apply button differently.
+   */
+  hideErrors?: boolean;
   onCancel: () => void;
   onTogglePatch: () => void;
   onDryRun: () => void;
-  onToggleDiff: () => void;
+  /**
+   * Optional in form mode (no diff button → never invoked). Required
+   * in YAML mode.
+   */
+  onToggleDiff?: () => void;
   onApply: () => void;
-  onJumpToError: () => void;
+  /**
+   * Optional in form mode (errors indicator hidden → never invoked).
+   * Required in YAML mode.
+   */
+  onJumpToError?: () => void;
 }
 
 export function ActionBar({
@@ -50,6 +71,8 @@ export function ActionBar({
   schemaLabel,
   schemaState,
   metaPending,
+  hideDiff,
+  hideErrors,
   onCancel,
   onTogglePatch,
   onDryRun,
@@ -85,7 +108,7 @@ export function ActionBar({
       ? metaMsg
       : !dirty
         ? noEdits
-        : errorCount > 0
+        : !hideErrors && errorCount > 0
           ? `fix ${errorCount} schema error${errorCount === 1 ? "" : "s"} first`
           : null;
 
@@ -99,13 +122,15 @@ export function ActionBar({
           value={String(opsCount)}
           className={dirty ? "text-accent" : "text-ink-faint"}
         />
-        <SegmentButton
-          label="errors"
-          value={String(errorCount)}
-          className={errorCount > 0 ? "text-red" : "text-green"}
-          onClick={errorCount > 0 ? onJumpToError : undefined}
-          tabular
-        />
+        {!hideErrors && (
+          <SegmentButton
+            label="errors"
+            value={String(errorCount)}
+            className={errorCount > 0 ? "text-red" : "text-green"}
+            onClick={errorCount > 0 ? onJumpToError : undefined}
+            tabular
+          />
+        )}
         {schemaLabel && (
           <SchemaPill label={schemaLabel} state={schemaState ?? "loading"} />
         )}
@@ -136,14 +161,16 @@ export function ActionBar({
         >
           {applyState.kind === "dryRunning" ? "dry-running…" : "dry-run"}
         </BarButton>
-        <BarButton
-          onClick={guarded(onToggleDiff, diffReason)}
-          softDisabled={diffReason !== null}
-          active={mode === "diff"}
-          title={diffReason ?? undefined}
-        >
-          diff
-        </BarButton>
+        {!hideDiff && (
+          <BarButton
+            onClick={guarded(onToggleDiff ?? (() => undefined), diffReason)}
+            softDisabled={diffReason !== null}
+            active={mode === "diff"}
+            title={diffReason ?? undefined}
+          >
+            diff
+          </BarButton>
+        )}
         <button
           type="button"
           onClick={guarded(onApply, applyReason)}

--- a/web/src/components/detail/yaml/ActionBar.tsx
+++ b/web/src/components/detail/yaml/ActionBar.tsx
@@ -27,6 +27,12 @@ interface ActionBarProps {
   applyState: ApplyState;
   schemaLabel?: string;
   schemaState?: "loading" | "loaded" | "missing" | "failed";
+  /**
+   * True while `useResourceMeta` hasn't returned yet. Apply / dry-run
+   * gate on this because the retained-ownership body builder (#181)
+   * needs managedFields to decide which paths to re-assert.
+   */
+  metaPending?: boolean;
   onCancel: () => void;
   onTogglePatch: () => void;
   onDryRun: () => void;
@@ -43,6 +49,7 @@ export function ActionBar({
   applyState,
   schemaLabel,
   schemaState,
+  metaPending,
   onCancel,
   onTogglePatch,
   onDryRun,
@@ -67,17 +74,20 @@ export function ActionBar({
 
   const noEdits = "make a change first";
   const busyMsg = applyState.kind === "dryRunning" ? "dry-run in progress…" : "apply in progress…";
+  const metaMsg = "loading ownership info…";
 
   const patchReason = busy ? busyMsg : !dirty ? noEdits : null;
-  const dryRunReason = busy ? busyMsg : !dirty ? noEdits : null;
+  const dryRunReason = busy ? busyMsg : metaPending ? metaMsg : !dirty ? noEdits : null;
   const diffReason = busy ? busyMsg : !dirty ? noEdits : null;
   const applyReason = busy
     ? busyMsg
-    : !dirty
-      ? noEdits
-      : errorCount > 0
-        ? `fix ${errorCount} schema error${errorCount === 1 ? "" : "s"} first`
-        : null;
+    : metaPending
+      ? metaMsg
+      : !dirty
+        ? noEdits
+        : errorCount > 0
+          ? `fix ${errorCount} schema error${errorCount === 1 ? "" : "s"} first`
+          : null;
 
   return (
     <div className="flex h-9 shrink-0 items-center gap-4 border-t border-border bg-surface px-3 font-mono text-[11px]">

--- a/web/src/components/detail/yaml/CoManagementBanner.tsx
+++ b/web/src/components/detail/yaml/CoManagementBanner.tsx
@@ -1,0 +1,85 @@
+// CoManagementBanner — sticky note shown at editor open when the
+// resource has managedFields entries from controllers other than
+// periscope-spa. Operators see who else writes this resource so
+// they aren't surprised when their edits are reconciled away later.
+//
+// Sits between DriftBanner and SchemaMissingBanner in the YamlEditor
+// banner stack. Dismissable per-session per-resource via useDismissed
+// — quiet ack, no re-prompt until a fresh tab.
+//
+// Density / palette mirrors SchemaMissingBanner (yellow strip with
+// a left glyph). Distinct from DriftBanner (which fires mid-edit
+// when the cluster mutates under the user) and ApplyErrorBanner
+// (red, post-apply failure). Read-only — no actions beyond dismiss.
+
+import { cn } from "../../../lib/cn";
+
+export interface OtherOwnerSummary {
+  manager: string;
+  /** Number of paths this manager owns. Used to rank for display. */
+  pathCount: number;
+}
+
+interface CoManagementBannerProps {
+  /** Paths the body will re-assert this session (count only). */
+  selfOwnedCount: number;
+  /** Other managers grouped by name. Caller pre-sorts by salience. */
+  otherOwners: OtherOwnerSummary[];
+  onDismiss: () => void;
+}
+
+const TOP_N = 3;
+
+export function CoManagementBanner({
+  selfOwnedCount,
+  otherOwners,
+  onDismiss,
+}: CoManagementBannerProps) {
+  if (otherOwners.length === 0) return null;
+
+  const top = otherOwners.slice(0, TOP_N);
+  const hidden = Math.max(0, otherOwners.length - top.length);
+  const managerList = top.map((o) => o.manager).join(", ");
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-start gap-3 border-y px-4 py-2",
+        "border-yellow/40 bg-yellow/5",
+      )}
+      role="status"
+    >
+      <span aria-hidden className="mt-1 size-2 shrink-0 rounded-sm bg-yellow/70" />
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[11px] font-medium text-yellow">
+          co-managed resource
+        </div>
+        <div className="mt-0.5 font-mono text-[11.5px] text-ink-muted">
+          <span className="text-ink">{managerList}</span>
+          {hidden > 0 && (
+            <span> +{hidden} more</span>
+          )}
+          {" — "}
+          edits will be co-owned; these managers may overwrite them on reconcile.
+          {selfOwnedCount > 0 && (
+            <>
+              {" "}
+              <span className="text-ink">
+                {selfOwnedCount} field{selfOwnedCount === 1 ? "" : "s"} you already
+                own will be retained.
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss co-management notice"
+        className="ml-2 shrink-0 rounded-sm px-2 py-0.5 font-mono text-[10.5px] text-ink-faint transition-colors hover:bg-surface-2 hover:text-ink"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/detail/yaml/YamlEditor.tsx
+++ b/web/src/components/detail/yaml/YamlEditor.tsx
@@ -65,17 +65,24 @@ import {
 import { useOpenAPISchema, useResourceMeta, useEditorYaml } from "../../../hooks/useResource";
 import { usePublishEditorDirty } from "../../../hooks/useEditorDirty";
 import {
-  buildMinimalSSA,
   computeOps,
   MultiDocumentError,
+  YamlParseError,
   type Identity,
   type Op,
 } from "../../../lib/yamlPatch";
+import {
+  buildRetainedOwnershipBody,
+  buildRetainedOwnershipBodyFromOps,
+  ManagedFieldsUnavailableError,
+} from "../../../lib/applyBodyBuilder";
 import { ActionBar, type ApplyState } from "./ActionBar";
 import { ProblemsStrip } from "./ProblemsStrip";
 import { ApplyErrorBanner } from "./ApplyErrorBanner";
 import { SchemaMissingBanner } from "./SchemaMissingBanner";
 import { DriftBanner } from "./DriftBanner";
+import { CoManagementBanner, type OtherOwnerSummary } from "./CoManagementBanner";
+import { useDismissed } from "../../../hooks/useDismissed";
 import { DriftDiffOverlay } from "./DriftDiffOverlay";
 import { showToast } from "../../../lib/toastBus";
 import { ConflictResolutionView, type FieldConflict, type Resolution } from "./ConflictResolutionView";
@@ -734,10 +741,29 @@ function Editor({
 
       let body: string;
       try {
-        body = buildMinimalSSA(ops, identity);
+        // pristineLocked is reused as `current`: on a clean buffer the
+        // pristine-swap effect keeps it pinned to the latest server
+        // YAML; on a dirty buffer the user has explicitly chosen to
+        // ignore drift, so re-asserting whatever they last had is the
+        // safest behavior. A dedicated current-state query is a
+        // deferrable optimization (#181).
+        ({ yaml: body } = buildRetainedOwnershipBody({
+          baseline: pristineLocked,
+          draft: currentYaml,
+          current: pristineLocked,
+          identity,
+          managedFields: metaQuery.data?.managedFields ?? null,
+        }));
       } catch (e) {
-        if (e instanceof MultiDocumentError) {
-          setApplyState({ kind: "error", message: e.message });
+        if (e instanceof ManagedFieldsUnavailableError) {
+          setApplyState({
+            kind: "error",
+            message: "Ownership info is still loading — try again in a moment.",
+          });
+          return;
+        }
+        if (e instanceof MultiDocumentError || e instanceof YamlParseError) {
+          setApplyState({ kind: "error", message: (e as Error).message });
           return;
         }
         throw e;
@@ -799,7 +825,7 @@ function Editor({
     // ops captured intentionally — we want the snapshot at apply time, not
     // the latest after the user edits while waiting for the response
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [identity, opsForCurrentBuffer, resource, cluster, source, qc, setParams, parseConflictCauses, ops],
+    [identity, opsForCurrentBuffer, resource, cluster, source, qc, setParams, parseConflictCauses, ops, pristineLocked, currentYaml, metaQuery.data],
   );
 
   // Apply with per-field resolutions from ConflictResolutionView. Filter
@@ -838,8 +864,26 @@ function Editor({
 
     let body: string;
     try {
-      body = buildMinimalSSA(filteredOps, identity);
+      // FromOps variant: we've already filtered the user-edit ops by
+      // `resolutions` above, so we don't want the builder to redo the
+      // baseline/draft diff. excludePriorOwned mirrors the same revert
+      // semantics on the retained-ownership side — paths the operator
+      // released stay released across both ops.
+      ({ yaml: body } = buildRetainedOwnershipBodyFromOps({
+        ops: filteredOps,
+        current: pristineLocked,
+        identity,
+        managedFields: metaQuery.data?.managedFields ?? null,
+        excludePriorOwned: (p) => resolutions.get(p) === "revert",
+      }));
     } catch (e) {
+      if (e instanceof ManagedFieldsUnavailableError) {
+        setApplyState({
+          kind: "error",
+          message: "Ownership info is still loading — try again in a moment.",
+        });
+        return;
+      }
       setApplyState({ kind: "error", message: (e as Error).message });
       return;
     }
@@ -879,7 +923,7 @@ function Editor({
       setApplyState({ kind: "error", message });
       setShowTakeover(false);
     }
-  }, [identity, opsForCurrentBuffer, resolutions, opPathToString, resource, source, qc, setParams, onCancel]);
+  }, [identity, opsForCurrentBuffer, resolutions, opPathToString, resource, source, qc, setParams, onCancel, pristineLocked, metaQuery.data]);
 
   // Standalone dry-run (the "dry-run" button in ActionBar). Same 409
   // handling as runApply — if the dry-run hits a field-manager
@@ -892,8 +936,21 @@ function Editor({
     if (currentOps.length === 0) return;
     let body: string;
     try {
-      body = buildMinimalSSA(currentOps, identity);
+      ({ yaml: body } = buildRetainedOwnershipBody({
+        baseline: pristineLocked,
+        draft: currentYaml,
+        current: pristineLocked,
+        identity,
+        managedFields: metaQuery.data?.managedFields ?? null,
+      }));
     } catch (e) {
+      if (e instanceof ManagedFieldsUnavailableError) {
+        setApplyState({
+          kind: "error",
+          message: "Ownership info is still loading — try again in a moment.",
+        });
+        return;
+      }
       setApplyState({ kind: "error", message: (e as Error).message });
       return;
     }
@@ -934,7 +991,7 @@ function Editor({
       }
       setApplyState({ kind: "error", message });
     }
-  }, [identity, opsForCurrentBuffer, resource, parseConflictCauses]);
+  }, [identity, opsForCurrentBuffer, resource, parseConflictCauses, pristineLocked, currentYaml, metaQuery.data]);
 
 
 
@@ -1040,6 +1097,36 @@ function Editor({
     ? `${gvk.group ? gvk.group + "/" : ""}${gvk.version} ${gvk.kind}`
     : undefined;
 
+  // Co-management summary derived from managedFields. Other managers
+  // (non-periscope-spa, any operation type) → grouped by manager name
+  // and ranked by path count. periscope-spa Apply paths feed the
+  // "retained" count in the banner copy.
+  const coManagement = useMemo(() => {
+    const entries = metaQuery.data?.managedFields;
+    if (!entries) return { selfOwnedCount: 0, otherOwners: [] as OtherOwnerSummary[] };
+    const owners = parseManagedFields(entries);
+    const otherCounts = new Map<string, number>();
+    let selfOwnedCount = 0;
+    for (const o of owners) {
+      if (o.manager === "periscope-spa") {
+        if (o.operation === "Apply") selfOwnedCount++;
+        continue;
+      }
+      otherCounts.set(o.manager, (otherCounts.get(o.manager) ?? 0) + 1);
+    }
+    const otherOwners: OtherOwnerSummary[] = [...otherCounts.entries()]
+      .map(([manager, pathCount]) => ({ manager, pathCount }))
+      .sort((a, b) => b.pathCount - a.pathCount);
+    return { selfOwnedCount, otherOwners };
+  }, [metaQuery.data]);
+
+  const coManagementDismissKey = `periscope.coMgmtDismissed:${cluster}:${resource.group}/${resource.version}:${resource.resource}:${resource.namespace ?? ""}:${resource.name}`;
+  const [coManagementDismissed, dismissCoManagement] = useDismissed(coManagementDismissKey);
+  const showCoManagementBanner =
+    mode === "edit" &&
+    !coManagementDismissed &&
+    coManagement.otherOwners.length > 0;
+
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col">
       {mode === "conflict" ? (
@@ -1131,6 +1218,14 @@ function Editor({
         />
       )}
 
+      {showCoManagementBanner && (
+        <CoManagementBanner
+          selfOwnedCount={coManagement.selfOwnedCount}
+          otherOwners={coManagement.otherOwners}
+          onDismiss={dismissCoManagement}
+        />
+      )}
+
       {showDriftDiff && (
         <DriftDiffOverlay
           source={source}
@@ -1167,6 +1262,7 @@ function Editor({
         applyState={applyState}
         schemaLabel={schemaLabel}
         schemaState={schemaState}
+        metaPending={metaQuery.isPending}
         onCancel={onCancel}
         onTogglePatch={() => setShowPatch((s) => !s)}
         onDryRun={() => void runDryRun()}

--- a/web/src/components/edit/KindEditRouter.tsx
+++ b/web/src/components/edit/KindEditRouter.tsx
@@ -296,15 +296,25 @@ function BufferedEditor({
                 mode="edit"
               />
             )}
-            {submit.state.kind === "error" && (
-              <SubmitErrorBanner
-                message={submit.state.message}
-                isConflict={submit.state.isConflict}
-                onSwitchToYaml={() => onSetMode("yaml")}
-                onDismiss={() => submit.reset()}
-              />
-            )}
           </div>
+          {/*
+           * SubmitErrorBanner intentionally lives OUTSIDE the form's
+           * overflow-auto scroll area so it stays visible regardless
+           * of how tall the form is. The previous placement (inside
+           * the scroll div, below every form section) buried errors
+           * for non-trivial resources — operators had to scroll to
+           * the bottom to discover that their apply had failed. This
+           * mirrors YamlEditor's ApplyErrorBanner placement (right
+           * above ActionBar, sibling of the scrollable editor).
+           */}
+          {submit.state.kind === "error" && (
+            <SubmitErrorBanner
+              message={submit.state.message}
+              isConflict={submit.state.isConflict}
+              onSwitchToYaml={() => onSetMode("yaml")}
+              onDismiss={() => submit.reset()}
+            />
+          )}
           <FormActionBar
             dirty={dirty}
             // Pending meta == we don't yet know what periscope-spa

--- a/web/src/components/edit/KindEditRouter.tsx
+++ b/web/src/components/edit/KindEditRouter.tsx
@@ -27,7 +27,7 @@ import { usePublishEditorDirty } from "../../hooks/useEditorDirty";
 import type { EditorSource } from "../../lib/customResources";
 import type { ResourceRef } from "../../lib/api";
 import type { SupportedKind } from "../../lib/schemaForm/k8sAllowlist";
-import { useEditorYaml } from "../../hooks/useResource";
+import { useEditorYaml, useResourceMeta } from "../../hooks/useResource";
 import { DetailLoading, DetailError } from "../detail/states";
 import { ConfigMapForm } from "./ConfigMapForm";
 import { SecretForm } from "./SecretForm";
@@ -125,6 +125,30 @@ function BufferedEditor({
   const [baselineYaml, setBaselineYaml] = useState(pristineYaml);
   const submit = useApplySubmit(source, resource);
 
+  // Live cluster YAML + managedFields — same react-query cache keys
+  // as the parent's queries, so these are free reads (no extra round
+  // trip). Threaded into submit() so the retained-ownership builder
+  // (#181) can extract current values for fields periscope-spa
+  // already claimed but the user hasn't touched.
+  const liveYamlQuery = useEditorYaml(
+    source,
+    cluster,
+    resource.namespace ?? "",
+    resource.name,
+    true,
+  );
+  const metaQuery = useResourceMeta(
+    cluster,
+    {
+      group: resource.group,
+      version: resource.version,
+      resource: resource.resource,
+      namespace: resource.namespace,
+      name: resource.name,
+    },
+    true,
+  );
+
   const dirty = draftYaml !== baselineYaml;
 
   // Publish dirty to the page-level useEditorDirty cache so the
@@ -169,7 +193,15 @@ function BufferedEditor({
   }, [dirty, setParams]);
 
   const onApply = useCallback(async () => {
-    const ok = await submit.submit(draftYaml);
+    const ok = await submit.submit({
+      baseline: baselineYaml,
+      draft: draftYaml,
+      // Fall back to baseline if the live query hasn't (re)resolved
+      // yet — same anchor the editor was mounted against. Worse case
+      // we miss a drift update; we never apply with `current = ""`.
+      current: liveYamlQuery.data ?? baselineYaml,
+      meta: metaQuery.data ?? null,
+    });
     if (ok) {
       // Reset baseline to the just-applied YAML so the form clears
       // dirty. The react-query invalidation kicked off in submit
@@ -177,7 +209,7 @@ function BufferedEditor({
       // as the new baseline.
       setBaselineYaml(draftYaml);
     }
-  }, [draftYaml, submit]);
+  }, [baselineYaml, draftYaml, liveYamlQuery.data, metaQuery.data, submit]);
 
   const onValuesYamlChange = useCallback(
     (next: string) => {
@@ -275,7 +307,15 @@ function BufferedEditor({
           </div>
           <FormActionBar
             dirty={dirty}
-            busy={submit.state.kind === "dryRunning" || submit.state.kind === "applying"}
+            // Pending meta == we don't yet know what periscope-spa
+            // owns; firing Apply now would degenerate to a first-apply
+            // body and silently release prior ownership. Gate the
+            // button until the 15s meta poll lands.
+            busy={
+              submit.state.kind === "dryRunning" ||
+              submit.state.kind === "applying" ||
+              metaQuery.isPending
+            }
             onApply={onApply}
             onCancel={onCancel}
           />

--- a/web/src/components/edit/KindEditRouter.tsx
+++ b/web/src/components/edit/KindEditRouter.tsx
@@ -21,13 +21,13 @@
 // YAML mode (now without losing their edits) for the full
 // ConflictResolutionView machinery.
 
-import { lazy, Suspense, useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { usePublishEditorDirty } from "../../hooks/useEditorDirty";
 import type { EditorSource } from "../../lib/customResources";
 import type { ResourceRef } from "../../lib/api";
 import type { SupportedKind } from "../../lib/schemaForm/k8sAllowlist";
-import { useEditorYaml, useResourceMeta } from "../../hooks/useResource";
+import { useEditorYaml, useOpenAPISchema, useResourceMeta } from "../../hooks/useResource";
 import { DetailLoading, DetailError } from "../detail/states";
 import { ConfigMapForm } from "./ConfigMapForm";
 import { SecretForm } from "./SecretForm";
@@ -36,6 +36,10 @@ import { IngressForm } from "./IngressForm";
 import { DeploymentForm } from "./DeploymentForm";
 import { StatefulSetForm } from "./StatefulSetForm";
 import { useApplySubmit } from "./useApplySubmit";
+import { ActionBar } from "../detail/yaml/ActionBar";
+import { PatchPreviewDrawer } from "../detail/yaml/PatchPreviewDrawer";
+import { computeOps } from "../../lib/yamlPatch";
+import { findSchemaForGVK, parseIdentityFromYaml } from "../../lib/k8sSchema";
 
 const YamlEditor = lazy(() =>
   import("../detail/yaml").then((m) => ({ default: m.YamlEditor })),
@@ -149,6 +153,90 @@ function BufferedEditor({
     true,
   );
 
+  // ----- Form-mode action-bar state -----
+  // Mirror of the affordances YamlEditor's ActionBar surfaces (ops
+  // count, patch preview, dry-run, schema status) so form-mode
+  // operators get the same pre-apply visibility. Diff and errors are
+  // intentionally hidden — see hideDiff / hideErrors below.
+  const opsForBar = useMemo(() => {
+    if (draftYaml === baselineYaml) return [];
+    try {
+      return computeOps(baselineYaml, draftYaml);
+    } catch {
+      return [];
+    }
+  }, [baselineYaml, draftYaml]);
+
+  const identityForBar = useMemo(
+    () => parseIdentityFromYaml(draftYaml),
+    [draftYaml],
+  );
+
+  // Schema query gives ActionBar the right pill state (loading /
+  // loaded / missing). Same cache key the form components use under
+  // the hood, so this is a free read. `kind` (SupportedKind) is the
+  // PascalCase K8s kind name; `resource.group/version` come from the
+  // SPA's resolved ResourceRef.
+  const schemaQuery = useOpenAPISchema(
+    cluster,
+    resource.group,
+    resource.version,
+    true,
+  );
+  const schemaLabel = `${resource.group ? resource.group + "/" : ""}${resource.version} ${kind}`;
+  const schemaState: "loading" | "loaded" | "missing" | "failed" =
+    schemaQuery.isError
+      ? "failed"
+      : !schemaQuery.data
+        ? "loading"
+        : findSchemaForGVK(schemaQuery.data, {
+              group: resource.group,
+              version: resource.version,
+              kind,
+            })
+          ? "loaded"
+          : "missing";
+
+  // PatchPreviewDrawer state — mirror of YamlEditor.tsx. Width
+  // persists via the same localStorage key so users get a single
+  // remembered width across YAML / form modes.
+  const [showPatch, setShowPatch] = useState(false);
+  const [patchDrawerWidth, setPatchDrawerWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return 420;
+    const stored = window.localStorage.getItem("periscope.patchDrawerWidth");
+    const n = stored ? parseInt(stored, 10) : NaN;
+    return Number.isFinite(n) && n >= 280 && n <= 800 ? n : 420;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("periscope.patchDrawerWidth", String(patchDrawerWidth));
+  }, [patchDrawerWidth]);
+
+  const onPatchResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = patchDrawerWidth;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      const onMove = (ev: MouseEvent) => {
+        // Drawer is on the right edge — drag LEFT widens it (subtract
+        // current clientX from start). Clamp 280…800 to match YAML mode.
+        const dx = startX - ev.clientX;
+        setPatchDrawerWidth(Math.min(800, Math.max(280, startWidth + dx)));
+      };
+      const onUp = () => {
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUp);
+      };
+      window.addEventListener("mousemove", onMove);
+      window.addEventListener("mouseup", onUp);
+    },
+    [patchDrawerWidth],
+  );
+
   const dirty = draftYaml !== baselineYaml;
 
   // Publish dirty to the page-level useEditorDirty cache so the
@@ -211,6 +299,15 @@ function BufferedEditor({
     }
   }, [baselineYaml, draftYaml, liveYamlQuery.data, metaQuery.data, submit]);
 
+  const onDryRun = useCallback(() => {
+    void submit.dryRun({
+      baseline: baselineYaml,
+      draft: draftYaml,
+      current: liveYamlQuery.data ?? baselineYaml,
+      meta: metaQuery.data ?? null,
+    });
+  }, [baselineYaml, draftYaml, liveYamlQuery.data, metaQuery.data, submit]);
+
   const onValuesYamlChange = useCallback(
     (next: string) => {
       setDraftYaml(next);
@@ -247,54 +344,83 @@ function BufferedEditor({
         </Suspense>
       ) : (
         <div className="flex flex-1 flex-col overflow-hidden">
-          <div className="flex-1 overflow-auto px-3 py-3">
-            {kind === "ConfigMap" && (
-              <ConfigMapForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
-            )}
-            {kind === "Secret" && (
-              <SecretForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
-            )}
-            {kind === "Service" && (
-              <ServiceForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
-            )}
-            {kind === "Ingress" && (
-              <IngressForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
-            )}
-            {kind === "Deployment" && (
-              <DeploymentForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
-            )}
-            {kind === "StatefulSet" && (
-              <StatefulSetForm
-                cluster={cluster}
-                valuesYaml={draftYaml}
-                onValuesYamlChange={onValuesYamlChange}
-                mode="edit"
-              />
+          {/*
+           * Form scroll area + PatchPreviewDrawer share a flex row so
+           * the drawer pushes (not overlays) the form. Same layout
+           * YamlEditor uses for the Monaco editor + drawer pair.
+           */}
+          <div className="flex min-h-0 flex-1 flex-row">
+            <div className="flex-1 overflow-auto px-3 py-3">
+              {kind === "ConfigMap" && (
+                <ConfigMapForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+              {kind === "Secret" && (
+                <SecretForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+              {kind === "Service" && (
+                <ServiceForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+              {kind === "Ingress" && (
+                <IngressForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+              {kind === "Deployment" && (
+                <DeploymentForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+              {kind === "StatefulSet" && (
+                <StatefulSetForm
+                  cluster={cluster}
+                  valuesYaml={draftYaml}
+                  onValuesYamlChange={onValuesYamlChange}
+                  mode="edit"
+                />
+              )}
+            </div>
+            {showPatch && (
+              <>
+                <div
+                  className="w-1 cursor-col-resize bg-border hover:bg-accent"
+                  onMouseDown={onPatchResizeStart}
+                  role="separator"
+                  aria-orientation="vertical"
+                />
+                <PatchPreviewDrawer
+                  width={patchDrawerWidth}
+                  ops={opsForBar}
+                  identity={identityForBar}
+                  cluster={resource.cluster}
+                  group={resource.group}
+                  version={resource.version}
+                  resource={resource.resource}
+                  namespace={resource.namespace}
+                  name={resource.name}
+                  onClose={() => setShowPatch(false)}
+                />
+              </>
             )}
           </div>
           {/*
@@ -315,19 +441,25 @@ function BufferedEditor({
               onDismiss={() => submit.reset()}
             />
           )}
-          <FormActionBar
+          <ActionBar
+            mode="edit"
+            opsCount={opsForBar.length}
+            // hideErrors below suppresses both the indicator and the
+            // "fix N schema errors first" apply gate — form-mode
+            // validation is handled inside the form components and
+            // doesn't surface a count up here.
+            errorCount={0}
             dirty={dirty}
-            // Pending meta == we don't yet know what periscope-spa
-            // owns; firing Apply now would degenerate to a first-apply
-            // body and silently release prior ownership. Gate the
-            // button until the 15s meta poll lands.
-            busy={
-              submit.state.kind === "dryRunning" ||
-              submit.state.kind === "applying" ||
-              metaQuery.isPending
-            }
-            onApply={onApply}
+            applyState={submit.state}
+            schemaLabel={schemaLabel}
+            schemaState={schemaState}
+            metaPending={metaQuery.isPending}
+            hideDiff
+            hideErrors
             onCancel={onCancel}
+            onTogglePatch={() => setShowPatch((s) => !s)}
+            onDryRun={onDryRun}
+            onApply={onApply}
           />
         </div>
       )}
@@ -387,39 +519,6 @@ function ToggleButton({
     >
       {children}
     </button>
-  );
-}
-
-function FormActionBar({
-  dirty,
-  busy,
-  onApply,
-  onCancel,
-}: {
-  dirty: boolean;
-  busy: boolean;
-  onApply: () => void;
-  onCancel: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-end gap-2 border-t border-border bg-surface px-3 py-2">
-      <button
-        type="button"
-        onClick={onCancel}
-        disabled={busy}
-        className="rounded-sm border border-border bg-bg px-3 py-1 font-mono text-[12px] text-ink hover:border-ink-faint disabled:opacity-50"
-      >
-        cancel
-      </button>
-      <button
-        type="button"
-        onClick={onApply}
-        disabled={!dirty || busy}
-        className="rounded-sm border border-accent bg-accent px-3 py-1 font-mono text-[12px] text-bg hover:opacity-90 disabled:opacity-50"
-      >
-        {busy ? "applying…" : "apply changes"}
-      </button>
-    </div>
   );
 }
 

--- a/web/src/components/edit/useApplySubmit.test.ts
+++ b/web/src/components/edit/useApplySubmit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { classifyBuildError } from "./useApplySubmit";
+import { ManagedFieldsUnavailableError } from "../../lib/applyBodyBuilder";
+import { MultiDocumentError, YamlParseError } from "../../lib/yamlPatch";
+
+// classifyBuildError is the pure mapping layer between exceptions
+// thrown by buildRetainedOwnershipBody and the SubmitState the form
+// banner consumes. The rest of useApplySubmit is glue (react-query
+// invalidate + abort controller + setState + api.applyResource), so
+// we keep dedicated tests scoped to the part with branching logic.
+describe("classifyBuildError", () => {
+  it("ManagedFieldsUnavailableError → friendly retry message", () => {
+    const got = classifyBuildError(new ManagedFieldsUnavailableError());
+    expect(got).toEqual({
+      kind: "error",
+      message: "Ownership info is still loading — try again in a moment.",
+      isConflict: false,
+    });
+  });
+
+  it("MultiDocumentError → surfaces the package error message verbatim", () => {
+    const e = new MultiDocumentError(3);
+    const got = classifyBuildError(e);
+    expect(got).toMatchObject({
+      kind: "error",
+      message: e.message,
+      isConflict: false,
+    });
+  });
+
+  it("YamlParseError → surfaces the package error message verbatim", () => {
+    const e = new YamlParseError("yaml: did not find expected node content");
+    const got = classifyBuildError(e);
+    expect(got).toMatchObject({
+      kind: "error",
+      message: "yaml: did not find expected node content",
+      isConflict: false,
+    });
+  });
+
+  it("returns null for unrecognised errors so the hook can re-throw", () => {
+    // Generic Error → null → submit() will `throw e` so the unexpected
+    // surfaces in DevTools rather than being swallowed.
+    expect(classifyBuildError(new Error("something else"))).toBeNull();
+    expect(classifyBuildError(new TypeError("nope"))).toBeNull();
+    expect(classifyBuildError("string thrown")).toBeNull();
+    expect(classifyBuildError(undefined)).toBeNull();
+  });
+
+  it("never produces isConflict=true (build errors are pre-network)", () => {
+    // Sanity guard: classifyBuildError must not collide with 409
+    // post-network conflict handling. isConflict is reserved for the
+    // ApiError 409 path further down in submit().
+    const cases: unknown[] = [
+      new ManagedFieldsUnavailableError(),
+      new MultiDocumentError(2),
+      new YamlParseError("bad"),
+    ];
+    for (const c of cases) {
+      const got = classifyBuildError(c);
+      // Narrowing: classified errors are always the "error" variant.
+      expect(got?.kind).toBe("error");
+      if (got?.kind === "error") {
+        expect(got.isConflict).toBe(false);
+      }
+    }
+  });
+});

--- a/web/src/components/edit/useApplySubmit.ts
+++ b/web/src/components/edit/useApplySubmit.ts
@@ -11,14 +11,26 @@
 // pre-flight (PR #100), and audit-log emission all still happen.
 // Operators who hit a 409 conflict are routed to YAML mode where
 // the full ConflictResolutionView is available.
+//
+// As of #181 this hook routes through `buildRetainedOwnershipBody`,
+// the same retained-ownership minimal-patch builder YamlEditor uses,
+// so form-mode applies no longer claim ownership of every field in
+// the resource — they only claim what the user actually edited plus
+// what periscope-spa already owned.
 
 import { useCallback, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { api, ApiError, type ResourceRef } from "../../lib/api";
+import { api, ApiError, type ResourceMeta, type ResourceRef } from "../../lib/api";
+import {
+  buildRetainedOwnershipBody,
+  ManagedFieldsUnavailableError,
+} from "../../lib/applyBodyBuilder";
 import {
   invalidateAfterApply,
   type EditorSource,
 } from "../../lib/customResources";
+import { parseIdentityFromYaml } from "../../lib/k8sSchema";
+import { MultiDocumentError, YamlParseError } from "../../lib/yamlPatch";
 
 export type SubmitState =
   | { kind: "idle" }
@@ -27,9 +39,53 @@ export type SubmitState =
   | { kind: "success" }
   | { kind: "error"; message: string; status?: number; isConflict: boolean };
 
+/**
+ * Maps errors thrown while constructing the apply body into the
+ * `error` SubmitState the banner renders. Returns `null` for errors
+ * the hook should re-throw (programmer bugs, not user-facing).
+ *
+ * Pure — exported for testing.
+ */
+export function classifyBuildError(e: unknown): SubmitState | null {
+  if (e instanceof ManagedFieldsUnavailableError) {
+    return {
+      kind: "error",
+      message: "Ownership info is still loading — try again in a moment.",
+      isConflict: false,
+    };
+  }
+  if (e instanceof MultiDocumentError || e instanceof YamlParseError) {
+    return {
+      kind: "error",
+      message: (e as Error).message,
+      isConflict: false,
+    };
+  }
+  return null;
+}
+
+export interface SubmitInput {
+  /** YAML the user mounted against (anchor for the user-edits diff). */
+  baseline: string;
+  /** Current form/YAML buffer (the user's intent). */
+  draft: string;
+  /**
+   * Latest server YAML — values for prior-owned paths the user hasn't
+   * touched. Caller threads this from the live `useEditorYaml` cache.
+   */
+  current: string;
+  /**
+   * ResourceMeta snapshot from `useResourceMeta`. `null` means the
+   * 15s meta poll hasn't landed yet; we fail closed rather than apply
+   * with an empty ownership set (which would behave like a first-apply
+   * and silently release ownership of prior periscope-spa claims).
+   */
+  meta: ResourceMeta | null;
+}
+
 export interface UseApplySubmit {
   state: SubmitState;
-  submit: (yaml: string) => Promise<boolean>;
+  submit: (input: SubmitInput) => Promise<boolean>;
   reset: () => void;
 }
 
@@ -42,10 +98,43 @@ export function useApplySubmit(
   const abortRef = useRef<AbortController | null>(null);
 
   const submit = useCallback(
-    async (yaml: string): Promise<boolean> => {
+    async ({ baseline, draft, current, meta }: SubmitInput): Promise<boolean> => {
       if (abortRef.current) abortRef.current.abort();
       const ac = new AbortController();
       abortRef.current = ac;
+
+      // Identity parsing precedes the builder so a malformed draft
+      // surfaces the right error rather than going through the
+      // builder's ManagedFieldsUnavailableError path.
+      const identity = parseIdentityFromYaml(draft);
+      if (!identity) {
+        setState({
+          kind: "error",
+          message:
+            "Could not parse apiVersion/kind/metadata.name from the buffer.",
+          isConflict: false,
+        });
+        return false;
+      }
+
+      let yaml: string;
+      try {
+        ({ yaml } = buildRetainedOwnershipBody({
+          baseline,
+          draft,
+          current,
+          identity,
+          managedFields: meta?.managedFields ?? null,
+        }));
+      } catch (e) {
+        const classified = classifyBuildError(e);
+        if (classified) {
+          setState(classified);
+          return false;
+        }
+        throw e;
+      }
+
       const args = {
         cluster: resource.cluster,
         group: resource.group,

--- a/web/src/components/edit/useApplySubmit.ts
+++ b/web/src/components/edit/useApplySubmit.ts
@@ -88,6 +88,14 @@ export interface SubmitInput {
 export interface UseApplySubmit {
   state: SubmitState;
   submit: (input: SubmitInput) => Promise<boolean>;
+  /**
+   * Run the L4 dry-run only — no L5 commit, no auto-takeover. Toasts
+   * via SubmitState transitions: dryRunning → success (auto-clears to
+   * idle after 1500ms) on success, or error on failure. Useful for the
+   * "dry-run" button in the form-mode ActionBar so operators can
+   * pre-flight admission webhooks / PSA / schema before committing.
+   */
+  dryRun: (input: SubmitInput) => Promise<boolean>;
   reset: () => void;
 }
 
@@ -207,7 +215,87 @@ export function useApplySubmit(
     [qc, resource, source],
   );
 
+  const dryRun = useCallback(
+    async ({ baseline, draft, current, meta }: SubmitInput): Promise<boolean> => {
+      if (abortRef.current) abortRef.current.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+
+      const identity = parseIdentityFromYaml(draft);
+      if (!identity) {
+        setState({
+          kind: "error",
+          message: "Could not parse apiVersion/kind/metadata.name from the buffer.",
+          isConflict: false,
+        });
+        return false;
+      }
+      if (!meta) {
+        setState({
+          kind: "error",
+          message: "Ownership info is still loading — try again in a moment.",
+          isConflict: false,
+        });
+        return false;
+      }
+
+      let yaml: string;
+      try {
+        ({ yaml } = buildRetainedOwnershipBody({
+          baseline,
+          draft,
+          current,
+          identity,
+          managedFields: meta.managedFields,
+        }));
+      } catch (e) {
+        const classified = classifyBuildError(e);
+        if (classified) {
+          setState(classified);
+          return false;
+        }
+        throw e;
+      }
+
+      try {
+        setState({ kind: "dryRunning" });
+        await api.applyResource(
+          {
+            cluster: resource.cluster,
+            group: resource.group,
+            version: resource.version,
+            resource: resource.resource,
+            namespace: resource.namespace,
+            name: resource.name,
+            yaml,
+            dryRun: true,
+          },
+          ac.signal,
+        );
+        // Toast-style success: flash, then return to idle so the
+        // button label / state machine resets for the next click.
+        // Matches YamlEditor.runDryRun's behaviour.
+        setState({ kind: "success" });
+        setTimeout(() => {
+          if (!ac.signal.aborted) setState({ kind: "idle" });
+        }, 1500);
+        return true;
+      } catch (e) {
+        if (ac.signal.aborted) return false;
+        const isApiError = e instanceof ApiError;
+        const status = isApiError ? e.status : undefined;
+        const isConflict = status === 409;
+        const message =
+          (isApiError ? e.bodyText : undefined) ||
+          (e instanceof Error ? e.message : "dry-run failed");
+        setState({ kind: "error", message, status, isConflict });
+        return false;
+      }
+    },
+    [resource],
+  );
+
   const reset = useCallback(() => setState({ kind: "idle" }), []);
 
-  return { state, submit, reset };
+  return { state, submit, dryRun, reset };
 }

--- a/web/src/components/edit/useApplySubmit.ts
+++ b/web/src/components/edit/useApplySubmit.ts
@@ -3,20 +3,21 @@
 // page re-fetches the live object. Errors surface as a banner the
 // caller renders.
 //
-// This is intentionally narrower than YamlEditor's apply
-// orchestration: no field-conflict resolution view (#116 form mode
-// links operators to the YAML editor for that), no drift overlay,
-// no patch preview. The backend pipeline behind `api.applyResource`
-// is identical, so SSA semantics, the per-doc SelfSubjectAccessReview
-// pre-flight (PR #100), and audit-log emission all still happen.
-// Operators who hit a 409 conflict are routed to YAML mode where
-// the full ConflictResolutionView is available.
-//
 // As of #181 this hook routes through `buildRetainedOwnershipBody`,
 // the same retained-ownership minimal-patch builder YamlEditor uses,
 // so form-mode applies no longer claim ownership of every field in
 // the resource — they only claim what the user actually edited plus
 // what periscope-spa already owned.
+//
+// The commit path also routes through `applyWithLenientConflictRetained`
+// (same wrapper the row-action mutation hooks use). This means:
+//   - HUMAN-class conflicts (kubectl-*, Rancher, unclassified) silently
+//     auto-takeover on a second attempt — same UX as scale / labels /
+//     suspend / restart / cordon.
+//   - GITOPS / HELM / CONTROLLER conflicts surface a classified
+//     "blocked by X" message instead of the raw apiserver 409 body.
+// Dry-run stays on the raw `api.applyResource` call (the wrapper is
+// commit-only — dry-runs can't conflict).
 
 import { useCallback, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -29,8 +30,9 @@ import {
   invalidateAfterApply,
   type EditorSource,
 } from "../../lib/customResources";
+import { applyWithLenientConflictRetained } from "../../hooks/mutations/_applyWithLenientConflict";
 import { parseIdentityFromYaml } from "../../lib/k8sSchema";
-import { MultiDocumentError, YamlParseError } from "../../lib/yamlPatch";
+import { MultiDocumentError, YamlParseError, computeOps } from "../../lib/yamlPatch";
 
 export type SubmitState =
   | { kind: "idle" }
@@ -117,6 +119,21 @@ export function useApplySubmit(
         return false;
       }
 
+      // Defensive meta gate at the top so we don't reach the lenient
+      // wrapper with managedFields=null (which would otherwise throw
+      // an internal "fetch api.getMeta first" error). The builder also
+      // throws ManagedFieldsUnavailableError, but checking here keeps
+      // both this check and the lenient wrapper's call below in the
+      // same code path with a single, user-friendly message.
+      if (!meta) {
+        setState({
+          kind: "error",
+          message: "Ownership info is still loading — try again in a moment.",
+          isConflict: false,
+        });
+        return false;
+      }
+
       let yaml: string;
       try {
         ({ yaml } = buildRetainedOwnershipBody({
@@ -135,20 +152,43 @@ export function useApplySubmit(
         throw e;
       }
 
-      const args = {
+      // ops here are the *user-edit* ops (computeOps over baseline/draft).
+      // The retained-ownership body the apiserver sees was already built
+      // above; the wrapper needs the same ops shape to reconstruct an
+      // equivalent body via buildRetainedOwnershipBodyFromOps. Passing
+      // them avoids re-parsing baseline/draft twice.
+      const ops = computeOps(baseline, draft);
+
+      const baseArgs = {
         cluster: resource.cluster,
         group: resource.group,
         version: resource.version,
         resource: resource.resource,
         namespace: resource.namespace,
         name: resource.name,
-        yaml,
       };
       try {
+        // L4 dry-run via the raw client. The wrapper is commit-only
+        // (auto-takeover doesn't make sense for dry-run since the
+        // apiserver never mutates state). We still want pre-flight
+        // validation surface (PSA, webhooks, schema) before claiming
+        // ownership of anything.
         setState({ kind: "dryRunning" });
-        await api.applyResource({ ...args, dryRun: true }, ac.signal);
+        await api.applyResource({ ...baseArgs, yaml, dryRun: true }, ac.signal);
+
+        // L5 commit through the lenient retain wrapper — same auto-
+        // takeover + classified-error behaviour the row actions get.
         setState({ kind: "applying" });
-        await api.applyResource({ ...args, dryRun: false }, ac.signal);
+        await applyWithLenientConflictRetained(
+          {
+            ...baseArgs,
+            identity,
+            ops,
+            current,
+            managedFields: meta.managedFields,
+          },
+          "apply",
+        );
         await invalidateAfterApply(qc, source, resource);
         setState({ kind: "success" });
         return true;

--- a/web/src/hooks/mutations/_applyWithLenientConflict.ts
+++ b/web/src/hooks/mutations/_applyWithLenientConflict.ts
@@ -23,7 +23,18 @@
 // "blocked by X on field Y, edit the source instead" message than to
 // silently lose the change minutes later.
 
-import { ApiError, api } from "../../lib/api";
+import {
+  ApiError,
+  api,
+  type ClusterScopedKind,
+  type ManagedFieldsEntry,
+  type YamlKind,
+} from "../../lib/api";
+import {
+  buildRetainedOwnershipBodyFromOps,
+  ManagedFieldsUnavailableError,
+} from "../../lib/applyBodyBuilder";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { analyzeConflict, formatBlockingMessage } from "../../lib/conflictPolicy";
 
 interface ApplyArgs {
@@ -36,6 +47,30 @@ interface ApplyArgs {
   yaml: string;
 }
 
+interface RetainedApplyArgs extends Omit<ApplyArgs, "yaml"> {
+  identity: Identity;
+  ops: Op[];
+  current: string;
+  managedFields: ManagedFieldsEntry[] | null | undefined;
+}
+
+// The ClusterScopedKind union duplicated here so the helper can do
+// a runtime membership check without re-exporting the array. Mirror
+// of the type in lib/api.ts:234 — kept in sync by the compiler via
+// the assignment below.
+const CLUSTER_SCOPED_KINDS: ClusterScopedKind[] = [
+  "namespaces",
+  "pvs",
+  "storageclasses",
+  "clusterroles",
+  "clusterrolebindings",
+  "ingressclasses",
+  "priorityclasses",
+  "runtimeclasses",
+  "nodes",
+];
+const CLUSTER_SCOPED_SET = new Set<string>(CLUSTER_SCOPED_KINDS);
+
 /**
  * applyWithLenientConflict wraps api.applyResource with the
  * auto-takeover-on-safe-conflict policy described in the file header.
@@ -44,6 +79,74 @@ interface ApplyArgs {
  *                      "scale", "update labels". Kept short — the toast
  *                      caller usually adds the resource name itself.
  */
+/**
+ * fetchCurrentYamlForKind picks the right namespaced vs cluster-scoped
+ * GET endpoint based on the YamlKind enum. Mutation hooks call this
+ * just before constructing the retained-ownership body so the builder
+ * has current cluster values for periscope-spa's prior claims.
+ */
+export async function fetchCurrentYamlForKind(
+  cluster: string,
+  kind: YamlKind,
+  namespace: string,
+  name: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (CLUSTER_SCOPED_SET.has(kind)) {
+    return api.clusterScopedYaml(cluster, kind as ClusterScopedKind, name, signal);
+  }
+  return api.yaml(
+    cluster,
+    kind as Exclude<YamlKind, ClusterScopedKind>,
+    namespace,
+    name,
+    signal,
+  );
+}
+
+/**
+ * applyWithLenientConflictRetained — same lenient-conflict policy as
+ * applyWithLenientConflict, but the request body is built via the
+ * retained-ownership minimal patch (#181) instead of plain
+ * buildMinimalSSA. Caller supplies the action's ops + identity plus
+ * the current cluster YAML and managedFields snapshot; we re-assert
+ * periscope-spa's prior claims alongside the user's edit so
+ * untouched fields aren't released on every mutation.
+ *
+ * Callers fetch `current` + `managedFields` themselves so the right
+ * API call (namespaced vs cluster-scoped) happens at the hook level
+ * where the kind is statically known. `fetchCurrentYamlForKind` above
+ * is the convenience for the namespaced/cluster-scoped routing.
+ */
+export async function applyWithLenientConflictRetained<T>(
+  args: RetainedApplyArgs,
+  actionPhrase: string,
+): Promise<T> {
+  const { identity, ops, current, managedFields, ...rest } = args;
+  let yaml: string;
+  try {
+    ({ yaml } = buildRetainedOwnershipBodyFromOps({
+      identity,
+      ops,
+      current,
+      managedFields,
+    }));
+  } catch (e) {
+    if (e instanceof ManagedFieldsUnavailableError) {
+      // Should not happen — the caller is responsible for fetching
+      // meta before reaching this wrapper. Re-throw as a programmer
+      // error rather than letting the toast spell out an internal
+      // message about the SSA body builder.
+      throw new Error(
+        "applyWithLenientConflictRetained called without managedFields — fetch api.getMeta first",
+        { cause: e },
+      );
+    }
+    throw e;
+  }
+  return applyWithLenientConflict<T>({ ...rest, yaml }, actionPhrase);
+}
+
 export async function applyWithLenientConflict<T>(
   args: ApplyArgs,
   actionPhrase: string,

--- a/web/src/hooks/mutations/useEditLabels.ts
+++ b/web/src/hooks/mutations/useEditLabels.ts
@@ -6,12 +6,15 @@
 // patched (some pages derive filter chips from labels and rebuilding
 // those derivations correctly in the optimistic phase is fragile).
 
-import { ApiError, type YamlKind } from "../../lib/api";
+import { ApiError, api, type YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { useOptimisticMutation } from "./_useOptimistic";
-import { applyWithLenientConflict } from "./_applyWithLenientConflict";
+import {
+  applyWithLenientConflictRetained,
+  fetchCurrentYamlForKind,
+} from "./_applyWithLenientConflict";
 
 interface EditLabelsArgs {
   cluster: string;
@@ -63,18 +66,28 @@ export function useEditLabels(args: EditLabelsArgs) {
     rollback: (qc, snap) => {
       qc.setQueryData(detailKey, snap.detail);
     },
-    mutationFn: (vars) => {
+    mutationFn: async (vars) => {
       const identity: Identity = {
         apiVersion: meta.group ? `${meta.group}/${meta.version}` : meta.version,
         kind: meta.kind,
         name: args.name,
         namespace: args.namespace || undefined,
       };
-      const yaml = buildMinimalSSA(
-        [{ op: "replace", path: ["metadata", "labels"], value: vars.labels }],
-        identity,
-      );
-      return applyWithLenientConflict(
+      const ops: Op[] = [
+        { op: "replace", path: ["metadata", "labels"], value: vars.labels },
+      ];
+      const [current, resourceMeta] = await Promise.all([
+        fetchCurrentYamlForKind(args.cluster, args.kind, args.namespace, args.name),
+        api.getMeta({
+          cluster: args.cluster,
+          group: meta.group,
+          version: meta.version,
+          resource: meta.resource,
+          namespace: args.namespace || undefined,
+          name: args.name,
+        }),
+      ]);
+      return applyWithLenientConflictRetained(
         {
           cluster: args.cluster,
           group: meta.group,
@@ -82,7 +95,10 @@ export function useEditLabels(args: EditLabelsArgs) {
           resource: meta.resource,
           namespace: args.namespace || undefined,
           name: args.name,
-          yaml,
+          identity,
+          ops,
+          current,
+          managedFields: resourceMeta.managedFields,
         },
         "update labels",
       );

--- a/web/src/hooks/mutations/useRolloutRestart.ts
+++ b/web/src/hooks/mutations/useRolloutRestart.ts
@@ -10,12 +10,15 @@
 // counts as the rollout progresses; the existing list-poll picks up
 // the cascade pod churn within ~15s (issue #4).
 
-import { ApiError, type YamlKind } from "../../lib/api";
+import { ApiError, api, type YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { useOptimisticMutation } from "./_useOptimistic";
-import { applyWithLenientConflict } from "./_applyWithLenientConflict";
+import {
+  applyWithLenientConflictRetained,
+  fetchCurrentYamlForKind,
+} from "./_applyWithLenientConflict";
 
 export type RestartableKind = "deployments" | "statefulsets" | "daemonsets";
 
@@ -66,37 +69,45 @@ export function useRolloutRestart(args: RestartArgs) {
     rollback: (qc, snap) => {
       qc.setQueryData(detailKey, snap.detail);
     },
-    mutationFn: () => {
+    mutationFn: async () => {
       const identity: Identity = {
         apiVersion: meta.group ? `${meta.group}/${meta.version}` : meta.version,
         kind: meta.kind,
         name: args.name,
         namespace: args.namespace,
       };
-      const yaml = buildMinimalSSA(
-        [
-          {
-            op: "replace",
-            path: [
-              "spec",
-              "template",
-              "metadata",
-              "annotations",
-              "kubectl.kubernetes.io/restartedAt",
-            ],
-            // ISO-8601 timestamp matches kubectl's format and is what
-            // controllers/operators expect to see in the field.
-            value: new Date().toISOString(),
-          },
-        ],
-        identity,
-      );
+      const ops: Op[] = [
+        {
+          op: "replace",
+          path: [
+            "spec",
+            "template",
+            "metadata",
+            "annotations",
+            "kubectl.kubernetes.io/restartedAt",
+          ],
+          // ISO-8601 timestamp matches kubectl's format and is what
+          // controllers/operators expect to see in the field.
+          value: new Date().toISOString(),
+        },
+      ];
+      const [current, resourceMeta] = await Promise.all([
+        fetchCurrentYamlForKind(args.cluster, args.kind, args.namespace, args.name),
+        api.getMeta({
+          cluster: args.cluster,
+          group: meta.group,
+          version: meta.version,
+          resource: meta.resource,
+          namespace: args.namespace,
+          name: args.name,
+        }),
+      ]);
       // Lenient SSA — kubectl-rollout (HUMAN) commonly owns this
       // annotation; the wrapper auto-takes-over on the second attempt.
       // GitOps-managed workloads now surface a classified error
       // ("Flux will revert in <5 min") instead of writing the
       // annotation only for it to be silently reverted on reconcile.
-      return applyWithLenientConflict(
+      return applyWithLenientConflictRetained(
         {
           cluster: args.cluster,
           group: meta.group,
@@ -104,7 +115,10 @@ export function useRolloutRestart(args: RestartArgs) {
           resource: meta.resource,
           namespace: args.namespace,
           name: args.name,
-          yaml,
+          identity,
+          ops,
+          current,
+          managedFields: resourceMeta.managedFields,
         },
         "rollout restart",
       );

--- a/web/src/hooks/mutations/useScaleResource.ts
+++ b/web/src/hooks/mutations/useScaleResource.ts
@@ -11,15 +11,18 @@
 // currently rendered (all-namespaces view, specific-namespace view,
 // or both at once).
 
-import { ApiError, type YamlKind } from "../../lib/api";
+import { ApiError, api, type YamlKind } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { patchRowInList } from "../../lib/listShape";
 import type { ResourceListResponse } from "../../lib/types";
 import type { QueryKey } from "@tanstack/react-query";
 import { useOptimisticMutation } from "./_useOptimistic";
-import { applyWithLenientConflict } from "./_applyWithLenientConflict";
+import {
+  applyWithLenientConflictRetained,
+  fetchCurrentYamlForKind,
+} from "./_applyWithLenientConflict";
 
 export type ScalableKind = "deployments" | "statefulsets" | "replicasets";
 
@@ -103,22 +106,35 @@ export function useScaleResource(args: ScaleArgs) {
       qc.setQueryData(detailKey, snap.detail);
       for (const [key, data] of snap.lists) qc.setQueryData(key, data);
     },
-    mutationFn: (vars) => {
+    mutationFn: async (vars) => {
       const identity: Identity = {
         apiVersion: meta.group ? `${meta.group}/${meta.version}` : meta.version,
         kind: meta.kind,
         name: args.name,
         namespace: args.namespace,
       };
-      const yaml = buildMinimalSSA(
-        [{ op: "replace", path: ["spec", "replicas"], value: vars.replicas }],
-        identity,
-      );
+      const ops: Op[] = [
+        { op: "replace", path: ["spec", "replicas"], value: vars.replicas },
+      ];
+      // Fetch current YAML + managedFields in parallel — required by the
+      // retained-ownership builder (#181) so periscope-spa keeps prior
+      // claims on every mutation instead of silently releasing them.
+      const [current, resourceMeta] = await Promise.all([
+        fetchCurrentYamlForKind(args.cluster, args.kind, args.namespace, args.name),
+        api.getMeta({
+          cluster: args.cluster,
+          group: meta.group,
+          version: meta.version,
+          resource: meta.resource,
+          namespace: args.namespace,
+          name: args.name,
+        }),
+      ]);
       // Lenient SSA: auto-takeover when the conflict is only with
       // HUMAN/UNKNOWN managers (kubectl-* / Rancher / unclassified).
       // GITOPS/HELM/CONTROLLER conflicts surface a classified error
       // instead — see _applyWithLenientConflict.ts.
-      return applyWithLenientConflict(
+      return applyWithLenientConflictRetained(
         {
           cluster: args.cluster,
           group: meta.group,
@@ -126,7 +142,10 @@ export function useScaleResource(args: ScaleArgs) {
           resource: meta.resource,
           namespace: args.namespace,
           name: args.name,
-          yaml,
+          identity,
+          ops,
+          current,
+          managedFields: resourceMeta.managedFields,
         },
         "scale",
       );

--- a/web/src/hooks/mutations/useToggleCordon.ts
+++ b/web/src/hooks/mutations/useToggleCordon.ts
@@ -7,15 +7,18 @@
 // Optimistic patching flips the `unschedulable` flag in both detail
 // and list caches so the cordon badge appears within one render.
 
-import { ApiError } from "../../lib/api";
+import { ApiError, api } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { patchRowInList } from "../../lib/listShape";
 import type { ResourceListResponse } from "../../lib/types";
 import type { QueryKey } from "@tanstack/react-query";
 import { useOptimisticMutation } from "./_useOptimistic";
-import { applyWithLenientConflict } from "./_applyWithLenientConflict";
+import {
+  applyWithLenientConflictRetained,
+  fetchCurrentYamlForKind,
+} from "./_applyWithLenientConflict";
 
 interface ToggleCordonArgs {
   cluster: string;
@@ -83,30 +86,40 @@ export function useToggleCordon(args: ToggleCordonArgs) {
       qc.setQueryData(detailKey, snap.detail);
       for (const [key, data] of snap.lists) qc.setQueryData(key, data);
     },
-    mutationFn: (vars) => {
+    mutationFn: async (vars) => {
       const identity: Identity = {
         apiVersion: meta.version,
         kind: meta.kind,
         name: args.name,
       };
-      const yaml = buildMinimalSSA(
-        [
-          {
-            op: "replace",
-            path: ["spec", "unschedulable"],
-            value: vars.unschedulable,
-          },
-        ],
-        identity,
-      );
-      return applyWithLenientConflict(
+      const ops: Op[] = [
+        {
+          op: "replace",
+          path: ["spec", "unschedulable"],
+          value: vars.unschedulable,
+        },
+      ];
+      const [current, resourceMeta] = await Promise.all([
+        fetchCurrentYamlForKind(args.cluster, "nodes", "", args.name),
+        api.getMeta({
+          cluster: args.cluster,
+          group: meta.group,
+          version: meta.version,
+          resource: meta.resource,
+          name: args.name,
+        }),
+      ]);
+      return applyWithLenientConflictRetained(
         {
           cluster: args.cluster,
           group: meta.group,
           version: meta.version,
           resource: meta.resource,
           name: args.name,
-          yaml,
+          identity,
+          ops,
+          current,
+          managedFields: resourceMeta.managedFields,
         },
         "cordon toggle",
       );

--- a/web/src/hooks/mutations/useToggleSuspend.ts
+++ b/web/src/hooks/mutations/useToggleSuspend.ts
@@ -4,15 +4,18 @@
 // completes; both the detail cache and any loaded list caches are
 // updated.
 
-import { ApiError } from "../../lib/api";
+import { ApiError, api } from "../../lib/api";
 import { KIND_REGISTRY } from "../../lib/k8sKinds";
 import { queryKeys } from "../../lib/queryKeys";
-import { buildMinimalSSA, type Identity } from "../../lib/yamlPatch";
+import { type Identity, type Op } from "../../lib/yamlPatch";
 import { patchRowInList } from "../../lib/listShape";
 import type { ResourceListResponse } from "../../lib/types";
 import type { QueryKey } from "@tanstack/react-query";
 import { useOptimisticMutation } from "./_useOptimistic";
-import { applyWithLenientConflict } from "./_applyWithLenientConflict";
+import {
+  applyWithLenientConflictRetained,
+  fetchCurrentYamlForKind,
+} from "./_applyWithLenientConflict";
 
 interface ToggleSuspendArgs {
   cluster: string;
@@ -79,18 +82,28 @@ export function useToggleSuspend(args: ToggleSuspendArgs) {
       qc.setQueryData(detailKey, snap.detail);
       for (const [key, data] of snap.lists) qc.setQueryData(key, data);
     },
-    mutationFn: (vars) => {
+    mutationFn: async (vars) => {
       const identity: Identity = {
         apiVersion: `${meta.group}/${meta.version}`,
         kind: meta.kind,
         name: args.name,
         namespace: args.namespace,
       };
-      const yaml = buildMinimalSSA(
-        [{ op: "replace", path: ["spec", "suspend"], value: vars.suspend }],
-        identity,
-      );
-      return applyWithLenientConflict(
+      const ops: Op[] = [
+        { op: "replace", path: ["spec", "suspend"], value: vars.suspend },
+      ];
+      const [current, resourceMeta] = await Promise.all([
+        fetchCurrentYamlForKind(args.cluster, "cronjobs", args.namespace, args.name),
+        api.getMeta({
+          cluster: args.cluster,
+          group: meta.group,
+          version: meta.version,
+          resource: meta.resource,
+          namespace: args.namespace,
+          name: args.name,
+        }),
+      ]);
+      return applyWithLenientConflictRetained(
         {
           cluster: args.cluster,
           group: meta.group,
@@ -98,7 +111,10 @@ export function useToggleSuspend(args: ToggleSuspendArgs) {
           resource: meta.resource,
           namespace: args.namespace,
           name: args.name,
-          yaml,
+          identity,
+          ops,
+          current,
+          managedFields: resourceMeta.managedFields,
         },
         "suspend toggle",
       );

--- a/web/src/hooks/useApplyYamlState.ts
+++ b/web/src/hooks/useApplyYamlState.ts
@@ -128,6 +128,12 @@ export function useApplyYamlState(): UseApplyYamlState {
       const gvr = gvrFromApiVersionAndKind(doc.apiVersion, doc.kind);
       updateResult(doc.id, { state: "pending" });
       try {
+        // Multi-doc Apply-YAML dialog: each doc has no baseline (this is
+        // a create-or-upsert flow, not an edit of a known resource), so
+        // there are no prior-owned paths to retain — we send the user's
+        // full intent as-is. The retained-ownership builder in
+        // lib/applyBodyBuilder.ts (see issue #181) is specifically for
+        // editor paths where a baseline + managedFields are available.
         const response = await api.applyResource(
           {
             cluster,
@@ -177,6 +183,9 @@ export function useApplyYamlState(): UseApplyYamlState {
       const ctrl = new AbortController();
       updateResult(doc.id, { state: "pending" });
       try {
+        // Force-apply path of the multi-doc dialog — same create-or-
+        // upsert semantics as runOne above, so we send doc.raw as-is
+        // rather than the retained-ownership minimal patch. See #181.
         await api.applyResource(
           {
             cluster,

--- a/web/src/hooks/useDismissed.ts
+++ b/web/src/hooks/useDismissed.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+/**
+ * useDismissed — per-session, per-key boolean stored in sessionStorage.
+ *
+ * Returns `[dismissed, dismiss]`. Initialised from sessionStorage on
+ * mount. `dismiss()` flips the flag AND writes it back. The flag
+ * naturally clears when the browser tab closes (sessionStorage scope)
+ * — opening the same resource in a fresh tab re-prompts.
+ *
+ * Used by CoManagementBanner so a quiet ack doesn't bury the
+ * "this resource is co-managed by X" message forever — only for the
+ * current session.
+ */
+export function useDismissed(key: string): [boolean, () => void] {
+  const [dismissed, setDismissed] = useState<boolean>(() => readFlag(key));
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    try {
+      window.sessionStorage.setItem(key, "1");
+    } catch {
+      // sessionStorage unavailable (Safari private mode pre-15, SSR)
+      // — keep the in-memory state, accept that a reload would re-prompt.
+    }
+  }, [key]);
+
+  return [dismissed, dismiss];
+}
+
+function readFlag(key: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}

--- a/web/src/lib/applyBodyBuilder.test.ts
+++ b/web/src/lib/applyBodyBuilder.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildRetainedOwnershipBody,
+  buildRetainedOwnershipBodyFromOps,
+  selectSelfOwnedPaths,
+  ManagedFieldsUnavailableError,
+} from "./applyBodyBuilder";
+import {
+  buildMinimalSSA,
+  computeOps,
+  parseOrThrow,
+  type Identity,
+  type Op,
+} from "./yamlPatch";
+import type { ManagedFieldsEntry } from "./api";
+
+// ---------- shared fixtures ----------
+
+const IDENTITY: Identity = {
+  apiVersion: "networking.k8s.io/v1",
+  kind: "Ingress",
+  name: "demo",
+  namespace: "default",
+};
+
+const PRISTINE_INGRESS = `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: demo
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+spec:
+  ingressClassName: alb
+  rules:
+    - host: demo.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 80
+`;
+
+const PORT_3000 = PRISTINE_INGRESS.replace("number: 80", "number: 3000");
+
+/** managedFields entry where periscope-spa owns the ALB annotations. */
+function periscopeOwnsAlbAnnotations(): ManagedFieldsEntry {
+  return {
+    manager: "periscope-spa",
+    operation: "Apply",
+    apiVersion: "networking.k8s.io/v1",
+    fieldsType: "FieldsV1",
+    fieldsV1: {
+      "f:metadata": {
+        "f:annotations": {
+          "f:alb.ingress.kubernetes.io/scheme": {},
+          "f:alb.ingress.kubernetes.io/listen-ports": {},
+        },
+      },
+    },
+  };
+}
+
+// ---------- selectSelfOwnedPaths — apiVersion-drift union ----------
+
+describe("selectSelfOwnedPaths", () => {
+  it("unions paths across multiple periscope-spa entries (apiVersion drift)", () => {
+    const entries: ManagedFieldsEntry[] = [
+      {
+        manager: "periscope-spa",
+        operation: "Apply",
+        apiVersion: "apps/v1",
+        fieldsType: "FieldsV1",
+        fieldsV1: { "f:spec": { "f:replicas": {} } },
+      },
+      {
+        manager: "periscope-spa",
+        operation: "Apply",
+        apiVersion: "apps/v1beta1",
+        fieldsType: "FieldsV1",
+        fieldsV1: {
+          "f:spec": {
+            "f:template": {
+              "f:spec": {
+                "f:containers": {
+                  'k:{"name":"nginx"}': { "f:image": {} },
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+    const paths = selectSelfOwnedPaths(entries, "periscope-spa");
+    expect(paths.sort()).toEqual(
+      [
+        "spec.replicas",
+        "spec.template.spec.containers[name=nginx].image",
+      ].sort(),
+    );
+  });
+
+  it("ignores Update operation entries (CSA) — only Apply ownership is retained", () => {
+    const entries: ManagedFieldsEntry[] = [
+      {
+        manager: "periscope-spa",
+        operation: "Update",
+        apiVersion: "apps/v1",
+        fieldsType: "FieldsV1",
+        fieldsV1: { "f:spec": { "f:replicas": {} } },
+      },
+    ];
+    expect(selectSelfOwnedPaths(entries, "periscope-spa")).toEqual([]);
+  });
+
+  it("ignores entries from other managers", () => {
+    const entries: ManagedFieldsEntry[] = [
+      {
+        manager: "kubectl-client-side-apply",
+        operation: "Update",
+        apiVersion: "v1",
+        fieldsType: "FieldsV1",
+        fieldsV1: { "f:metadata": { "f:annotations": { ".": {} } } },
+      },
+    ];
+    expect(selectSelfOwnedPaths(entries, "periscope-spa")).toEqual([]);
+  });
+});
+
+// ---------- buildRetainedOwnershipBody — core behaviour ----------
+
+describe("buildRetainedOwnershipBody", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("first-ever apply (empty managedFields) matches legacy buildMinimalSSA byte-for-byte", () => {
+    const baseline = PRISTINE_INGRESS;
+    const draft = PORT_3000;
+    const result = buildRetainedOwnershipBody({
+      baseline,
+      draft,
+      current: baseline,
+      identity: IDENTITY,
+      managedFields: [],
+    });
+    expect(result.firstApply).toBe(true);
+    expect(result.priorOwnedPaths).toEqual([]);
+    expect(result.yaml).toBe(buildMinimalSSA(computeOps(baseline, draft), IDENTITY));
+  });
+
+  it("subsequent apply retains prior-owned annotations from current cluster state", () => {
+    const result = buildRetainedOwnershipBody({
+      baseline: PRISTINE_INGRESS,
+      draft: PORT_3000,
+      current: PRISTINE_INGRESS,
+      identity: IDENTITY,
+      managedFields: [periscopeOwnsAlbAnnotations()],
+    });
+    expect(result.firstApply).toBe(false);
+    expect(result.priorOwnedPaths.sort()).toEqual(
+      [
+        "metadata.annotations.alb.ingress.kubernetes.io/scheme",
+        "metadata.annotations.alb.ingress.kubernetes.io/listen-ports",
+      ].sort(),
+    );
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    const annotations = (
+      (parsed.metadata as Record<string, unknown>).annotations as Record<string, unknown>
+    );
+    expect(annotations["alb.ingress.kubernetes.io/scheme"]).toBe("internet-facing");
+    expect(annotations["alb.ingress.kubernetes.io/listen-ports"]).toBe(
+      '[{"HTTP":80}]',
+    );
+  });
+
+  it("user edits a prior-owned path → edit wins (edit ops applied last)", () => {
+    // periscope-spa already owns spec.replicas with cluster value 3;
+    // user is editing it to 7 in draft.
+    const baseline = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 3
+`;
+    const draft = baseline.replace("replicas: 3", "replicas: 7");
+    const current = baseline; // current cluster still has 3
+    const mf: ManagedFieldsEntry = {
+      manager: "periscope-spa",
+      operation: "Apply",
+      apiVersion: "apps/v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: { "f:spec": { "f:replicas": {} } },
+    };
+    const result = buildRetainedOwnershipBody({
+      baseline,
+      draft,
+      current,
+      identity: {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        name: "demo",
+      },
+      managedFields: [mf],
+    });
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    expect((parsed.spec as Record<string, unknown>).replicas).toBe(7);
+  });
+
+  it("user 'remove' op on a prior-owned path wins (null leaf overwrites retained value)", () => {
+    const baseline = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+  annotations:
+    keep-me: yes
+    drop-me: 'true'
+data:
+  k: v
+`;
+    const draft = baseline.replace("    drop-me: 'true'\n", "");
+    const current = baseline;
+    const mf: ManagedFieldsEntry = {
+      manager: "periscope-spa",
+      operation: "Apply",
+      apiVersion: "v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: {
+        "f:metadata": {
+          "f:annotations": {
+            "f:keep-me": {},
+            "f:drop-me": {},
+          },
+        },
+      },
+    };
+    const result = buildRetainedOwnershipBody({
+      baseline,
+      draft,
+      current,
+      identity: { apiVersion: "v1", kind: "ConfigMap", name: "demo" },
+      managedFields: [mf],
+    });
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    const annotations = (
+      (parsed.metadata as Record<string, unknown>).annotations as Record<string, unknown>
+    );
+    // keep-me retained from current; drop-me explicitly nulled by user edit.
+    expect(annotations["keep-me"]).toBe("yes");
+    expect(annotations["drop-me"]).toBeNull();
+  });
+
+  it("managedFields === null → throws ManagedFieldsUnavailableError", () => {
+    expect(() =>
+      buildRetainedOwnershipBody({
+        baseline: PRISTINE_INGRESS,
+        draft: PORT_3000,
+        current: PRISTINE_INGRESS,
+        identity: IDENTITY,
+        managedFields: null,
+      }),
+    ).toThrow(ManagedFieldsUnavailableError);
+  });
+
+  it("managedFields === undefined → throws ManagedFieldsUnavailableError", () => {
+    expect(() =>
+      buildRetainedOwnershipBody({
+        baseline: PRISTINE_INGRESS,
+        draft: PORT_3000,
+        current: PRISTINE_INGRESS,
+        identity: IDENTITY,
+        managedFields: undefined,
+      }),
+    ).toThrow(ManagedFieldsUnavailableError);
+  });
+
+  it("prior-owned path missing from current cluster state is silently dropped", () => {
+    const baseline = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+  annotations:
+    only-one: still-here
+data:
+  k: v
+`;
+    const draft = baseline.replace("k: v", "k: v2");
+    // periscope claims an annotation that no longer exists in current.
+    const mf: ManagedFieldsEntry = {
+      manager: "periscope-spa",
+      operation: "Apply",
+      apiVersion: "v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: {
+        "f:metadata": {
+          "f:annotations": {
+            "f:only-one": {},
+            "f:was-deleted-externally": {},
+          },
+        },
+      },
+    };
+    const result = buildRetainedOwnershipBody({
+      baseline,
+      draft,
+      current: baseline,
+      identity: { apiVersion: "v1", kind: "ConfigMap", name: "demo" },
+      managedFields: [mf],
+    });
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    const annotations = (
+      (parsed.metadata as Record<string, unknown>).annotations as Record<string, unknown>
+    );
+    // only-one retained; was-deleted-externally not present.
+    expect(annotations["only-one"]).toBe("still-here");
+    expect("was-deleted-externally" in annotations).toBe(false);
+  });
+
+  it("excludePriorOwned callback drops paths the operator chose to revert", () => {
+    const result = buildRetainedOwnershipBody({
+      baseline: PRISTINE_INGRESS,
+      draft: PORT_3000,
+      current: PRISTINE_INGRESS,
+      identity: IDENTITY,
+      managedFields: [periscopeOwnsAlbAnnotations()],
+      excludePriorOwned: (p) =>
+        p === "metadata.annotations.alb.ingress.kubernetes.io/scheme",
+    });
+    expect(result.priorOwnedPaths).toEqual([
+      "metadata.annotations.alb.ingress.kubernetes.io/listen-ports",
+    ]);
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    const annotations = ((parsed.metadata as Record<string, unknown>)
+      .annotations ?? {}) as Record<string, unknown>;
+    expect("alb.ingress.kubernetes.io/scheme" in annotations).toBe(false);
+    expect(annotations["alb.ingress.kubernetes.io/listen-ports"]).toBe(
+      '[{"HTTP":80}]',
+    );
+  });
+
+  it("retained path with IndexKey segment is dropped with a console.warn", () => {
+    // i: marker on an atomic list.
+    const mf: ManagedFieldsEntry = {
+      manager: "periscope-spa",
+      operation: "Apply",
+      apiVersion: "v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: {
+        "f:spec": {
+          "f:finalizers": {
+            "i:0": { ".": {} },
+          },
+        },
+      },
+    };
+    const baseline = `apiVersion: v1
+kind: Foo
+metadata:
+  name: demo
+spec:
+  finalizers:
+    - keep.me/forever
+  field: a
+`;
+    const draft = baseline.replace("field: a", "field: b");
+    buildRetainedOwnershipBody({
+      baseline,
+      draft,
+      current: baseline,
+      identity: { apiVersion: "v1", kind: "Foo", name: "demo" },
+      managedFields: [mf],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/IndexKey/),
+    );
+  });
+
+  it("ops returned to caller is the user-edit set only (not the synthetic retain ops)", () => {
+    const result = buildRetainedOwnershipBody({
+      baseline: PRISTINE_INGRESS,
+      draft: PORT_3000,
+      current: PRISTINE_INGRESS,
+      identity: IDENTITY,
+      managedFields: [periscopeOwnsAlbAnnotations()],
+    });
+    // The user only edited the port; the retained annotations should
+    // NOT show up here — parseConflictCauses relies on this.
+    expect(result.ops.length).toBe(1);
+    expect(result.ops[0].op).toBe("replace");
+  });
+});
+
+// ---------- buildRetainedOwnershipBodyFromOps — mutation-hook entry ----------
+
+describe("buildRetainedOwnershipBodyFromOps", () => {
+  it("composes a body from caller-supplied ops + retained ownership", () => {
+    const scaleOp: Op = {
+      op: "replace",
+      path: ["spec", "replicas"],
+      value: 5,
+    };
+    const current = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+  annotations:
+    flux.io/managed: 'true'
+spec:
+  replicas: 3
+`;
+    const mf: ManagedFieldsEntry = {
+      manager: "periscope-spa",
+      operation: "Apply",
+      apiVersion: "apps/v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: {
+        "f:metadata": { "f:annotations": { "f:flux.io/managed": {} } },
+      },
+    };
+    const result = buildRetainedOwnershipBodyFromOps({
+      ops: [scaleOp],
+      current,
+      identity: { apiVersion: "apps/v1", kind: "Deployment", name: "demo" },
+      managedFields: [mf],
+    });
+    expect(result.firstApply).toBe(false);
+    const parsed = parseOrThrow(result.yaml).obj as Record<string, unknown>;
+    expect((parsed.spec as Record<string, unknown>).replicas).toBe(5);
+    const annotations = (
+      (parsed.metadata as Record<string, unknown>).annotations as Record<string, unknown>
+    );
+    expect(annotations["flux.io/managed"]).toBe("true");
+  });
+
+  it("first-apply case (empty managedFields) returns minimal SSA with just the ops", () => {
+    const op: Op = { op: "replace", path: ["spec", "replicas"], value: 2 };
+    const result = buildRetainedOwnershipBodyFromOps({
+      ops: [op],
+      current: "",
+      identity: { apiVersion: "apps/v1", kind: "Deployment", name: "demo" },
+      managedFields: [],
+    });
+    expect(result.firstApply).toBe(true);
+    expect(result.priorOwnedPaths).toEqual([]);
+  });
+
+  it("throws on null managedFields (defensive race guard)", () => {
+    expect(() =>
+      buildRetainedOwnershipBodyFromOps({
+        ops: [],
+        current: "",
+        identity: { apiVersion: "v1", kind: "Foo", name: "x" },
+        managedFields: null,
+      }),
+    ).toThrow(ManagedFieldsUnavailableError);
+  });
+});

--- a/web/src/lib/applyBodyBuilder.ts
+++ b/web/src/lib/applyBodyBuilder.ts
@@ -111,6 +111,12 @@ export interface BuildBodyFromOpsInput {
   identity: Identity;
   managedFields: ManagedFieldsEntry[] | null | undefined;
   selfManager?: string;
+  /**
+   * See `BuildBodyInput.excludePriorOwned`. Used by `runApplyResolved`
+   * in YamlEditor to drop paths the operator chose to revert in the
+   * field-manager conflict view.
+   */
+  excludePriorOwned?: (path: string) => boolean;
 }
 
 export interface BuildBodyFromOpsResult {
@@ -165,6 +171,7 @@ export function buildRetainedOwnershipBodyFromOps(
     identity,
     managedFields,
     selfManager = DEFAULT_SELF_MANAGER,
+    excludePriorOwned,
   } = input;
 
   assertManagedFieldsPresent(managedFields);
@@ -175,6 +182,7 @@ export function buildRetainedOwnershipBodyFromOps(
     identity,
     managedFields: managedFields as ManagedFieldsEntry[],
     selfManager,
+    excludePriorOwned,
   });
 }
 

--- a/web/src/lib/applyBodyBuilder.ts
+++ b/web/src/lib/applyBodyBuilder.ts
@@ -1,0 +1,430 @@
+// applyBodyBuilder — single source of truth for SSA Apply request bodies.
+//
+// Periscope's SPA used to construct apply bodies inconsistently:
+//   - YAML mode → minimal SSA via computeOps + buildMinimalSSA
+//   - Form mode → full draft buffer
+//   - Mutation hooks (scale/labels/suspend/restart/cordon) → ad-hoc minimal
+//
+// The full-buffer path made periscope-spa claim ownership of every field
+// in the body. A subsequent apply that omitted any field would release
+// that ownership; with no other manager owning it, the field was dropped.
+// In production this manifested as ALB controller annotations vanishing
+// after an Ingress port edit (see issue #181).
+//
+// The fix: a retained-ownership minimal patch. Each apply contains:
+//   1. The user's edited paths (computeOps(baseline, draft))
+//   2. Every path periscope-spa already owns, valued at current cluster
+//      state (walked from managedFields[manager=periscope-spa].fieldsV1)
+//
+// This matches SSA's "fully-specified intent" doctrine — we keep
+// asserting what we've claimed, plus our new edit — and eliminates
+// the migration cliff a naïve minimal-patch switch would create.
+//
+// For first-ever applies (no prior ownership yet), this degenerates to
+// today's minimal-patch behavior.
+//
+// Note on path representation: we work in PathSegment[] form everywhere
+// internally because the dotted-string form (`metadata.annotations.alb
+// .ingress.kubernetes.io/scheme`) is ambiguous when a map key contains
+// dots (annotation/label keys frequently do). Stringification happens
+// only at the boundary for UI / exclusion-callback consumers.
+
+import {
+  buildMinimalSSA,
+  parseOrThrow,
+  computeOps,
+  type Identity,
+  type Op,
+  type PathSegment,
+  type MergeKey,
+  type IndexKey,
+} from "./yamlPatch";
+import type { ManagedFieldsEntry } from "./api";
+
+const DEFAULT_SELF_MANAGER = "periscope-spa";
+
+/**
+ * Thrown when the caller cannot construct a retained-ownership body
+ * because managedFields hasn't loaded yet. Callers should gate the
+ * Apply CTA on metaQuery.isPending; this error is the defensive net
+ * for races (apply clicked before the 15s meta poll lands).
+ */
+export class ManagedFieldsUnavailableError extends Error {
+  constructor() {
+    super("managedFields not yet loaded — try again in a moment.");
+    this.name = "ManagedFieldsUnavailableError";
+  }
+}
+
+export interface BuildBodyInput {
+  /** YAML the user mounted against (anchor for `computeOps`). */
+  baseline: string;
+  /** Current editor buffer (what the user wants to apply). */
+  draft: string;
+  /**
+   * Latest server YAML — source of values for prior-owned paths the
+   * user hasn't touched. In YamlEditor this can reuse `pristineLocked`
+   * (kept fresh by the pristine-swap effect on clean buffers).
+   */
+  current: string;
+  identity: Identity;
+  /** From `useResourceMeta`'s ResourceMeta.managedFields. */
+  managedFields: ManagedFieldsEntry[] | null | undefined;
+  /** Defaults to "periscope-spa". Overridable for tests. */
+  selfManager?: string;
+  /**
+   * Optional filter: prior-owned paths the user has explicitly chosen
+   * to release (via the 409 ConflictResolutionView "revert" action).
+   * Receives the dotted-string form of each candidate retained path.
+   * Returning true drops the path from the body so periscope-spa
+   * releases ownership of it on this apply.
+   */
+  excludePriorOwned?: (path: string) => boolean;
+}
+
+export interface BuildBodyResult {
+  /** Stringified SSA body ready to POST. */
+  yaml: string;
+  /**
+   * User-edit ops only (not the synthetic retain-ownership ops).
+   * Exposed so callers like `parseConflictCauses` can match
+   * Status.details.causes[].field against the paths the user actually
+   * touched.
+   */
+  ops: Op[];
+  /**
+   * Dotted-form paths the body re-asserts ownership of. Useful for
+   * UI affordances ("+ N retained fields you already owned" in the
+   * PatchPreviewDrawer).
+   */
+  priorOwnedPaths: string[];
+  /**
+   * True when managedFields had no prior periscope-spa Apply entry.
+   * The body in this case is identical to the legacy minimal SSA.
+   */
+  firstApply: boolean;
+}
+
+export interface BuildBodyFromOpsInput {
+  ops: Op[];
+  current: string;
+  identity: Identity;
+  managedFields: ManagedFieldsEntry[] | null | undefined;
+  selfManager?: string;
+}
+
+export interface BuildBodyFromOpsResult {
+  yaml: string;
+  priorOwnedPaths: string[];
+  firstApply: boolean;
+}
+
+/**
+ * Editor-driven entry: diffs `baseline` vs `draft` for user edits,
+ * walks `managedFields` for prior periscope-spa ownership, composes
+ * the SSA body.
+ */
+export function buildRetainedOwnershipBody(
+  input: BuildBodyInput,
+): BuildBodyResult {
+  const {
+    baseline,
+    draft,
+    current,
+    identity,
+    managedFields,
+    selfManager = DEFAULT_SELF_MANAGER,
+    excludePriorOwned,
+  } = input;
+
+  assertManagedFieldsPresent(managedFields);
+
+  const ops = computeOps(baseline, draft);
+  const { yaml, priorOwnedPaths, firstApply } = composeBody({
+    ops,
+    current,
+    identity,
+    managedFields: managedFields as ManagedFieldsEntry[],
+    selfManager,
+    excludePriorOwned,
+  });
+
+  return { yaml, ops, priorOwnedPaths, firstApply };
+}
+
+/**
+ * Mutation-hook entry: caller has pre-computed ops (scale/labels/etc.)
+ * and we only need to layer in retained ownership.
+ */
+export function buildRetainedOwnershipBodyFromOps(
+  input: BuildBodyFromOpsInput,
+): BuildBodyFromOpsResult {
+  const {
+    ops,
+    current,
+    identity,
+    managedFields,
+    selfManager = DEFAULT_SELF_MANAGER,
+  } = input;
+
+  assertManagedFieldsPresent(managedFields);
+
+  return composeBody({
+    ops,
+    current,
+    identity,
+    managedFields: managedFields as ManagedFieldsEntry[],
+    selfManager,
+  });
+}
+
+/**
+ * Walks managedFields for `selfManager` Apply entries and returns the
+ * dotted-form paths of every claimed field, deduped.
+ *
+ * Note: dotted form is for display only. The builder works in segment
+ * form internally because dotted strings are ambiguous when map keys
+ * contain dots (annotation keys regularly do).
+ */
+export function selectSelfOwnedPaths(
+  entries: ManagedFieldsEntry[],
+  selfManager: string,
+): string[] {
+  const segs = selectSelfOwnedSegments(entries, selfManager);
+  const seen = new Set<string>();
+  for (const path of segs) seen.add(stringifyPath(path));
+  return [...seen];
+}
+
+// ---------------- internals ----------------
+
+interface ComposeBodyInput {
+  ops: Op[];
+  current: string;
+  identity: Identity;
+  managedFields: ManagedFieldsEntry[];
+  selfManager: string;
+  excludePriorOwned?: (path: string) => boolean;
+}
+
+function composeBody(input: ComposeBodyInput): BuildBodyResult {
+  const { ops, current, identity, managedFields, selfManager, excludePriorOwned } = input;
+
+  const selfOwnedSegments = selectSelfOwnedSegments(managedFields, selfManager);
+  const firstApply = selfOwnedSegments.length === 0;
+
+  if (firstApply) {
+    // Degenerate path: behaves exactly like the legacy minimal SSA.
+    return {
+      yaml: buildMinimalSSA(ops, identity),
+      ops,
+      priorOwnedPaths: [],
+      firstApply: true,
+    };
+  }
+
+  // Apply the user-side path-release filter (used by runApplyResolved
+  // when the operator chose to revert a field in the conflict view).
+  const retainSegments = excludePriorOwned
+    ? selfOwnedSegments.filter((segs) => !excludePriorOwned(stringifyPath(segs)))
+    : selfOwnedSegments;
+
+  // Extract current values for the retained paths. Paths we can't
+  // resolve (missing in current, IndexKey segments we don't materialize)
+  // are silently dropped — the worst case is we release ownership of
+  // one path on this apply, which is no worse than today's behavior.
+  const retainedOps = collectRetainedOps(retainSegments, current);
+  const retainedPathStrings = retainedOps.map((rop) => stringifyPath(rop.path));
+
+  // Compose: retained ops first, user ops second. Edit-wins follows
+  // from order — applyOpToTree's setLeaf overwrites the same slot.
+  const combinedOps: Op[] = [...retainedOps, ...ops];
+  const yaml = buildMinimalSSA(combinedOps, identity);
+
+  return {
+    yaml,
+    ops,
+    priorOwnedPaths: retainedPathStrings,
+    firstApply: false,
+  };
+}
+
+/**
+ * Walks the managedFields entries for `selfManager` (Apply op only)
+ * and emits each owned path as a PathSegment[]. Unions across
+ * multiple entries (apiVersion drift produces multiple entries for
+ * the same manager; the apiserver coalesces ownership on the next
+ * Apply regardless of which entry recorded which subset).
+ */
+function selectSelfOwnedSegments(
+  entries: ManagedFieldsEntry[],
+  selfManager: string,
+): PathSegment[][] {
+  const out: PathSegment[][] = [];
+  const seenKeys = new Set<string>();
+  for (const entry of entries) {
+    if (entry.manager !== selfManager) continue;
+    if (entry.operation !== "Apply") continue;
+    if (!entry.fieldsV1 || entry.fieldsType !== "FieldsV1") continue;
+    const collected: PathSegment[][] = [];
+    walkFieldsV1ToSegments(entry.fieldsV1, [], collected);
+    for (const segs of collected) {
+      // Dedup across entries via stringified key — duplicates across
+      // apiVersion entries are common and harmless.
+      const k = stringifyPath(segs);
+      if (seenKeys.has(k)) continue;
+      seenKeys.add(k);
+      out.push(segs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Segment-aware mirror of managedFields.walkFieldsV1. Emits PathSegment[]
+ * lists (no string concatenation) so map keys containing dots survive
+ * intact.
+ *
+ *   "f:<name>"  → string segment <name>
+ *   "k:<json>"  → MergeKey { [k]: v }   (one-entry JSON object)
+ *   "i:<n>"     → IndexKey { idx: n }
+ *   "."         → "this whole subtree is owned" — emit the current prefix
+ *
+ * Tolerant of malformed input: bad k: payloads / unknown prefixes are
+ * skipped silently.
+ */
+function walkFieldsV1ToSegments(
+  node: unknown,
+  prefix: PathSegment[],
+  out: PathSegment[][],
+): void {
+  if (!node || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    let segment: PathSegment | null = null;
+    if (key === ".") {
+      if (prefix.length > 0) out.push([...prefix]);
+      continue;
+    } else if (key.startsWith("f:")) {
+      segment = key.slice(2);
+    } else if (key.startsWith("k:")) {
+      try {
+        const keyObj = JSON.parse(key.slice(2)) as Record<string, unknown>;
+        const entries = Object.entries(keyObj);
+        if (entries.length > 0) {
+          const [k, v] = entries[0];
+          segment = { [k]: String(v) } as MergeKey;
+        }
+      } catch {
+        // malformed k: payload, skip this branch entirely
+      }
+    } else if (key.startsWith("i:")) {
+      const n = Number(key.slice(2));
+      if (Number.isInteger(n)) segment = { idx: n } as IndexKey;
+    } else {
+      // Unknown prefix (e.g. "v:" set-of-atomic-values) — skip
+      continue;
+    }
+    if (segment === null) continue;
+    const childPrefix = [...prefix, segment];
+    if (typeof value === "object" && value !== null && Object.keys(value as object).length > 0) {
+      walkFieldsV1ToSegments(value, childPrefix, out);
+    } else {
+      // leaf — empty {} means "this exact field is owned"
+      out.push(childPrefix);
+    }
+  }
+}
+
+function collectRetainedOps(
+  paths: PathSegment[][],
+  currentYaml: string,
+): Op[] {
+  let currentObj: unknown;
+  try {
+    currentObj = parseOrThrow(currentYaml).obj;
+  } catch {
+    // If we can't parse current state, fall through with no retained
+    // ops — the caller's user-edit ops still apply. This is intentional:
+    // the editor's apply already has an error path for unparseable
+    // YAML; we shouldn't crash the body builder on top of that.
+    return [];
+  }
+
+  const ops: Op[] = [];
+  for (const segs of paths) {
+    // IndexKey segments come from fieldsV1 "i:" markers on atomic
+    // lists (set semantics). applyOpToTree.stepInto doesn't materialize
+    // these positionally, and re-asserting a single index across an
+    // atomic list is semantically dicey anyway — drop with a warning.
+    if (segs.some(isIndexKey)) {
+      console.warn(
+        `[applyBodyBuilder] dropping retained path with IndexKey segment (atomic list): ${stringifyPath(segs)}`,
+      );
+      continue;
+    }
+    const value = walkValue(currentObj, segs);
+    if (value === undefined) {
+      // The field was removed from the resource between the last
+      // apply and now. Don't re-assert it — let ownership lapse.
+      continue;
+    }
+    ops.push({ op: "replace", path: segs, value });
+  }
+  return ops;
+}
+
+function walkValue(root: unknown, segs: PathSegment[]): unknown {
+  let node: unknown = root;
+  for (const seg of segs) {
+    if (node === undefined || node === null) return undefined;
+    if (typeof seg === "string") {
+      if (typeof node !== "object" || Array.isArray(node)) return undefined;
+      node = (node as Record<string, unknown>)[seg];
+    } else if (isIndexKey(seg)) {
+      if (!Array.isArray(node)) return undefined;
+      node = node[seg.idx];
+    } else {
+      // MergeKey: find the array item whose key === value.
+      if (!Array.isArray(node)) return undefined;
+      const [k, v] = Object.entries(seg)[0];
+      const found = (node as Record<string, unknown>[]).find(
+        (item) =>
+          item !== null &&
+          typeof item === "object" &&
+          String(item[k]) === v,
+      );
+      if (!found) return undefined;
+      node = found;
+    }
+  }
+  return node;
+}
+
+function stringifyPath(segs: PathSegment[]): string {
+  // Mirror of YamlEditor.opPathToString — kept local to avoid a
+  // cross-module dependency for one tiny helper.
+  const parts: string[] = [];
+  for (const seg of segs) {
+    if (typeof seg === "string") {
+      parts.push(seg);
+    } else if (isIndexKey(seg)) {
+      parts.push(`[${seg.idx}]`);
+    } else {
+      const [k, v] = Object.entries(seg)[0];
+      parts.push(`[${k}=${v}]`);
+    }
+  }
+  return parts.join(".").replace(/\.\[/g, "[");
+}
+
+function isIndexKey(seg: PathSegment): seg is IndexKey {
+  return typeof seg !== "string" && "idx" in (seg as object);
+}
+
+function assertManagedFieldsPresent(
+  mf: ManagedFieldsEntry[] | null | undefined,
+): asserts mf is ManagedFieldsEntry[] {
+  if (mf === null || mf === undefined) {
+    throw new ManagedFieldsUnavailableError();
+  }
+}

--- a/web/src/lib/managedFields.test.ts
+++ b/web/src/lib/managedFields.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseManagedFields,
+  walkFieldsV1,
+  type FieldOwner,
+} from "./managedFields";
+import type { ManagedFieldsEntry } from "./api";
+
+// walkFieldsV1 — sub-tree → dotted path walker.
+//
+// Inputs are shaped like Kubernetes managedFields.fieldsV1: each key
+// carries a one-character prefix that tells the walker how to project
+// it onto the resource graph.
+describe("walkFieldsV1", () => {
+  function walk(node: Record<string, unknown>, prefix = ""): string[] {
+    const out: string[] = [];
+    walkFieldsV1(node, prefix, out);
+    return out.sort();
+  }
+
+  it("emits an f: leaf as a dotted path", () => {
+    expect(walk({ "f:spec": { "f:replicas": {} } })).toEqual(["spec.replicas"]);
+  });
+
+  it("emits '.': {} as 'this subtree is owned' at the current prefix", () => {
+    // Nested ".": means periscope owns the whole metadata.labels map.
+    const tree = {
+      "f:metadata": {
+        "f:labels": {
+          ".": {},
+        },
+      },
+    };
+    expect(walk(tree)).toEqual(["metadata.labels"]);
+  });
+
+  it("ignores '.': {} at root prefix (no parent path to claim)", () => {
+    // Defensive: walkFieldsV1 should not emit an empty-string path.
+    expect(walk({ ".": {} })).toEqual([]);
+  });
+
+  it("emits k: merge-key segments with bracket notation, no dot", () => {
+    const tree = {
+      "f:spec": {
+        "f:containers": {
+          'k:{"name":"nginx"}': {
+            "f:image": {},
+          },
+        },
+      },
+    };
+    expect(walk(tree)).toEqual(["spec.containers[name=nginx].image"]);
+  });
+
+  it("emits i: integer-index segments with bracket notation", () => {
+    const tree = {
+      "f:spec": {
+        "f:rules": {
+          "i:0": { "f:host": {} },
+        },
+      },
+    };
+    expect(walk(tree)).toEqual(["spec.rules[0].host"]);
+  });
+
+  it("mixes f:, k:, i: at the same level cleanly", () => {
+    const tree = {
+      "f:spec": {
+        "f:replicas": {},
+        "f:containers": {
+          'k:{"name":"nginx"}': { "f:image": {} },
+        },
+        "f:rules": {
+          "i:0": { "f:host": {} },
+        },
+      },
+    };
+    expect(walk(tree)).toEqual([
+      "spec.containers[name=nginx].image",
+      "spec.replicas",
+      "spec.rules[0].host",
+    ]);
+  });
+
+  it("descends 4+ levels without dropping prefixes", () => {
+    const tree = {
+      "f:spec": {
+        "f:template": {
+          "f:spec": {
+            "f:containers": {
+              'k:{"name":"nginx"}': {
+                "f:resources": {
+                  "f:limits": {
+                    "f:memory": {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(walk(tree)).toEqual([
+      "spec.template.spec.containers[name=nginx].resources.limits.memory",
+    ]);
+  });
+
+  it("skips malformed k: values without throwing (entry + children dropped)", () => {
+    // The "{...}" payload isn't valid JSON.
+    const tree = {
+      "f:spec": {
+        "f:containers": {
+          "k:{not-json}": {
+            "f:image": {},
+          },
+          'k:{"name":"valid"}': {
+            "f:image": {},
+          },
+        },
+      },
+    };
+    // The malformed k: produces no segment → walker skips this key
+    // entirely (children not visited). The valid sibling still emits.
+    expect(() => walk(tree)).not.toThrow();
+    expect(walk(tree)).toEqual(["spec.containers[name=valid].image"]);
+  });
+
+  it("skips unknown prefixes silently (forward-compat with new fieldsV1 markers)", () => {
+    const tree = {
+      "f:spec": {
+        "f:replicas": {},
+        // v: is a real K8s marker (set-of-atomic-values). We don't
+        // emit anything for it — it's covered by the parent path.
+        "f:finalizers": {
+          'v:"foo.example.com/cleanup"': {},
+        },
+      },
+    };
+    // Only spec.replicas; "v:" not surfaced as a path of its own.
+    expect(walk(tree)).toEqual(["spec.replicas"]);
+  });
+
+  it("tolerates non-object nodes (returns whatever could be parsed)", () => {
+    // node: null, string, number → no-op.
+    expect(walk(null as unknown as Record<string, unknown>)).toEqual([]);
+    expect(walk("not an object" as unknown as Record<string, unknown>)).toEqual([]);
+  });
+});
+
+// parseManagedFields — turns the array of managedFields entries on a
+// K8s object into a flat list of FieldOwner records.
+describe("parseManagedFields", () => {
+  const NGINX_ENTRY: ManagedFieldsEntry = {
+    manager: "kubectl-client-side-apply",
+    operation: "Update",
+    apiVersion: "apps/v1",
+    fieldsType: "FieldsV1",
+    fieldsV1: {
+      "f:spec": {
+        "f:replicas": {},
+      },
+    },
+  };
+
+  it("returns [] for null / undefined / empty input", () => {
+    expect(parseManagedFields(null)).toEqual([]);
+    expect(parseManagedFields(undefined)).toEqual([]);
+    expect(parseManagedFields([])).toEqual([]);
+  });
+
+  it("emits one FieldOwner per leaf path with manager + operation populated", () => {
+    const owners = parseManagedFields([NGINX_ENTRY]);
+    expect(owners).toEqual<FieldOwner[]>([
+      {
+        path: "spec.replicas",
+        manager: "kubectl-client-side-apply",
+        operation: "Update",
+      },
+    ]);
+  });
+
+  it("skips entries lacking fieldsV1 / wrong fieldsType", () => {
+    const owners = parseManagedFields([
+      {
+        manager: "stale-manager",
+        operation: "Apply",
+        apiVersion: "apps/v1",
+        // no fieldsV1 / fieldsType
+      },
+      NGINX_ENTRY,
+    ]);
+    expect(owners).toHaveLength(1);
+    expect(owners[0].manager).toBe("kubectl-client-side-apply");
+  });
+});

--- a/web/src/lib/managedFields.ts
+++ b/web/src/lib/managedFields.ts
@@ -47,7 +47,7 @@ export interface FieldOwner {
  * input (missing prefixes, non-object values) — returns whatever it
  * could parse.
  */
-function walkFieldsV1(
+export function walkFieldsV1(
   node: unknown,
   prefix: string,
   out: string[],


### PR DESCRIPTION
## Summary

Periscope's SPA used to construct SSA Apply bodies inconsistently across call sites. Form-mode applies and the five mutation hooks (scale, edit-labels, suspend, restart, cordon) sent either the full draft buffer or an ad-hoc minimal patch. The full-buffer paths made `periscope-spa` claim ownership of every field in the body — a subsequent apply that omitted any field would release that ownership, dropping the field entirely if no other manager owned it.

This PR routes every in-place edit through a single shared `applyBodyBuilder` that produces a **retained-ownership minimal patch**. Each apply contains the user's edited paths PLUS every path `periscope-spa` already owned (re-asserted with current cluster values from `managedFields`). No ownership is released as a side effect of editing one field, so co-owned annotations (e.g. ALB controller annotations on an Ingress) survive periscope-driven edits.

Once that pipeline was unified it surfaced three follow-on UX gaps in form mode. All three are fixed in this PR.

`Closes #181`

## What changed

### Retained-ownership SSA body builder

- **New module** `web/src/lib/applyBodyBuilder.ts`:
  - `buildRetainedOwnershipBody({baseline, draft, current, identity, managedFields})` — editor-driven entry. Diffs baseline → draft for user edits, walks `managedFields[manager=periscope-spa]` for prior claims, composes one SSA body that asserts both.
  - `buildRetainedOwnershipBodyFromOps({ops, current, identity, managedFields})` — same idea for callers that already have `Op[]` (mutation hooks).
  - `selectSelfOwnedPaths(entries, manager)` — dotted-form summary for UI consumers (banner copy).
  - `ManagedFieldsUnavailableError` — defensive guard against the apply-clicked-before-meta-loaded race.
  - Internally works in `PathSegment[]` form because dotted strings are ambiguous when map keys contain dots (annotation/label keys regularly do).

### Editor paths

- `YamlEditor.runApply` / `runApplyResolved` / `runDryRun` — all three call sites routed through the builder.
- `useApplySubmit.submit({baseline, draft, current, meta})` — form-mode path, signature now object-shaped; routes through both the retained body builder **and** `applyWithLenientConflictRetained` so HUMAN-class conflicts auto-take-over (same UX as row actions) and GITOPS / HELM / CONTROLLER conflicts surface a classified "blocked by X" message.
- `useApplySubmit.dryRun(...)` — new method that runs only the L4 dry-run with a toast-style success state; powers the `dry-run` button in form mode.
- `BufferedEditor` (KindEditRouter) — wires `useResourceMeta` + a second `useEditorYaml` call (cache-shared with the parent, no extra round-trip) and passes them to `submit` / `dryRun`.

### Mutation hooks migrated

All five callers of `_applyWithLenientConflict` now route through a new `applyWithLenientConflictRetained` wrapper that pulls `current YAML + managedFields` synchronously inside the mutationFn and forwards to the body builder:

- `useScaleResource`
- `useEditLabels`
- `useToggleSuspend`
- `useRolloutRestart`
- `useToggleCordon`

A `fetchCurrentYamlForKind` helper in `_applyWithLenientConflict.ts` handles the namespaced-vs-cluster-scoped routing so each hook only specifies its kind.

### Form-mode action-bar parity

Form mode used to render a stripped-down `FormActionBar` (cancel + apply only) — operators lost the `ops`/`schema` indicators, the `patch` preview, and the `dry-run` pre-flight that YAML mode users had. Now both modes use the same `ActionBar` component:

- New `hideDiff` and `hideErrors` flags on `ActionBar` suppress YAML-mode-only affordances. Form mode passes both — form mode has no Monaco surface for a YAML-level diff (the structured patch view covers the same intent) and no monaco-style markers for the errors count.
- `BufferedEditor` lifts the shared editor state: `ops = computeOps(baseline, draft)`, `identity = parseIdentityFromYaml(draft)`, schema query for the schema-pill state, `showPatch` + drawer-width state (persisted under the same `localStorage` key as YAML mode).
- `PatchPreviewDrawer` is now rendered in both modes; the same resizable-handle UX works in form mode.
- The deleted `FormActionBar` component lived in `KindEditRouter.tsx` — it's gone, replaced by `<ActionBar hideDiff hideErrors ...>`.

### Error-banner placement

`SubmitErrorBanner` used to render *inside* the form's `overflow-auto` scroll panel, below every form section. For non-trivial resources the banner was below the fold; operators had to scroll to discover their apply had failed. Banner is now a sibling of the scroll area, rendered just above `ActionBar` — same placement YAML mode uses for `ApplyErrorBanner`. Always visible.

### New UX — `CoManagementBanner`

Sticky one-line strip at editor open when the resource has managers other than `periscope-spa`. Lists the top 3 managers and the count of fields `periscope-spa` will retain. Dismissable per-resource per-session via a new `useDismissed` hook backed by `sessionStorage` — fresh tab re-prompts, but no spam within a session.

### Intentionally unchanged

- `useApplyYamlState` (multi-doc Apply-YAML dialog) — create/upsert flow has no baseline, so the full buffer IS the correct SSA shape. Inline comments at both `api.applyResource` sites document the rationale.
- Backend (`internal/k8s/apply.go`) — body-agnostic; no logic change.

## Test plan

- [x] `cd web && pnpm lint` — clean
- [x] `cd web && pnpm test` — 29 files, 450 tests, all green
- [x] `npx tsc -b --noEmit` — clean
- [x] `go test ./...` — green, including new `TestApplyResource_RetainsCoOwnedAnnotations` regression
- [x] **Manual: tutra/tutra Ingress YAML-mode edit** — pathType edit. After-diff: only `f:spec.f:rules` moved to periscope-spa; nginx annotations + ingressClassName + labels stayed with kubectl-client-side-apply. Cloudflare entries byte-identical.
- [ ] Manual: tutra/tutra form-mode edit — after this PR, the kubectl-client-side-apply conflict on `spec.rules` should auto-takeover silently (lenient retain wrapper), no "FIELD MANAGER CONFLICT" banner.
- [ ] Manual: scale a Deployment via the row-level action — labels owned by another manager survive.
- [ ] Manual: open a resource where `periscope-spa` is sole owner (created via Apply-YAML dialog), edit a field, verify untouched fields stay present.
- [ ] Manual: open a resource managed by both `periscope-spa` and `argocd-application-controller`; verify co-management banner shows; dismiss; reload; verify banner stays gone for that session; open a different argocd-managed resource and verify the banner shows again.
- [ ] Manual: form mode action bar — verify `patch` drawer opens/closes, `dry-run` button runs L4 only and toasts on success, `ops` count updates as form fields change, `schema` pill is green for built-in kinds.
- [ ] Manual: form mode error visibility — trigger an apply error (e.g. invalid value) on a tall resource (Deployment with many sections), verify the banner is visible without scrolling.

## Notes for reviewers

1. **Dotted path representation.** The builder internally uses `PathSegment[]` rather than the dotted-string form because annotation keys frequently contain dots (`alb.ingress.kubernetes.io/scheme`). The early prototype tried `pathStringToSegments` and the round-trip tests immediately surfaced the ambiguity. Stringification happens only at the boundary (UI display, `excludePriorOwned` callback).

2. **`pristineLocked` reused as `current` in YamlEditor.** On a clean buffer the pristine-swap effect keeps `pristineLocked` pinned to the latest server YAML; on a dirty buffer the user has explicitly chosen to ignore drift, so re-asserting whatever they last had is safest. A dedicated current-state query is a deferrable optimization.

3. **`runApplyResolved` uses the FromOps variant** (not the editor variant) because it has pre-filtered ops via `resolutions`. `excludePriorOwned` mirrors the revert semantics on the retained-ownership side.

4. **Mutation hooks fetch `getYaml + getMeta` in parallel** inside the mutationFn. One extra round-trip per click — acceptable for deliberate, low-frequency actions.

5. **Go regression test scope:** the fake dynamic client doesn't model SSA field-manager merge (would require envtest / a real apiserver). The new test asserts the apply handler doesn't *strip* co-owned annotations between the SPA body and the dynamic client request — a defensive guard against future regressions in `stripDisallowedMetadata` or similar.

6. **Form-mode dry-run keeps the raw `api.applyResource` call** — the lenient wrapper is commit-only (a dry-run can't conflict). Only the L5 commit step goes through `applyWithLenientConflictRetained`.

## Out of scope

- Explicit per-field "release ownership" affordance — possible follow-up, needs design.
- Expanding `MERGE_KEYS` in `yamlPatch.ts` so `spec.rules` (Ingress) and similar arrays diff per-item instead of atomic replace — separate issue.
- Backend-side enforcement (reject applies that drop periscope-spa-owned paths) — belt-and-suspenders, defer.
- Per-field ConflictResolutionView in form mode — after this PR, the common HUMAN-class conflict auto-resolves and the residual case (mixed-category multi-field conflicts) is rare and inherently power-user. The "switch to YAML mode" link remains the escape hatch; promoting that flow to a one-click mode-preserving experience is a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
