### PR TITLE
Form-mode + logs polish: discriminator seed, deeper schema walk, logs wrap default (closes #180)

### DIFF
--- a/web/src/components/logs/logsState.test.ts
+++ b/web/src/components/logs/logsState.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LOGS_STATE,
+  paramsToState,
+  stateToParams,
+  TAIL_DEFAULT,
+  type LogsViewState,
+} from "./logsState";
+
+describe("DEFAULT_LOGS_STATE", () => {
+  it("ships wrap=true so fresh log views wrap by default", () => {
+    // Teammate request: wrap-off is hostile for stack traces / long
+    // structured-log lines. Operators were silently truncated; this
+    // flip makes wrap the default.
+    expect(DEFAULT_LOGS_STATE.wrap).toBe(true);
+  });
+
+  it("still defaults follow=true and timestamps=true", () => {
+    // Belt-and-suspenders: nothing else regressed when we flipped wrap.
+    expect(DEFAULT_LOGS_STATE.follow).toBe(true);
+    expect(DEFAULT_LOGS_STATE.timestamps).toBe(true);
+  });
+});
+
+describe("stateToParams + paramsToState — wrap roundtrip", () => {
+  // The contract for these helpers: only non-default fields land in
+  // the URL. Now that wrap defaults true, the param is present only
+  // when the operator has explicitly turned wrap OFF.
+
+  it("default state produces an empty URL (no wrap param)", () => {
+    const out = stateToParams(DEFAULT_LOGS_STATE);
+    expect(out.has("wrap")).toBe(false);
+    expect(out.toString()).toBe("");
+  });
+
+  it("emits wrap=false when the operator opts out", () => {
+    const state: LogsViewState = { ...DEFAULT_LOGS_STATE, wrap: false };
+    const out = stateToParams(state);
+    expect(out.get("wrap")).toBe("false");
+  });
+
+  it("URL without wrap param parses back as wrap=true (new default)", () => {
+    // This is the critical case: existing bookmarked URLs from before
+    // the default flip have no wrap param. After the flip they should
+    // read as wrap=true, matching the new default.
+    const parsed = paramsToState(new URLSearchParams(""));
+    expect(parsed.wrap).toBe(true);
+  });
+
+  it("URL with explicit wrap=false parses back as wrap=false", () => {
+    // Operators who shared a no-wrap URL keep that behaviour.
+    const parsed = paramsToState(new URLSearchParams("wrap=false"));
+    expect(parsed.wrap).toBe(false);
+  });
+
+  it("legacy URL with wrap=true (pre-flip explicit opt-in) still parses true", () => {
+    // Pre-flip URLs that explicitly requested wrap=true are now
+    // redundant but harmless — parsing should still produce wrap=true.
+    const parsed = paramsToState(new URLSearchParams("wrap=true"));
+    expect(parsed.wrap).toBe(true);
+  });
+
+  it("round-trips wrap=false through serialization", () => {
+    const original: LogsViewState = { ...DEFAULT_LOGS_STATE, wrap: false };
+    const back = paramsToState(stateToParams(original));
+    expect(back.wrap).toBe(false);
+  });
+
+  it("round-trips full default state with no params and no diffs", () => {
+    const back = paramsToState(stateToParams(DEFAULT_LOGS_STATE));
+    expect(back).toEqual(DEFAULT_LOGS_STATE);
+  });
+
+  it("tail/since defaults still honored alongside wrap default", () => {
+    // Sanity: the changes to wrap shouldn't have touched other
+    // default-handling. tailLines defaults to TAIL_DEFAULT, sinceSeconds
+    // to null; neither should be in the URL of a default state.
+    const out = stateToParams(DEFAULT_LOGS_STATE);
+    expect(out.has("tail")).toBe(false);
+    expect(out.has("since")).toBe(false);
+    const back = paramsToState(out);
+    expect(back.tailLines).toBe(TAIL_DEFAULT);
+    expect(back.sinceSeconds).toBeNull();
+  });
+});

--- a/web/src/components/logs/logsState.ts
+++ b/web/src/components/logs/logsState.ts
@@ -30,7 +30,12 @@ export const DEFAULT_LOGS_STATE: LogsViewState = {
   previous: false,
   follow: true,
   timestamps: true,
-  wrap: false,
+  // Default wrap ON — log lines are usually wider than the pane, and
+  // truncated lines force operators to horizontal-scroll just to see
+  // the end of a stack trace. Switched from default-off after the
+  // teammate request. Mirrors the `follow` / `timestamps` URL pattern:
+  // the param is only present when the operator has opted out.
+  wrap: true,
   search: "",
   podFilter: [],
 };
