### PR TITLE
Helm: auto-render inspector RBAC when in-cluster backend is used

### DIFF
--- a/deploy/helm/periscope/templates/inspector-rbac.yaml
+++ b/deploy/helm/periscope/templates/inspector-rbac.yaml
@@ -1,0 +1,84 @@
+{{- /*
+  inspector-rbac.yaml — auto-rendered ClusterRole + binding granting
+  the periscope-server's ServiceAccount cluster-scope read access on
+  the resources that background workers need when at least one
+  registered cluster is the SERVER'S OWN cluster (backend: in-cluster).
+
+  Why this exists:
+
+  - Inspector hydrate (internal/cve/hydrate.go) calls Nodes().List()
+    against the local apiserver using the pod's SA token — not the
+    impersonated user's identity, because hydrate is a background
+    task with no human in the loop. Without a node read grant on the
+    SA it 403s on every cluster activation and the SPA shows empty
+    CVE severity chips.
+  - Karpenter detection lists `customresourcedefinitions` at cluster
+    scope to discover whether karpenter.sh resources are present.
+    Same in-cluster RBAC gap — same silent 403 on every activation.
+  - Image-digest collection watches pods cluster-wide to keep the
+    per-image findings cache fresh.
+
+  For agent-backed clusters this is a non-issue: the agent chart's
+  own ClusterRole already grants `get/list/watch` on `*` resources
+  (see deploy/helm/periscope-agent/templates/clusterrole.yaml), so
+  the agent's bridge SA covers it. Only the in-cluster backend
+  needs the server's own SA to have these verbs locally.
+
+  Render gates:
+    - `.Values.inspector.enabled` — the operator has opted into the
+      Inspector feature. When false, no background scans run, so
+      no RBAC is needed.
+    - any `.Values.clusters[*].backend == "in-cluster"` — at least
+      one managed cluster IS the local apiserver. When all clusters
+      are agent-backed, the local SA never makes these calls.
+
+  Operators who prefer to manage RBAC out-of-band (e.g. a separate
+  Terraform module) can override by deleting the template or setting
+  `inspector.enabled` to false and applying their own equivalent.
+*/}}
+{{- $hasInCluster := false -}}
+{{- range .Values.clusters }}
+  {{- if eq .backend "in-cluster" }}
+    {{- $hasInCluster = true -}}
+  {{- end }}
+{{- end }}
+{{- if and .Values.inspector.enabled $hasInCluster -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: periscope-inspector
+  labels:
+    {{- include "periscope.labels" . | nindent 4 }}
+rules:
+  # Inspector hydrate reads cluster nodes for EC2-instance-owner
+  # attribution (managed nodegroup / Karpenter NodeClaim / unmanaged).
+  # See internal/cve/hydrate.go.
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/status"]
+    verbs: ["get", "list", "watch"]
+  # Image-digest watch — feeds the per-pod severity chip cache.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # Karpenter detection lists CRDs at cluster scope to discover
+  # whether karpenter.sh resources are installed.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: periscope-inspector
+  labels:
+    {{- include "periscope.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: periscope-inspector
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "periscope.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/periscope/values.yaml
+++ b/deploy/helm/periscope/values.yaml
@@ -501,6 +501,17 @@ watchStreams:
 # lazily on first activation (~10-30s scan), keeps it fresh via the
 # pod watch hook + a 6h TTL, and serves reads at <1ms thereafter. The
 # SPA never calls Inspector directly.
+#
+# K8s RBAC: when `inspector.enabled: true` AND at least one entry in
+# `clusters[]` is `backend: in-cluster`, the chart auto-renders a
+# `periscope-inspector` ClusterRole + binding granting the server's
+# ServiceAccount cluster-scope `get/list/watch` on nodes, pods, and
+# customresourcedefinitions. These reads are needed by the background
+# CVE hydrate (Nodes().List for instance-owner attribution), the
+# image-digest watch (pods), and karpenter detection (CRDs at cluster
+# scope). Agent-backed clusters cover this via the agent chart's own
+# ClusterRole, so the local RBAC is only required when in-cluster
+# backend is used. See templates/inspector-rbac.yaml.
 # -----------------------------------------------------------------------------
 inspector:
   # Opt-in. Set to true only after IAM + account enablement above.

--- a/docs/setup/cluster-rbac.md
+++ b/docs/setup/cluster-rbac.md
@@ -736,3 +736,45 @@ serves subsequent reads in under a millisecond and refreshes every
 Audit note: Inspector reads are internal metadata fetches, not user
 actions — they do not emit audit rows. AWS CloudTrail records the
 underlying API calls against the periscope-server's role.
+
+### K8s RBAC for in-cluster backend (auto-rendered)
+
+When `inspector.enabled: true` AND at least one entry in `clusters[]`
+uses `backend: in-cluster`, the chart auto-renders a
+`periscope-inspector` ClusterRole + ClusterRoleBinding that grant
+the periscope-server's ServiceAccount cluster-scope
+`get / list / watch` on three resources:
+
+| Resource | Why |
+|---|---|
+| `nodes` (+ `/status`) | Inspector hydrate ([`internal/cve/hydrate.go`](../../internal/cve/hydrate.go)) lists nodes to extract EC2 instance IDs from `Spec.ProviderID` and classify each instance as managed-nodegroup / Karpenter NodeClaim / unmanaged. |
+| `pods` | Image-digest watch keeps the per-pod severity-chip cache fresh — without it the chips render stale or empty until a manual refresh. |
+| `customresourcedefinitions` (`apiextensions.k8s.io`) | Karpenter detection lists CRDs at cluster scope to discover whether `karpenter.sh` resources are installed; otherwise periscope logs a 403 on every cluster activation. |
+
+These reads are used by **background workers** (no human in the loop),
+so they go through the pod's SA directly — not through the
+impersonated user identity that user-driven UI reads use. The
+existing `periscope-impersonator` ClusterRole only grants `impersonate`
+verbs, which is why the chart needs to add this extra grant when the
+in-cluster backend is in play.
+
+**Agent-backed clusters do not need this** — the
+[`periscope-agent` chart](../../deploy/helm/periscope-agent/templates/clusterrole.yaml)
+already grants `get / list / watch` on `*` resources to the agent's
+own SA, so background reads through the tunnel are covered there.
+The auto-rendered ClusterRole on the server side is only emitted
+when at least one cluster in `.Values.clusters` has
+`backend: in-cluster`.
+
+Operators who manage RBAC out-of-band (e.g. a separate Terraform
+module) can override by either keeping `inspector.enabled: false` and
+applying equivalent RBAC themselves, or by deleting the rendered
+template post-`helm template`.
+
+To inspect what would be applied:
+
+```bash
+helm template periscope deploy/helm/periscope \
+  --values my-values.yaml \
+  --show-only templates/inspector-rbac.yaml
+```

--- a/docs/setup/values.md
+++ b/docs/setup/values.md
@@ -356,6 +356,8 @@ Surfaces Inspector v2 findings inline on the Nodes / Pods / Workloads pages.
 2. Grant the periscope-server's Pod Identity / IRSA role the four `inspector2:*` permissions listed in [`cluster-rbac.md`](./cluster-rbac.md#aws-inspector-v2-optional-v11).
 3. Set `inspector.enabled: true` in your Helm values.
 
+When at least one entry in `clusters[]` uses `backend: in-cluster`, the chart **auto-renders** a `periscope-inspector` ClusterRole + ClusterRoleBinding granting the server's ServiceAccount the K8s reads (`nodes`, `pods`, `customresourcedefinitions`) the background hydrate / image-digest watch / karpenter detect need. See [`cluster-rbac.md`  K8s RBAC for in-cluster backend](./cluster-rbac.md#k8s-rbac-for-in-cluster-backend-auto-rendered) for the full rationale. Agent-backed clusters cover this via the agent chart's own ClusterRole.
+
 | Value | Type | Default | Description |
 |---|---|---|---|
 | `inspector.enabled` | bool | `false` | Master switch. Renders no env vars (and no goroutines run) when false. |


### PR DESCRIPTION
## Summary

When `inspector.enabled: true` AND at least one entry in `clusters[]` uses `backend: in-cluster`, the chart now auto-renders a `periscope-inspector` ClusterRole + ClusterRoleBinding granting the periscope-server's ServiceAccount cluster-scope `get / list / watch` on the resources its background workers need. Without this grant the workers 403 silently on every cluster activation — the SPA shows empty CVE chips and the pod logs ship a karpenter-detect error every poll.

The chart only solves the AWS Inspector / EC2 IAM side of the inspector feature today; the in-cluster K8s RBAC was a known-missing piece that operators had to discover by reading the 403s.

## What changed

### New template — `deploy/helm/periscope/templates/inspector-rbac.yaml`

Renders a `periscope-inspector` ClusterRole (and its binding to the server's SA) when **both** of these are true:

- `.Values.inspector.enabled` — operator opted into the Inspector feature.
- At least one entry in `.Values.clusters[]` has `backend: in-cluster` — at least one managed cluster IS the local apiserver, so the server's own SA actually does these reads.

The role grants three resource sets:

| Resource | Why |
|---|---|
| `nodes` (+ `/status`) | Inspector hydrate ([`internal/cve/hydrate.go`](https://github.com/gnana997/periscope/blob/main/internal/cve/hydrate.go)) lists nodes to extract EC2 instance IDs from `Spec.ProviderID` and classify each instance as managed-nodegroup / Karpenter NodeClaim / unmanaged. |
| `pods` | Image-digest watch keeps the per-pod severity-chip cache fresh. |
| `customresourcedefinitions` (`apiextensions.k8s.io`) | Karpenter detection lists CRDs at cluster scope to discover whether `karpenter.sh` resources are installed. Without this, every cluster activation logs a 403. |

### Why agent-backed clusters don't need this

The `periscope-agent` chart's [`clusterrole.yaml`](https://github.com/gnana997/periscope/blob/main/deploy/helm/periscope-agent/templates/clusterrole.yaml) already grants `get / list / watch` on `*` resources to the agent's own ServiceAccount. Background reads on agent-backed clusters go through the tunnel and bind against the agent's RBAC, not the server's. So the new server-side template gates on `$hasInCluster` and emits nothing when all clusters are agent-backed.

### Docs

- `docs/setup/cluster-rbac.md` — new "K8s RBAC for in-cluster backend (auto-rendered)" subsection under the existing AWS Inspector v2 chapter. Resource-by-resource rationale, agent-cluster carve-out, override instructions.
- `docs/setup/values.md` — one-line forward link from the Inspector setup steps to the new subsection.
- `deploy/helm/periscope/values.yaml` — inline comment block on the `inspector:` value explaining what the chart auto-renders.

### Why no `values.schema.json` change

The template gates on two values that already exist in the schema with the right types:

- `inspector.enabled` — already declared `boolean`.
- `clusters[].backend` — already declared as `enum: ["eks", "kubeconfig", "in-cluster", "agent"]`.

No new value introduced.

## Test plan

- [x] `helm template test deploy/helm/periscope --show-only templates/inspector-rbac.yaml` across 5 gate combinations:

  | Scenario | inspector | clusters[*].backend | Renders? |
  |---|---|---|---|
  | A: chart defaults | off | empty | no ✓ |
  | B: inspector on, no clusters | on | empty | no ✓ |
  | C: inspector on, in-cluster | on | `in-cluster` | **yes** ✓ |
  | D: inspector on, agent only | on | `agent` | no ✓ |
  | E: inspector off, in-cluster | off | `in-cluster` | no ✓ |

- [x] `kubectl apply --dry-run=client -f <rendered>` — both ClusterRole and ClusterRoleBinding pass apiserver schema validation.

- [ ] Manual: set `inspector.enabled: true` in an in-cluster deploy, `helm upgrade`, observe pod logs no longer emit `karpenter detect failed ... cannot list resource "customresourcedefinitions"` 403s on cluster activation.

- [ ] Manual: open Pods / Workloads pages in the SPA on an in-cluster deploy with Inspector v2 enabled — severity chips should populate after the first hydrate (~10-30s).

## Notes for reviewers

1. **Scope on the karpenter-detect CRD read.** Karpenter detection runs unconditionally on every cluster activation (not just when Inspector is enabled), so strictly speaking the CRD read belongs in a different grant. We're bundling it under `inspector.enabled` because (a) it's the most common feature combo that needs it — operators who turn on Inspector almost always have Karpenter-aware clusters too, and (b) splitting it into a separate `karpenter.enabled` flag would add a value and a template for one verb. If operators want karpenter detect without Inspector, they can set `inspector.enabled: true` and ignore the AWS-side cost (Inspector v2 only bills when its own scans run; the K8s side is free). Worth a follow-up if anyone files an issue.

2. **No `kind`-cluster regression test.** The helm-template + kubectl-dry-run combo verifies the manifest shape; a full kind deploy would exercise the actual SA → 200 on `kubectl auth can-i list nodes`. Skipped here because the chart fix is mechanical and the runtime verification belongs in the operator's own upgrade window.

3. **No backwards-incompatible change.** Existing v1.0.x deployments with `inspector.enabled: false` (the default) see zero template change. Existing v1.1+ deployments that already enabled Inspector and manually applied the K8s RBAC will see the chart add a duplicate `periscope-inspector` ClusterRole — Helm will warn on the conflict if the operator applied a manifest with the same name; otherwise it's additive (RBAC is a union of grants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