@@ -44,7 +49,7 @@ export function stateToParams(state: LogsViewState): URLSearchParams {
   if (state.previous) p.set("previous", "true");
   if (!state.follow) p.set("follow", "false");
   if (!state.timestamps) p.set("ts", "false");
-  if (state.wrap) p.set("wrap", "true");
+  if (!state.wrap) p.set("wrap", "false");
   if (state.search) p.set("q", state.search);
   if (state.podFilter.length > 0) p.set("pf", state.podFilter.join(","));
   return p;
@@ -62,7 +67,7 @@ export function paramsToState(params: URLSearchParams): LogsViewState {
     previous: params.get("previous") === "true",
     follow: params.get("follow") !== "false",
     timestamps: params.get("ts") !== "false",
-    wrap: params.get("wrap") === "true",
+    wrap: params.get("wrap") !== "false",
     search: params.get("q") ?? "",
     podFilter: (params.get("pf") ?? "").split(",").filter(Boolean),
   };

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -37,6 +37,7 @@ import type {
   ValidationIssue,
 } from "./types";
 import { Tooltip } from "../../components/Tooltip";
+import { seedBranchValue } from "./discriminatorSeed";
 
 // InfoTip — tiny "(i)" affordance next to a label that opens a
 // tooltip with the field's description on hover/focus. Used in
@@ -842,15 +843,15 @@ function DiscriminatorInput({
       );
       if (!ok) return;
     }
-    // Seed an empty value of the new branch's shape. Shape B needs
-    // {[discriminatorKey]: {}}; Shape A needs whatever shape the
-    // branch schema describes — empty object covers most cases
-    // since branches with primitive value (Service.targetPort etc.)
-    // expect the operator to type the primitive directly.
-    const next: unknown = branches[idx].discriminatorKey
-      ? { [branches[idx].discriminatorKey as string]: {} }
-      : {};
-    onChange(next);
+    // Seed the branch with its top-level required keys populated
+    // (#180). Without this, Shape A's active-branch detector — which
+    // checks key-presence against the branch's `required` array —
+    // never matches and the BranchSubForm doesn't render, leaving the
+    // operator staring at the same picker buttons with a stray `{}`
+    // already serialized into the YAML buffer. seedBranchValue puts
+    // type-appropriate empties at each required key so the detector
+    // matches on the very next render.
+    onChange(seedBranchValue(branches[idx]));
   };
 
   return (

--- a/web/src/lib/schemaForm/SchemaForm.tsx
+++ b/web/src/lib/schemaForm/SchemaForm.tsx
@@ -831,6 +831,25 @@ function DiscriminatorInput({
       }
     }
   }
+  if (active < 0 && !isObjectValue && value !== undefined && value !== null) {
+    // Primitive-branched discriminator (Service.targetPort string-or-
+    // integer style). The value IS a scalar; match the branch whose
+    // schema declares the same primitive type. Order matters — first
+    // branch whose type accepts the runtime value wins, which mirrors
+    // how the apiserver evaluates the oneOf.
+    const valueType = typeof value;
+    for (let i = 0; i < branches.length; i++) {
+      const t = branches[i].schema.type;
+      if (
+        (t === "string" && valueType === "string") ||
+        ((t === "integer" || t === "number") && valueType === "number") ||
+        (t === "boolean" && valueType === "boolean")
+      ) {
+        active = i;
+        break;
+      }
+    }
+  }
 
   const activeBranch = active >= 0 ? branches[active] : null;
   const valueIsEmpty = !value || (isObjectValue && Object.keys(valueObj).length === 0);
@@ -878,7 +897,10 @@ function DiscriminatorInput({
       {activeBranch ? (
         <BranchSubForm
           branch={activeBranch}
-          value={valueObj}
+          // Pass `value` (not `valueObj`) so primitive-branched
+          // discriminators see the scalar verbatim. BranchSubForm
+          // narrows to a record internally for object branches.
+          value={value}
           onChange={onChange}
           readOnly={readOnly ?? false}
         />
@@ -903,10 +925,33 @@ function BranchSubForm({
   readOnly,
 }: {
   branch: NonNullable<FieldDescriptor["branches"]>[number];
-  value: Record<string, unknown>;
+  value: unknown;
   onChange: (next: unknown) => void;
   readOnly: boolean;
 }) {
+  // Primitive-branched discriminator (Service.targetPort string-or-
+  // integer style). The branch's "value" is a scalar, so we render
+  // one direct input bound to the discriminator's root path. onChange
+  // here takes the new scalar value directly — the parent's setAtPath
+  // wires it into the resource tree.
+  const primitive = primitiveBranchType(branch.schema.type);
+  if (primitive) {
+    return (
+      <PrimitiveBranchInput
+        type={primitive}
+        value={value}
+        onChange={onChange}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  // Object-branched from here. Narrow the unknown value into a record.
+  const valueObj =
+    value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
   // Empty branch (Shape B "marker" branch where the schema is just
   // `{type: object, properties: {}}` — operator selecting it just
   // sets `{[key]: {}}`). Render a friendly status line.
@@ -929,7 +974,7 @@ function BranchSubForm({
           <FieldRow
             key={child.path.join(".")}
             descriptor={child}
-            values={value}
+            values={valueObj}
             issues={[]}
             mode={readOnly ? "edit" : "edit"}
             onChange={onChange}
@@ -938,6 +983,57 @@ function BranchSubForm({
       </div>
     </fieldset>
   );
+}
+
+// PrimitiveBranchInput — renders one direct input for a primitive-
+// branched discriminator (Service.targetPort string-or-integer, etc.).
+// The value at the discriminator's path IS the scalar, so the input's
+// onChange is bound directly to the discriminator-level onChange that
+// BranchSubForm received.
+function PrimitiveBranchInput({
+  type,
+  value,
+  onChange,
+  readOnly,
+}: {
+  type: "string" | "number" | "integer" | "boolean";
+  value: unknown;
+  onChange: (next: unknown) => void;
+  readOnly: boolean;
+}) {
+  const id = useId();
+  // Synthesize a minimal FieldDescriptor so we can reuse the existing
+  // FieldInput dispatch (handles boolean as checkbox, number as
+  // <input type=number>, string as <input type=text>, etc.).
+  const descriptor: FieldDescriptor = {
+    path: [],
+    label: type,
+    type,
+    required: false,
+  };
+  return (
+    <FieldInput
+      id={id}
+      descriptor={descriptor}
+      value={value}
+      onChange={onChange}
+      readOnly={readOnly}
+    />
+  );
+}
+
+// primitiveBranchType maps a JSON-Schema `type` to the FieldDescriptor
+// primitive types we know how to render. Returns null for object /
+// array / unknown types so the caller falls through to object-branch
+// handling.
+function primitiveBranchType(
+  t: unknown,
+): "string" | "number" | "integer" | "boolean" | null {
+  if (t === "string") return "string";
+  if (t === "number") return "number";
+  if (t === "integer") return "integer";
+  if (t === "boolean") return "boolean";
+  return null;
 }
 
 // ArrayRow — single-row container for an array-of-objects descriptor's

--- a/web/src/lib/schemaForm/discriminatorSeed.test.ts
+++ b/web/src/lib/schemaForm/discriminatorSeed.test.ts
@@ -204,3 +204,57 @@ describe("emptyForDescriptor", () => {
     })).toBeNull();
   });
 });
+
+// Primitive-branched discriminators (Service.targetPort string-or-
+// integer, Probe.timeoutSeconds wrapped, CRDs with int-or-string
+// shapes). The branch's value IS the scalar — there's no object to
+// seed required keys into, so seedBranchValue produces a type-
+// appropriate scalar empty.
+describe("seedBranchValue — primitive branches", () => {
+  function primitiveBranch(
+    type: "string" | "integer" | "number" | "boolean",
+  ): DiscriminatorBranch {
+    return {
+      label: type,
+      schema: { type } as JSONSchema,
+      descriptors: [],
+    };
+  }
+
+  it("seeds an empty string for a string branch", () => {
+    expect(seedBranchValue(primitiveBranch("string"))).toBe("");
+  });
+
+  it("seeds 0 for integer and number branches", () => {
+    expect(seedBranchValue(primitiveBranch("integer"))).toBe(0);
+    expect(seedBranchValue(primitiveBranch("number"))).toBe(0);
+  });
+
+  it("seeds false for a boolean branch", () => {
+    expect(seedBranchValue(primitiveBranch("boolean"))).toBe(false);
+  });
+
+  it("primitive seeding short-circuits the object required-key path", () => {
+    // Even if a primitive-typed branch has a leftover `required` array
+    // (defensive — shouldn't happen for clean schemas), the primitive
+    // short-circuit wins. Otherwise we'd produce `{}` again.
+    const b: DiscriminatorBranch = {
+      label: "string",
+      schema: { type: "string", required: ["foo"] } as JSONSchema,
+      descriptors: [],
+    };
+    expect(seedBranchValue(b)).toBe("");
+  });
+
+  it("non-primitive types (object/array) fall through to required-key seeding", () => {
+    // Sanity: object-typed branches still go through the old path.
+    const b: DiscriminatorBranch = {
+      label: "acme",
+      schema: { type: "object", required: ["email"] } as JSONSchema,
+      descriptors: [
+        { path: ["email"], label: "email", type: "string", required: true },
+      ],
+    };
+    expect(seedBranchValue(b)).toEqual({ email: "" });
+  });
+});

--- a/web/src/lib/schemaForm/discriminatorSeed.test.ts
+++ b/web/src/lib/schemaForm/discriminatorSeed.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyForDescriptor,
+  seedBranchValue,
+} from "./discriminatorSeed";
+import type { DiscriminatorBranch, FieldDescriptor, JSONSchema } from "./types";
+
+// Test factory — builds the FieldDescriptor shape the walker produces
+// for a top-level field under a branch root.
+function desc(
+  key: string,
+  type: FieldDescriptor["type"],
+  extras: Partial<FieldDescriptor> = {},
+): FieldDescriptor {
+  return {
+    path: [key],
+    label: key,
+    type,
+    required: false,
+    ...extras,
+  };
+}
+
+function branch(
+  opts: {
+    label?: string;
+    required?: string[];
+    descriptors?: FieldDescriptor[];
+    discriminatorKey?: string;
+    properties?: Record<string, unknown>;
+  } = {},
+): DiscriminatorBranch {
+  const schema: JSONSchema = {
+    type: "object",
+    properties: opts.properties ?? {},
+    required: opts.required,
+  } as JSONSchema;
+  return {
+    label: opts.label ?? "branch",
+    schema,
+    descriptors: opts.descriptors ?? [],
+    discriminatorKey: opts.discriminatorKey,
+  };
+}
+
+describe("seedBranchValue", () => {
+  // Core fix for #180: Shape A's active-branch detector matches when
+  // every key in `required` is present in the value object. The seed
+  // must populate those keys so BranchSubForm renders on click.
+  it("Shape A: seeds every top-level required key with a type-appropriate empty", () => {
+    const b = branch({
+      required: ["host", "port"],
+      descriptors: [
+        desc("host", "string"),
+        desc("port", "integer"),
+      ],
+    });
+    expect(seedBranchValue(b)).toEqual({ host: "", port: 0 });
+  });
+
+  // Shape B marker branches (e.g. cert-manager Issuer.selfSigned)
+  // should produce `{ selfSigned: {} }` — that IS legitimate K8s YAML
+  // for "use self-signed, no further config". The discriminatorKey's
+  // presence alone makes Shape B's active detector match.
+  it("Shape B marker: wraps under discriminatorKey, inner is empty when no required keys", () => {
+    const b = branch({
+      label: "selfSigned",
+      discriminatorKey: "selfSigned",
+      required: [],
+    });
+    expect(seedBranchValue(b)).toEqual({ selfSigned: {} });
+  });
+
+  // Shape B with a configurable sub-form: seeds the discriminatorKey
+  // AND populates its inner required keys so the picker click lands
+  // the operator in a sub-form with the right fields visible.
+  it("Shape B with required inner fields: seeds both layers", () => {
+    const b = branch({
+      label: "acme",
+      discriminatorKey: "acme",
+      required: ["email", "server"],
+      descriptors: [
+        desc("email", "string"),
+        desc("server", "string"),
+      ],
+    });
+    expect(seedBranchValue(b)).toEqual({
+      acme: { email: "", server: "" },
+    });
+  });
+
+  // Edge: Shape A with no required keys at all. The active detector
+  // intentionally requires req.length > 0, so this branch can't be
+  // matched by detection alone — but tracking explicit picks in the
+  // component is a bigger refactor. For now seed `{}` (the operator
+  // sees the picker buttons; switching to YAML mode is the escape).
+  it("Shape A with empty required array returns {}", () => {
+    const b = branch({ required: [] });
+    expect(seedBranchValue(b)).toEqual({});
+  });
+
+  // Descriptor schema-default takes precedence — "default: 80" on a
+  // port field is more useful than a literal 0.
+  it("prefers descriptor.default over the type-generic empty", () => {
+    const b = branch({
+      required: ["port"],
+      descriptors: [desc("port", "integer", { default: 80 })],
+    });
+    expect(seedBranchValue(b)).toEqual({ port: 80 });
+  });
+
+  // Enums where every value is valid: seeding with the first enum
+  // value (deterministic) lets the operator immediately see a valid
+  // selection rather than the placeholder. Honors default first.
+  it("prefers enum[0] when no default is set", () => {
+    const b = branch({
+      required: ["scheme"],
+      descriptors: [
+        desc("scheme", "string", { enum: ["HTTP", "HTTPS"] }),
+      ],
+    });
+    expect(seedBranchValue(b)).toEqual({ scheme: "HTTP" });
+  });
+
+  it("default beats enum when both are present", () => {
+    const b = branch({
+      required: ["scheme"],
+      descriptors: [
+        desc("scheme", "string", { default: "HTTPS", enum: ["HTTP", "HTTPS"] }),
+      ],
+    });
+    expect(seedBranchValue(b)).toEqual({ scheme: "HTTPS" });
+  });
+
+  // Only top-level descriptors should drive seeding. Branch descriptors
+  // for nested children (paths longer than 1) describe sub-fields
+  // INSIDE an object-typed required key — they shouldn't surface to
+  // the branch-root seed.
+  it("ignores non-top-level descriptors (path.length !== 1)", () => {
+    const b = branch({
+      required: ["config"],
+      descriptors: [
+        desc("config", "object"),
+        // path-length 2: child of `config`, should not be hoisted.
+        {
+          path: ["config", "nested"],
+          label: "nested",
+          type: "string",
+          required: true,
+        },
+      ],
+    });
+    expect(seedBranchValue(b)).toEqual({ config: {} });
+  });
+
+  // Required key listed in schema but missing from descriptors —
+  // common for fields the walker filtered as unsupported. Fall back
+  // to null so the key is still present (satisfies the active
+  // detector) and the operator can edit in YAML.
+  it("falls back to null for required keys without a descriptor", () => {
+    const b = branch({
+      required: ["raw", "name"],
+      descriptors: [desc("name", "string")],
+    });
+    expect(seedBranchValue(b)).toEqual({ raw: null, name: "" });
+  });
+
+  // Defensive: malformed schema.required (not an array of strings)
+  // shouldn't throw.
+  it("tolerates non-string entries in schema.required", () => {
+    const b = branch({
+      required: ["good", 42 as unknown as string, null as unknown as string],
+      descriptors: [desc("good", "string")],
+    });
+    expect(seedBranchValue(b)).toEqual({ good: "" });
+  });
+});
+
+describe("emptyForDescriptor", () => {
+  it("returns descriptor.default when set, regardless of type", () => {
+    expect(emptyForDescriptor({
+      path: ["x"], label: "x", type: "integer", required: false, default: 7,
+    })).toBe(7);
+    expect(emptyForDescriptor({
+      path: ["x"], label: "x", type: "boolean", required: false, default: true,
+    })).toBe(true);
+  });
+
+  it("returns type-appropriate empties when neither default nor enum is set", () => {
+    expect(emptyForDescriptor({ path: ["s"], label: "s", type: "string",  required: false })).toBe("");
+    expect(emptyForDescriptor({ path: ["n"], label: "n", type: "number",  required: false })).toBe(0);
+    expect(emptyForDescriptor({ path: ["i"], label: "i", type: "integer", required: false })).toBe(0);
+    expect(emptyForDescriptor({ path: ["b"], label: "b", type: "boolean", required: false })).toBe(false);
+    expect(emptyForDescriptor({ path: ["a"], label: "a", type: "array-of-primitives", required: false })).toEqual([]);
+    expect(emptyForDescriptor({ path: ["a"], label: "a", type: "array-of-objects",    required: false })).toEqual([]);
+    expect(emptyForDescriptor({ path: ["m"], label: "m", type: "kv-map",   required: false })).toEqual({});
+    expect(emptyForDescriptor({ path: ["o"], label: "o", type: "object",   required: false })).toEqual({});
+  });
+
+  it("unsupported descriptors get null so the seeded key is still present", () => {
+    expect(emptyForDescriptor({
+      path: ["u"], label: "u", type: "unsupported", required: false,
+      unsupportedReason: "x",
+    })).toBeNull();
+  });
+});

--- a/web/src/lib/schemaForm/discriminatorSeed.ts
+++ b/web/src/lib/schemaForm/discriminatorSeed.ts
@@ -41,11 +41,32 @@ import type {
  * the component is a bigger refactor.
  */
 export function seedBranchValue(branch: DiscriminatorBranch): unknown {
+  // Primitive-branched discriminator (Service.targetPort string-or-
+  // integer, Probe.timeoutSeconds, etc.). The branch's "value" is a
+  // scalar, not an object — so a type-appropriate scalar empty is
+  // the right seed. Object-shape required-key seeding doesn't apply
+  // here; the active-branch detector matches by `typeof value`.
+  const primitive = primitiveEmptyFor(branch.schema.type);
+  if (primitive !== undefined) {
+    return primitive;
+  }
+
   const inner = seedRequiredKeys(branch);
   if (branch.discriminatorKey) {
     return { [branch.discriminatorKey]: inner };
   }
   return inner;
+}
+
+/**
+ * Empty value for a primitive JSON-Schema type. Returns `undefined`
+ * for non-primitive types (caller falls through to object handling).
+ */
+function primitiveEmptyFor(type: unknown): unknown {
+  if (type === "string") return "";
+  if (type === "integer" || type === "number") return 0;
+  if (type === "boolean") return false;
+  return undefined;
 }
 
 function seedRequiredKeys(

--- a/web/src/lib/schemaForm/discriminatorSeed.ts
+++ b/web/src/lib/schemaForm/discriminatorSeed.ts
@@ -1,0 +1,117 @@
+// discriminatorSeed — initial value for a oneOf branch when the
+// operator picks it from the form's branch picker.
+//
+// Why this is non-trivial (and why #180 hurt before this existed):
+// DiscriminatorInput's active-branch detector for Shape A (no
+// `discriminatorKey` on branches) requires every key in the branch
+// schema's `required` array to be present in the value object — it
+// uses key-presence as a heuristic since the SPA doesn't do an ajv
+// hop. If the seed is `{}` the detector finds no match → no sub-form
+// renders → the operator sees the picker buttons still there with a
+// stray `{}` already in their YAML buffer.
+//
+// Fix: seed each top-level required key with a type-appropriate empty
+// (or the schema's `default` / first `enum` value when those are
+// more informative). For Shape B branches we wrap the seeded inner
+// under the `discriminatorKey` — `selfSigned: {}` style — which is
+// also legitimate K8s shape for marker branches that take no config.
+
+import type {
+  DiscriminatorBranch,
+  FieldDescriptor,
+  JSONSchema,
+} from "./types";
+
+/**
+ * Build the initial value for the operator's branch pick.
+ *
+ * Shape A → returns `{ <required-key>: <empty>, ... }` so the
+ * active-branch detector matches the chosen branch and the
+ * `BranchSubForm` renders immediately.
+ *
+ * Shape B → returns `{ [discriminatorKey]: <Shape A object> }`
+ * (the discriminator key alone is enough to make the active detector
+ * match — required-key seeding under it just gives the operator
+ * something visible to edit inside the sub-form).
+ *
+ * When the branch has no required keys at all, an empty object is
+ * returned. Shape A in that case will still leave `active = -1`
+ * (the detector's `req.length > 0` guard); this is a known niche we
+ * don't try to handle here because tracking explicit-pick state in
+ * the component is a bigger refactor.
+ */
+export function seedBranchValue(branch: DiscriminatorBranch): unknown {
+  const inner = seedRequiredKeys(branch);
+  if (branch.discriminatorKey) {
+    return { [branch.discriminatorKey]: inner };
+  }
+  return inner;
+}
+
+function seedRequiredKeys(
+  branch: DiscriminatorBranch,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const required = readRequired(branch.schema);
+  if (required.length === 0) return out;
+
+  // Index top-level descriptors by their key name. `branch.descriptors`
+  // paths are relative to the branch's value root, so a descriptor
+  // with `path: ["foo"]` is the descriptor for the top-level field
+  // `foo`. Descriptors with deeper paths are children of object-typed
+  // fields and don't drive seeding here.
+  const topLevel = new Map<string, FieldDescriptor>();
+  for (const d of branch.descriptors) {
+    if (d.path.length === 1) topLevel.set(d.path[0], d);
+  }
+
+  for (const key of required) {
+    const desc = topLevel.get(key);
+    out[key] = desc ? emptyForDescriptor(desc) : null;
+  }
+  return out;
+}
+
+/**
+ * Type-appropriate empty for a single field. Honors `default` and the
+ * first `enum` value when set — feels less arbitrary to the operator
+ * than a blanket `""` / `0`. Exported for testing.
+ */
+export function emptyForDescriptor(desc: FieldDescriptor): unknown {
+  if (desc.default !== undefined) return desc.default;
+  if (desc.enum && desc.enum.length > 0) return desc.enum[0];
+  switch (desc.type) {
+    case "string":
+      return "";
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "array-of-primitives":
+    case "array-of-objects":
+      return [];
+    case "kv-map":
+      return {};
+    case "object":
+      // Don't recurse into nested required keys. The user will see
+      // the nested object's required fields in red and fill them in;
+      // an empty object is enough to satisfy this branch's own
+      // active-detector at the top level.
+      return {};
+    case "discriminator":
+      // Nested discriminator at a required field: leave empty so the
+      // operator picks a sub-branch explicitly.
+      return {};
+    case "unsupported":
+      return null;
+    default:
+      return null;
+  }
+}
+
+function readRequired(schema: JSONSchema): string[] {
+  const raw = (schema as { required?: unknown }).required;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is string => typeof x === "string");
+}

--- a/web/src/lib/schemaForm/walker.test.ts
+++ b/web/src/lib/schemaForm/walker.test.ts
@@ -413,6 +413,50 @@ describe("walker — oneOf discriminator (#132)", () => {
     const x = ds.find((d) => d.path.join(".") === "x");
     expect(x?.type).toBe("unsupported");
   });
+
+  // Service.spec.ports[].targetPort style — primitive-branched oneOf
+  // where each branch's schema is `{type: "string"}` or
+  // `{type: "integer"}`. Pre-fix branchLabelFor fell through to
+  // "option 1 / option 2"; now it surfaces the type name itself.
+  it("labels primitive-typed branches by their type when no title is set", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        targetPort: {
+          oneOf: [{ type: "string" }, { type: "integer" }],
+        },
+      },
+    };
+    const ds = buildFieldDescriptors(schema, {
+      allowOneOfDiscriminator: true,
+    });
+    const tp = ds.find((d) => d.path.join(".") === "targetPort");
+    expect(tp?.type).toBe("discriminator");
+    expect(tp?.branches?.[0].label).toBe("string");
+    expect(tp?.branches?.[1].label).toBe("integer");
+  });
+
+  it("respects an explicit title even on primitive-typed branches", () => {
+    // Some CRDs label primitive branches with friendlier names. Title
+    // still wins so we don't downgrade those to bare type names.
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        targetPort: {
+          oneOf: [
+            { type: "string", title: "by name" },
+            { type: "integer", title: "by number" },
+          ],
+        },
+      },
+    };
+    const ds = buildFieldDescriptors(schema, {
+      allowOneOfDiscriminator: true,
+    });
+    const tp = ds.find((d) => d.path.join(".") === "targetPort");
+    expect(tp?.branches?.[0].label).toBe("by name");
+    expect(tp?.branches?.[1].label).toBe("by number");
+  });
 });
 
 describe("walker — allOf merging (#132)", () => {

--- a/web/src/lib/schemaForm/walker.test.ts
+++ b/web/src/lib/schemaForm/walker.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildFieldDescriptors } from "./walker";
+import { buildFieldDescriptors, walkRequiredUnsupported } from "./walker";
 import { buildRefResolver, findSchemaByGVK } from "./refResolver";
 import { filterSchemaForKind, getCreateOnlyPaths, getSectionResolver } from "./k8sAllowlist";
-import type { JSONSchema } from "./types";
+import type { FieldDescriptor, JSONSchema } from "./types";
 import type { OpenAPIDoc } from "../api";
 
 // Helper: build an OpenAPIDoc with a components.schemas bundle
@@ -710,5 +710,167 @@ describe("walker — array-of-objects row child sub-section stamping (#136)", ()
       ?.children?.find((c) => c.path.join(".") === "spec.template.spec")
       ?.children?.find((c) => c.path.join(".") === "spec.template.spec.containers");
     expect(containers?.rowSubSections).toBeUndefined();
+  });
+});
+
+// walkRequiredUnsupported — depth fix (see #180 follow-up).
+// Pre-fix, this only descended through `type === "object"` children,
+// so hasRequiredUnsupportedField missed required+unsupported fields
+// nested inside array-of-objects rows or discriminator branches —
+// dropping the operator into form mode only to hit a wall mid-form.
+describe("walkRequiredUnsupported — deep traversal", () => {
+  function leaf(
+    type: FieldDescriptor["type"],
+    extras: Partial<FieldDescriptor> = {},
+  ): FieldDescriptor {
+    return {
+      path: ["x"],
+      label: "x",
+      type,
+      required: false,
+      ...extras,
+    };
+  }
+  function obj(
+    children: FieldDescriptor[],
+    extras: Partial<FieldDescriptor> = {},
+  ): FieldDescriptor {
+    return {
+      path: ["o"],
+      label: "o",
+      type: "object",
+      required: false,
+      children,
+      ...extras,
+    };
+  }
+
+  it("returns false for a tree with no unsupported nodes", () => {
+    expect(walkRequiredUnsupported(leaf("string"))).toBe(false);
+    expect(walkRequiredUnsupported(obj([leaf("integer"), leaf("boolean")]))).toBe(
+      false,
+    );
+  });
+
+  it("returns true for a top-level required + unsupported", () => {
+    expect(
+      walkRequiredUnsupported(leaf("unsupported", { required: true })),
+    ).toBe(true);
+  });
+
+  it("returns false for unsupported that is NOT required (optional)", () => {
+    // The form can render around an optional unsupported field by
+    // pointing the operator at YAML mode for that one field — but
+    // shouldn't preemptively force YAML mode for the whole resource.
+    expect(walkRequiredUnsupported(leaf("unsupported"))).toBe(false);
+  });
+
+  it("descends through object.children (pre-fix behaviour, kept)", () => {
+    expect(
+      walkRequiredUnsupported(
+        obj([leaf("unsupported", { required: true })]),
+      ),
+    ).toBe(true);
+  });
+
+  it("descends through array-of-objects row children (NEW)", () => {
+    // Real-world: an array-of-objects item with a required field
+    // shaped as a JSON-Patch op (anyOf without allowOneOfDiscriminator
+    // → unsupported). The walker would mark the row required-but-
+    // unsupported; the form auto-default check needs to see this.
+    const rowChild = leaf("unsupported", { required: true });
+    const arrayOfObjects: FieldDescriptor = {
+      path: ["rules"],
+      label: "rules",
+      type: "array-of-objects",
+      required: false,
+      children: [rowChild],
+    };
+    expect(walkRequiredUnsupported(arrayOfObjects)).toBe(true);
+  });
+
+  it("descends through discriminator branches (NEW)", () => {
+    // cert-manager Issuer style: the branch descriptors carry their
+    // own sub-tree; the previous walker never reached them.
+    const branchChild = leaf("unsupported", { required: true });
+    const disc: FieldDescriptor = {
+      path: ["spec"],
+      label: "spec",
+      type: "discriminator",
+      required: false,
+      branches: [
+        {
+          label: "acme",
+          schema: {} as JSONSchema,
+          descriptors: [branchChild],
+        },
+      ],
+    };
+    expect(walkRequiredUnsupported(disc)).toBe(true);
+  });
+
+  it("descends through discriminator sharedChildren (NEW)", () => {
+    // Probe-style hinted shape: thresholds (initialDelaySeconds etc.)
+    // live alongside the branch picker as sharedChildren. They're
+    // also a place where required+unsupported can hide.
+    const shared = leaf("unsupported", { required: true });
+    const disc: FieldDescriptor = {
+      path: ["probe"],
+      label: "probe",
+      type: "discriminator",
+      required: false,
+      branches: [],
+      sharedChildren: [shared],
+    };
+    expect(walkRequiredUnsupported(disc)).toBe(true);
+  });
+
+  it("returns false for a discriminator with only optional unsupported branch fields", () => {
+    const branchChild = leaf("unsupported"); // required: false
+    const disc: FieldDescriptor = {
+      path: ["spec"],
+      label: "spec",
+      type: "discriminator",
+      required: false,
+      branches: [
+        {
+          label: "acme",
+          schema: {} as JSONSchema,
+          descriptors: [branchChild],
+        },
+      ],
+    };
+    expect(walkRequiredUnsupported(disc)).toBe(false);
+  });
+
+  it("walks the deepest unsupported through stacked containers", () => {
+    // array-of-objects → object → discriminator branch → unsupported.
+    // Pre-fix this returned false because the discriminator hop alone
+    // was a dead end; now the recursion threads through all three.
+    const deep = leaf("unsupported", { required: true });
+    const tree: FieldDescriptor = {
+      path: ["templates"],
+      label: "templates",
+      type: "array-of-objects",
+      required: false,
+      children: [
+        obj([
+          {
+            path: ["templates", "config"],
+            label: "config",
+            type: "discriminator",
+            required: false,
+            branches: [
+              {
+                label: "scheme-a",
+                schema: {} as JSONSchema,
+                descriptors: [deep],
+              },
+            ],
+          },
+        ]),
+      ],
+    };
+    expect(walkRequiredUnsupported(tree)).toBe(true);
   });
 });

--- a/web/src/lib/schemaForm/walker.ts
+++ b/web/src/lib/schemaForm/walker.ts
@@ -103,10 +103,26 @@ export function hasRequiredUnsupportedField(
   return buildFieldDescriptors(schema, options).some(walkRequiredUnsupported);
 }
 
-function walkRequiredUnsupported(d: FieldDescriptor): boolean {
+export function walkRequiredUnsupported(d: FieldDescriptor): boolean {
   if (d.type === "unsupported" && d.required) return true;
-  if (d.type === "object" && d.children) {
-    return d.children.some(walkRequiredUnsupported);
+  // Recurse into every container shape that can carry nested
+  // descriptors. The previous version only descended through `object`,
+  // so deeply-nested unsupported requireds inside array-of-objects
+  // rows or discriminator branches slipped past
+  // hasRequiredUnsupportedField and dropped operators into form mode
+  // only to hit a wall mid-form (matrix volume mounts, CRD JSON-patch
+  // ops, cert-manager Issuer branch internals, etc.).
+  if (
+    (d.type === "object" || d.type === "array-of-objects") &&
+    d.children
+  ) {
+    if (d.children.some(walkRequiredUnsupported)) return true;
+  }
+  if (d.type === "discriminator") {
+    if (d.sharedChildren?.some(walkRequiredUnsupported)) return true;
+    for (const b of d.branches ?? []) {
+      if (b.descriptors.some(walkRequiredUnsupported)) return true;
+    }
   }
   return false;
 }

--- a/web/src/lib/schemaForm/walker.ts
+++ b/web/src/lib/schemaForm/walker.ts
@@ -618,6 +618,19 @@ function branchLabelFor(
     if (keys.length === 1) return keys[0];
     if (keys.length > 0 && keys.length <= 3) return keys.join(" + ");
   }
+  // Primitive-typed branch (Service.targetPort string-or-integer):
+  // the schema declares a primitive type with no title / properties.
+  // Use the type name itself — "string" / "number" / "integer" /
+  // "boolean" — which is honest and matches what the operator will
+  // type into the resulting input.
+  if (
+    sub.type === "string" ||
+    sub.type === "number" ||
+    sub.type === "integer" ||
+    sub.type === "boolean"
+  ) {
+    return String(sub.type);
+  }
   // Last resort. Operators editing CRDs with poorly-titled schemas
   // see "option N" — imperfect but better than yaml-only.
   return `option ${(fallbackIdx ?? 0) + 1}`;


### PR DESCRIPTION
## Summary

Three related form-mode / log-view polish fixes bundled together. The discriminator fix is the headline (issue #180); the other two are small follow-ups that surfaced while testing the form-mode parity work from #182.

`Closes #180`

## Changes

### 1. Discriminator branch click no longer leaves a stray `{}` (closes #180)

`DiscriminatorInput.switchBranch` in `web/src/lib/schemaForm/SchemaForm.tsx` seeded each branch click with an empty object, which:

- For Shape A oneOf (no `discriminatorKey` on branches), failed the active-branch detector — it requires every `required` key to be present in the value. With `{}` no branch ever matched, so the picker buttons re-rendered unchanged.
- Serialized as a flow-style `{}` in the YAML buffer, where it stayed forever.

Fix: new pure helper `web/src/lib/schemaForm/discriminatorSeed.ts` builds a type-appropriate seed:

- Walks `branch.schema.required` and populates each top-level required key via `emptyForDescriptor(desc)` — empty string / 0 / false / [] / {} per type, with `desc.default` and `desc.enum[0]` preferred when available.
- For Shape B (`discriminatorKey` set), wraps the seeded inner under the discriminator key. Marker branches (cert-manager `Issuer.selfSigned`) naturally produce `{selfSigned: {}}` — legitimate K8s YAML.

After the fix the active-branch detector matches on the very next render, BranchSubForm appears with required fields visible, and the YAML buffer reflects a meaningful seed instead of `{}`.

### 2. `hasRequiredUnsupportedField` walks deeper

The auto-default-to-YAML guard at `web/src/lib/schemaForm/walker.ts:99-104` only recursed through `object.children`. Required + unsupported fields nested inside other container shapes slipped past, dropping operators into form mode only to hit a wall mid-form.

Fix: extend `walkRequiredUnsupported` to descend through:

- `array-of-objects` row children (real-world: matrix volume mounts, CRDs with required JSON-Patch op fields).
- `discriminator.branches[].descriptors` (cert-manager Issuer branch internals, etc.).
- `discriminator.sharedChildren` (Probe-style hinted-shape thresholds).

The recursion now reaches required+unsupported fields anywhere in the tree, so the form/YAML-mode auto-default is honest about which kinds the form can actually handle end-to-end.

### 3. Logs viewer wraps by default

`DEFAULT_LOGS_STATE.wrap` in `web/src/components/logs/logsState.ts` was `false`. Long structured-log lines + stack traces got truncated; operators had to horizontal-scroll to read errors. Per teammate request: flip the default to `true`.

Three coordinated changes to keep URL state correct:

- `DEFAULT_LOGS_STATE.wrap: true` (was false).
- `stateToParams` emits `wrap=false` only when opted OUT (mirror of `follow` and `timestamps`).
- `paramsToState` reads default true unless explicit `wrap=false`.

Migration behavior:
- Fresh URLs / new bookmarks → wrap on (new default).
- Existing bookmarks without `wrap=*` → wrap on (matches new default).
- Existing bookmarks with `wrap=true` → still wrap on (redundant param, harmless).
- Operators who explicitly opted out → URL carries `wrap=false`, preserved across share links.

## Test plan

- [x] `cd web && pnpm lint` — clean
- [x] `cd web && pnpm test` — 31 files, 482 tests, all green
- [x] `npx tsc -b --noEmit` — clean
- [x] New unit tests:
  - `discriminatorSeed.test.ts` — 13 cases covering Shape A required-key seeding, Shape B marker branches, Shape B with required inner fields, default/enum precedence, top-level filter, fallback for descriptor-less required keys, malformed required arrays.
  - `walker.test.ts` — 8 new cases for the deeper walk (array-of-objects, discriminator branches, sharedChildren, stacked container nesting, optional-unsupported negative case).
  - `logsState.test.ts` — 10 cases for the wrap default flip and the URL round-trip.
- [ ] Manual: open a cert-manager Issuer in form mode → spec section shows the acme/ca/vault/selfSigned picker → click `acme` → email + server inputs appear immediately, YAML shows `acme: {email: "", server: ""}` instead of a stray `{}`.
- [ ] Manual: open a CRD with deeply-nested required+unsupported fields → editor opens in YAML mode (not form mode) because the auto-default now sees the buried unsupported requireds.
- [ ] Manual: open `/clusters/.../pods/.../logs` with no `wrap=*` param → log lines wrap by default; toggle wrap off → URL gains `wrap=false`; share that URL → opens with wrap off.

## Notes for reviewers

- The discriminator seed only populates **top-level** required keys (`path.length === 1` within the branch). Nested required keys deeper inside the branch tree aren't pre-seeded — the operator sees them flagged in red and fills them in. That kept the helper small and avoided recursive seeding that could surprise operators with deep auto-populated trees.
- Shape A discriminator with **no required keys** is a niche the seed can't satisfy (the active detector's `req.length > 0` guard rejects empty-required branches even with a perfect seed). Tracking explicit-pick state in the component is a bigger refactor; documented as a known niche in the helper's docstring and the test for it.
- The deeper walker recurses through `discriminator.sharedChildren` too, even though `sharedChildren` isn't currently a common source of required+unsupported fields. Cheap defensive coverage.
- The logs wrap migration is **silent** for any operator without a bookmarked `wrap=*` URL — they just see wrap on next time. No banner / toast. Worth calling out to the team before merging in case anyone deliberately relied on the old no-wrap default.
