### PR TITLE
Helm: cluster-admin tier opt-in + shared-mode RBAC default (closes #84, #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ tag.
 
 ## [Unreleased]
 
+### Changed
+
+- **Helm: cluster-admin tier binding is now opt-in** (#84). Default
+  install of both `periscope` and `periscope-agent` charts no longer
+  renders the `periscope-tier-admin` ClusterRoleBinding, so AWS
+  Guardrails and CIS Kubernetes Benchmark 5.1.1 pass out of the box.
+  New `clusterRBAC.adminTier.{enabled, clusterRoleName}` value gates
+  the binding and lets operators repoint at a tighter custom
+  ClusterRole. The chart fails loudly at template time when
+  `auth.authorization.groupTiers` maps any group to `admin` but
+  `clusterRBAC.adminTier.enabled` is false — a silent 403 storm was
+  the alternative.
+  **Migration**: if your release was on v1.0.x with tier mode AND any
+  `auth.authorization.groupTiers` value resolving to `admin`, set
+  `clusterRBAC.adminTier.enabled: true` on upgrade to preserve current
+  behaviour. The chart pre-render check will surface the same recipe
+  with a specific group name on `helm template` /
+  `helm upgrade --dry-run`.
+
+### Fixed
+
+- **Helm: shared authz mode + in-cluster backend now wires the SA RBAC
+  by default** (#142). The previous default left the periscope
+  ServiceAccount with zero cluster-scoped permissions when
+  `auth.authorization.mode: shared` and any `clusters[].backend:
+  in-cluster`, causing every list-call to return 403 and the SPA
+  `OverviewPage` to crash on `.length` of `null`. The chart now
+  auto-renders a `periscope-shared` ClusterRoleBinding pointing the
+  SA at `clusterRBAC.sharedRoleName` (default `view` — read-only and
+  safe). Operators who manage RBAC out-of-band can suppress by setting
+  `clusterRBAC.sharedRoleName: ""`. The kind quickstart
+  (`examples/values-kind.yaml`) is updated to `mode: shared` +
+  `sharedRoleName: edit` to demonstrate the clean default.
+
 ## [1.0.7] - 2026-05-12
 
 ### Added

--- a/deploy/helm/periscope-agent/templates/cluster-rbac.yaml
+++ b/deploy/helm/periscope-agent/templates/cluster-rbac.yaml
@@ -53,7 +53,12 @@ subjects:
   - kind: Group
     name: periscope-tier:write
     apiGroup: rbac.authorization.k8s.io
+{{- if and .Values.clusterRBAC.adminTier .Values.clusterRBAC.adminTier.enabled }}
 ---
+# Issue #84 — opt-in cluster-admin binding for the admin tier.
+# Default `clusterRoleName: cluster-admin` preserves v1.0.x behaviour
+# when adminTier.enabled=true; operators can repoint at a tighter
+# custom ClusterRole via clusterRBAC.adminTier.clusterRoleName.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -63,11 +68,12 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Values.clusterRBAC.adminTier.clusterRoleName | default "cluster-admin" }}
 subjects:
   - kind: Group
     name: periscope-tier:admin
     apiGroup: rbac.authorization.k8s.io
+{{- end }}
 
 ---
 # 2a. Triage tier — view + debug verbs, no spec mutation.

--- a/deploy/helm/periscope-agent/values.schema.json
+++ b/deploy/helm/periscope-agent/values.schema.json
@@ -176,11 +176,27 @@
     },
     "clusterRBAC": {
       "type": "object",
-      "description": "Auto-create the ClusterRoleBindings that map periscope-tier:* groups to K8s built-in roles (read→view, write→edit, admin→cluster-admin) plus the custom triage + maintain ClusterRoles. Without these bindings, requests reaching this managed cluster get 403 Forbidden — see Issue 2.5 in deployment-journey.md. Default true so deployment-out-of-the-box works; disable if you want to ship a tighter custom set.",
+      "description": "Auto-create the ClusterRoleBindings that map periscope-tier:* groups to K8s built-in roles (read→view, write→edit) plus the custom triage + maintain ClusterRoles. The admin tier → cluster-admin binding is now opt-in via adminTier.enabled (#84). Without these bindings, requests reaching this managed cluster get 403 Forbidden — see Issue 2.5 in deployment-journey.md. Default enabled=true so deployment-out-of-the-box works; disable if you want to ship a tighter custom set.",
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "When true, the chart installs ClusterRoleBindings for all five tier groups + the triage/maintain custom ClusterRoles. Set false to manage tier bindings yourself."
+          "description": "When true, the chart installs ClusterRoleBindings for the read / triage / write / maintain tier groups + the triage/maintain custom ClusterRoles. The admin tier binding is gated separately by adminTier.enabled."
+        },
+        "adminTier": {
+          "type": "object",
+          "description": "Issue #84: cluster-admin tier binding is opt-in. Default install does not render the periscope-tier:admin ClusterRoleBinding so CIS 5.1.1 / AWS Guardrails pass out of the box.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Render the periscope-tier:admin ClusterRoleBinding on this managed cluster. Default false."
+            },
+            "clusterRoleName": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Target ClusterRole for the admin tier. Defaults to `cluster-admin`. Operators who want a tighter posture can point at a custom role they ship out-of-band."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/deploy/helm/periscope-agent/values.yaml
+++ b/deploy/helm/periscope-agent/values.yaml
@@ -144,13 +144,24 @@ clusterRole:
 # When enabled, the chart installs:
 #   ClusterRoleBinding periscope-tier-read    → view
 #   ClusterRoleBinding periscope-tier-write   → edit
-#   ClusterRoleBinding periscope-tier-admin   → cluster-admin
+#   ClusterRoleBinding periscope-tier-admin   → cluster-admin (OPT-IN, #84)
 #   ClusterRoleBinding periscope-tier-triage  → periscope-triage (custom)
 #   ClusterRoleBinding periscope-tier-maintain→ periscope-maintain (custom)
 # plus the two custom ClusterRoles. Identical tier semantics to the
 # server chart's clusterRBAC.
 clusterRBAC:
   enabled: true
+
+  # cluster-admin tier binding — OPT-IN (#84).
+  #
+  # The default install no longer renders the periscope-tier:admin →
+  # cluster-admin ClusterRoleBinding. AWS Guardrails and CIS Kubernetes
+  # Benchmark 5.1.1 both flag this binding on its YAML alone. Opt in by
+  # setting adminTier.enabled=true; optionally redirect to a tighter
+  # custom ClusterRole via adminTier.clusterRoleName.
+  adminTier:
+    enabled: false
+    clusterRoleName: cluster-admin
 
 resources:
   requests:

--- a/deploy/helm/periscope/templates/cluster-rbac.yaml
+++ b/deploy/helm/periscope/templates/cluster-rbac.yaml
@@ -10,6 +10,27 @@
     {{- $hasInCluster = true -}}
   {{- end }}
 {{- end }}
+
+{{- /*
+  Issue #84 migration guard. The default cluster-admin ClusterRoleBinding
+  is now opt-in via clusterRBAC.adminTier.enabled. If the operator left
+  it off but explicitly mapped at least one IdP group to the admin tier,
+  their impersonated admins would land on zero matching RBAC at apiserver
+  evaluation time — a silent 403 storm in the dashboard. Fail loudly at
+  template time with the migration recipe instead.
+*/}}
+{{- $adminTierEnabled := false -}}
+{{- if .Values.clusterRBAC.adminTier }}
+  {{- $adminTierEnabled = .Values.clusterRBAC.adminTier.enabled -}}
+{{- end }}
+{{- if and (not $adminTierEnabled) (eq .Values.auth.authorization.mode "tier") }}
+  {{- range $group, $tier := .Values.auth.authorization.groupTiers }}
+    {{- if eq $tier "admin" }}
+      {{- fail (printf "auth.authorization.groupTiers maps %q to the admin tier, but clusterRBAC.adminTier.enabled is false. Either set clusterRBAC.adminTier.enabled=true (restores v1.0.x behaviour — renders the cluster-admin ClusterRoleBinding), or remap %q to a non-admin tier (read|triage|write|maintain). See CHANGELOG.md and docs/setup/cluster-rbac.md for the v1.x admin-tier opt-in note (#84)." $group $group) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- if or .Values.clusterRBAC.enabled $hasInCluster -}}
 {{- /*
   cluster-rbac.yaml — per-cluster RBAC manifests for tier-mode
@@ -104,7 +125,12 @@ subjects:
   - kind: Group
     name: periscope-tier:write
     apiGroup: rbac.authorization.k8s.io
+{{- if and .Values.clusterRBAC.adminTier .Values.clusterRBAC.adminTier.enabled }}
 ---
+# Issue #84 — opt-in cluster-admin binding for the admin tier.
+# Default `clusterRoleName: cluster-admin` preserves v1.0.x behaviour
+# when adminTier.enabled=true; operators can repoint at a tighter
+# custom ClusterRole via clusterRBAC.adminTier.clusterRoleName.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -114,11 +140,12 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Values.clusterRBAC.adminTier.clusterRoleName | default "cluster-admin" }}
 subjects:
   - kind: Group
     name: periscope-tier:admin
     apiGroup: rbac.authorization.k8s.io
+{{- end }}
 
 ---
 # 3a. Triage tier — view + debug verbs, no spec mutation.
@@ -296,4 +323,31 @@ subjects:
   - kind: Group
     name: periscope-tier:maintain
     apiGroup: rbac.authorization.k8s.io
+
+{{- /*
+  Issue #142: shared authz mode + in-cluster backend.
+  When the server's own SA is the apiserver caller (no impersonation
+  chain), the chart auto-renders this ClusterRoleBinding so the
+  dashboard's list / detail / overview calls don't 403 silently. The
+  read-only `view` default is safe; flip clusterRBAC.sharedRoleName
+  to `edit` or `cluster-admin` for eval / dev setups, or to "" to
+  suppress entirely (operators who manage RBAC out-of-band).
+*/}}
+{{- if and $hasInCluster (eq .Values.auth.authorization.mode "shared") (ne (.Values.clusterRBAC.sharedRoleName | default "") "") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: periscope-shared
+  labels:
+    {{- include "periscope.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.clusterRBAC.sharedRoleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "periscope.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/periscope/values.schema.json
+++ b/deploy/helm/periscope/values.schema.json
@@ -189,7 +189,31 @@
     "clusterRBAC": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "bridgeGroup": {
+          "type": "string",
+          "description": "K8s group the EKS Access Entry binds Periscope's pod principal to on each managed cluster. Referenced by the periscope-impersonator ClusterRoleBinding."
+        },
+        "adminTier": {
+          "type": "object",
+          "description": "Issue #84: cluster-admin tier binding is opt-in. Default install does not render the periscope-tier:admin ClusterRoleBinding so CIS 5.1.1 / AWS Guardrails pass out of the box.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Render the periscope-tier:admin ClusterRoleBinding. Default false."
+            },
+            "clusterRoleName": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Target ClusterRole for the admin tier. Defaults to `cluster-admin`. Operators who want a tighter posture can point at a custom role (e.g. `cluster-admin-no-rbac` they ship out-of-band)."
+            }
+          },
+          "additionalProperties": false
+        },
+        "sharedRoleName": {
+          "type": "string",
+          "description": "Issue #142: when auth.authorization.mode is `shared` and any clusters[].backend is `in-cluster`, the chart renders a periscope-shared ClusterRoleBinding pointing the periscope SA at this ClusterRole. Default `view` (read-only, safe). Set to empty string to suppress."
+        }
       }
     },
     "podIdentity": {

--- a/deploy/helm/periscope/values.yaml
+++ b/deploy/helm/periscope/values.yaml
@@ -586,6 +586,40 @@ clusterRBAC:
   # ClusterRoleBinding for periscope-impersonator references this name.
   bridgeGroup: periscope-bridge
 
+  # cluster-admin tier binding — OPT-IN (#84).
+  #
+  # The default install no longer renders the periscope-tier:admin →
+  # cluster-admin ClusterRoleBinding. AWS Guardrails and CIS Kubernetes
+  # Benchmark 5.1.1 both flag this binding on its YAML alone (the
+  # scanners cannot see the gating chain that requires tier mode AND
+  # an admin-mapped IdP group). Opt in by setting adminTier.enabled=true
+  # below; optionally redirect to a tighter ClusterRole via
+  # adminTier.clusterRoleName.
+  #
+  # Migration: if your release was on v1.0.x with tier mode AND any
+  # auth.authorization.groupTiers value resolving to `admin`, set
+  # adminTier.enabled=true on upgrade to preserve current behaviour.
+  # Otherwise the operators with admin-tier mapping will see a
+  # template-time `helm` failure flagging the misconfiguration.
+  adminTier:
+    enabled: false
+    clusterRoleName: cluster-admin
+
+  # Shared authz mode — periscope SA needs direct RBAC (#142).
+  #
+  # When auth.authorization.mode is "shared" and at least one
+  # clusters[] entry is `backend: in-cluster`, the periscope SA
+  # calls the local apiserver directly (no impersonation). The chart
+  # renders a periscope-shared ClusterRoleBinding pointing the SA at
+  # this ClusterRole so the dashboard "just works" out of the box.
+  #
+  # Default `view` is read-only and safe — sufficient for the SPA's
+  # list / detail / overview pages. Flip to `edit` or `cluster-admin`
+  # for eval / dev setups where everyone hitting the dashboard should
+  # have write access. Set to "" to suppress the binding entirely
+  # (operators who manage RBAC out-of-band).
+  sharedRoleName: view
+
 # -----------------------------------------------------------------------------
 # Agent backend (#42) — per-cluster periscope-agent that dials out to
 # the central server over a long-lived WebSocket. Enabling this:

--- a/docs/setup/cluster-rbac.md
+++ b/docs/setup/cluster-rbac.md
@@ -134,6 +134,32 @@ matters, use `tier` or `raw`.
 
 ---
 
+### Single-cluster shorthand (in-cluster backend)
+
+When `auth.authorization.mode: shared` AND any `clusters[].backend: in-cluster`, you don't need the Access Entry / external bridge binding above. The chart **auto-renders** a `periscope-shared` ClusterRoleBinding pointing the periscope ServiceAccount at the ClusterRole you name in `clusterRBAC.sharedRoleName` (default `view`).
+
+```yaml
+auth:
+  authorization:
+    mode: shared      # default
+clusterRBAC:
+  sharedRoleName: view  # default — read-only, safe. Use `edit` for write access.
+clusters:
+  - name: local
+    backend: in-cluster
+```
+
+Choose the role that matches "everyone hitting the dashboard":
+
+| `sharedRoleName` | Reads | Writes | Use case |
+|---|---|---|---|
+| `view` (default) | yes | no | Production "look-only" dashboards |
+| `edit` | yes | namespaced | Most dev / staging / lab clusters |
+| `cluster-admin` | yes | all (incl. RBAC) | Local kind / single-operator demos. Note: trips CIS 5.1.1 / AWS Guardrails. |
+| `""` | n/a | n/a | Suppress the auto-binding; manage RBAC out-of-band. |
+
+Before [#142] this auto-binding didn't exist, and shared + in-cluster left the SA with zero RBAC — every list call returned 403 and the SPA's overview page crashed on `.length` of `null`. The fix is the chart change; this section is the new contract.
+
 ## Mode 2: `tier` (recommended once you've outgrown shared)
 
 Five built-in tiers; map your existing IdP groups to one of them.
@@ -181,6 +207,23 @@ broaden per cluster.
    - `ClusterRoleBinding/periscope-tier-admin` → `cluster-admin`
    - `ClusterRole/periscope-triage` + `ClusterRoleBinding/periscope-tier-triage`
    - `ClusterRole/periscope-maintain` + `ClusterRoleBinding/periscope-tier-maintain`
+
+   > **`admin` tier is opt-in as of v1.1 (#84).** The
+   > `ClusterRoleBinding/periscope-tier-admin → cluster-admin` line in
+   > the list above renders only when you set
+   > `clusterRBAC.adminTier.enabled: true` in values. AWS Guardrails
+   > and CIS Kubernetes Benchmark 5.1.1 flag the `cluster-admin`
+   > binding's YAML alone (the scanners cannot see the gating chain),
+   > so default-off keeps the default install clean.
+   >
+   > - To preserve v1.0.x behaviour on upgrade: set
+   >   `clusterRBAC.adminTier.enabled: true`.
+   > - To run the admin tier against a tighter custom role: set
+   >   `clusterRBAC.adminTier.clusterRoleName: <my-role>`.
+   > - If `auth.authorization.groupTiers` maps any group to `admin`
+   >   but `adminTier.enabled` is false, `helm template` fails with
+   >   the migration recipe — silent 403s are not allowed to slip
+   >   through.
 
 3. **Map IdP groups to tiers** in `values.yaml`:
 

--- a/docs/setup/values.md
+++ b/docs/setup/values.md
@@ -253,6 +253,9 @@ Tier-mode RBAC manifests rendered for the central cluster. See
 |---|---|---|---|
 | `clusterRBAC.enabled` | bool | `false` | Render the periscope-tier ClusterRoles + bindings. |
 | `clusterRBAC.bridgeGroup` | string | `periscope-bridge` | K8s group your EKS Access Entry binds the pod principal to. |
+| `clusterRBAC.adminTier.enabled` | bool | `false` | **(#84)** Render the `periscope-tier:admin` ClusterRoleBinding. OFF by default so CIS 5.1.1 / AWS Guardrails pass. Set true to restore v1.0.x behaviour. |
+| `clusterRBAC.adminTier.clusterRoleName` | string | `cluster-admin` | Target ClusterRole for the admin tier when enabled. Repoint at a tighter custom role for a less-permissive admin tier. |
+| `clusterRBAC.sharedRoleName` | string | `view` | **(#142)** When `auth.authorization.mode: shared` and any `clusters[].backend: in-cluster`, the chart auto-renders a `periscope-shared` ClusterRoleBinding pointing the SA at this ClusterRole. Default `view` is read-only. Use `edit` for write access, or empty `""` to suppress entirely. |
 
 ## agent
 
@@ -318,7 +321,9 @@ topology decision matrix.
 | Value | Type | Default | Notes |
 |---|---|---|---|
 | `clusterRole.enabled` | bool | `true` | Bind the agent SA to a ClusterRole granting `get/list/watch` on every kind + `impersonate` on users/groups/SAs. |
-| `clusterRBAC.enabled` | bool | `true` | Install tier ClusterRoleBindings on the managed cluster (`periscope-tier-read/write/admin/triage/maintain`). Required for impersonation to actually authorize. |
+| `clusterRBAC.enabled` | bool | `true` | Install tier ClusterRoleBindings on the managed cluster (`periscope-tier-read/write/triage/maintain` (the admin binding is opt-in — see below)). Required for impersonation to actually authorize. |
+| `clusterRBAC.adminTier.enabled` | bool | `false` | **(#84)** Render the `periscope-tier:admin` ClusterRoleBinding on the managed cluster. OFF by default so CIS 5.1.1 / AWS Guardrails pass. Set true to restore v1.0.x behaviour. |
+| `clusterRBAC.adminTier.clusterRoleName` | string | `cluster-admin` | Target ClusterRole for the admin tier when enabled. Repoint at a tighter custom role you ship out-of-band. |
 
 ## resources / security context
 

--- a/examples/values-kind.yaml
+++ b/examples/values-kind.yaml
@@ -35,18 +35,21 @@ auth:
     clientID: ""
     clientSecret: ""              # not used in dev mode
   authorization:
-    mode: tier
-    groupTiers:
-      # dev@local resolves to admin tier so the impersonation chain
-      # in the chart's cluster-rbac.yaml grants cluster-admin via
-      # the periscope-tier:admin ClusterRoleBinding. Required for the
-      # dev user to actually see resources in the SPA — shared mode
-      # left the SA with no RBAC and every list-call returned 403.
-      periscope-users: admin
+    # Shared mode is the simplest path for local kind: the periscope
+    # SA hits its own apiserver directly (no impersonation chain).
+    # Chart auto-renders a `periscope-shared` ClusterRoleBinding
+    # pointing the SA at the role named in clusterRBAC.sharedRoleName
+    # (default `view`, raised below to `edit` so the apply flow works).
+    # Before #142 the SA had zero RBAC in this mode and every
+    # list-call returned 403 — the workaround was to switch to tier
+    # mode with admin-mapped groups (which then renders cluster-admin,
+    # tripping CIS 5.1.1). Both broken paths are fixed; this file
+    # demonstrates the clean default.
+    mode: shared
   dev:
     subject: dev@local
     email:   dev@local
-    groups:  [periscope-users]    # matches a typical default-tier admin group
+    groups:  [periscope-users]    # purely an audit identity in shared mode
 
 # ─── Secret ──────────────────────────────────────────────────────────
 # `plain` mode with empty value → chart renders an empty Secret so the
@@ -64,6 +67,13 @@ secrets:
 clusters:
   - name: kind-local
     backend: in-cluster
+
+# ─── Cluster RBAC — shared-mode role override ────────────────────────
+# Bump from the default `view` (read-only) to `edit` so the dashboard's
+# apply / scale / restart flows work on the local cluster. Stays well
+# clear of cluster-admin — CIS 5.1.1 / AWS Guardrails still pass.
+clusterRBAC:
+  sharedRoleName: edit
 
 # ─── Resource limits — sized for a single-node kind/k3d cluster ──────
 resources:


### PR DESCRIPTION
## Summary

Two RBAC-posture issues bundled because they touch the same template, the same `clusterRBAC.*` value tree, and tell one cohesive default-install story:

- **#84** — the default `cluster-admin` ClusterRoleBinding is now opt-in. AWS Guardrails and CIS Kubernetes Benchmark 5.1.1 pass on a fresh `helm install` of both charts.
- **#142** — when `auth.authorization.mode: shared` and any `clusters[].backend: in-cluster`, the chart auto-renders a `periscope-shared` ClusterRoleBinding pointing the periscope ServiceAccount at a configurable ClusterRole (default `view` — read-only, safe). The 403-storm-then-SPA-crash on default-mode kind installs is fixed.

Closes #84 
Closes #142 

After this merges, the default install posture is:

- 0 `cluster-admin` ClusterRoleBindings rendered
- Shared mode + in-cluster works out of the box (read-only by default)
- CIS 5.1.1 / AWS Guardrails clean

## What changed

### Server chart (`deploy/helm/periscope/`)

- **`values.yaml`** — new `clusterRBAC.adminTier.{enabled, clusterRoleName}` block (default `false` / `cluster-admin`) and new `clusterRBAC.sharedRoleName: view` value, both with rationale comments.
- **`values.schema.json`** — strict validators for both. `adminTier` carries `additionalProperties: false` so misspelled subkeys fail at lint time.
- **`templates/cluster-rbac.yaml`** — three changes:
  1. Existing `periscope-tier-admin` ClusterRoleBinding wrapped in `{{- if and .Values.clusterRBAC.adminTier .Values.clusterRBAC.adminTier.enabled }}`.
  2. Its `roleRef.name` parametrized to `clusterRBAC.adminTier.clusterRoleName | default "cluster-admin"`.
  3. New `periscope-shared` ClusterRoleBinding appended at the end, gated on `$hasInCluster && eq .Values.auth.authorization.mode "shared" && (ne .Values.clusterRBAC.sharedRoleName "")`.
  4. Migration guard: `helm template` fails loudly when `auth.authorization.groupTiers.*` maps any group to `admin` but `clusterRBAC.adminTier.enabled` is false. The error names the offending group and the one-line migration recipe. No silent 403 storms.

### Agent chart (`deploy/helm/periscope-agent/`)

- **`values.yaml` + `values.schema.json`** — mirror the `adminTier` block. The agent chart doesn't get `sharedRoleName` (that concern is server-side; the agent's own ClusterRole is independent).
- **`templates/cluster-rbac.yaml`** — same gate + parametrize for the admin binding. The agent doesn't have access to `auth.authorization.groupTiers` (server-side value), so no migration guard there; the server chart's guard catches the misconfiguration first.

### Examples

- **`examples/values-kind.yaml`** — switched from `mode: tier` + `groupTiers: { periscope-users: admin }` (the previous workaround that tripped CIS 5.1.1 to dodge #142) to `mode: shared` + `sharedRoleName: edit`. The kind quickstart now demonstrates the clean default: read+write access on the local cluster, no `cluster-admin` reference anywhere in the rendered output.

### Docs

- **`docs/setup/values.md`** — 5 new value rows across the server + agent tables (`adminTier.{enabled,clusterRoleName}` per chart, `sharedRoleName` server-only).
- **`docs/setup/cluster-rbac.md`** — new "Single-cluster shorthand (in-cluster backend)" subsection under Mode 1 (shared), and an opt-in callout under Mode 2 (tier) Setup. Resource-by-resource table for picking the `sharedRoleName`.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering both changes + migration recipes.

## Migration recipes

| Scenario | Action on upgrade |
|---|---|
| v1.0.x release on `tier` mode WITH any `auth.authorization.groupTiers.*: admin` | Set `clusterRBAC.adminTier.enabled: true` to preserve current behaviour. The chart will refuse to render if you forget — error message includes the offending group name. |
| v1.0.x release on `tier` mode WITHOUT any `admin` mapping | No action. The `periscope-tier-admin` binding wasn't doing anything anyway; now it stays unrendered. |
| v1.0.x release on `shared` mode + in-cluster backend | No action. The chart now does what your manual `kubectl create clusterrolebinding periscope-shared --clusterrole=cluster-admin --serviceaccount=...` workaround did, but defaulting to `view` (read-only). Bump to `clusterRBAC.sharedRoleName: edit` if you used the write-path workaround. |
| v1.0.x release on `raw` mode | No action. |
| v1.0.x release on `shared` mode + agent backend | No action (the agent chart on the managed cluster already handles RBAC). |

## Test plan

11 `helm template` permutations — all green. Run them locally with:

```sh
cd deploy/helm/periscope

# A: defaults — 0 cluster-admin
helm template test . | grep -c "name: cluster-admin"        # ⇒ 0

# B: opt-in restores tier-admin binding
helm template test . \
  --set clusterRBAC.adminTier.enabled=true \
  --set clusterRBAC.enabled=true \
  | grep -A2 "name: periscope-tier-admin$"

# C: custom clusterRoleName under adminTier
helm template test . \
  --set clusterRBAC.adminTier.enabled=true \
  --set clusterRBAC.adminTier.clusterRoleName=my-tight-admin \
  --set clusterRBAC.enabled=true \
  | grep -B1 "name: my-tight-admin"

# D: migration guard — admin mapping without adminTier MUST fail
helm template test . \
  --set 'auth.authorization.mode=tier' \
  --set 'auth.authorization.groupTiers.eng=admin'           # ⇒ fail w/ recipe

# E: shared + in-cluster → periscope-shared binding to view
helm template test . \
  --set 'clusters[0].name=local' \
  --set 'clusters[0].backend=in-cluster' \
  | grep -A 14 "name: periscope-shared$"

# F: empty sharedRoleName suppresses
helm template test . \
  --set 'clusters[0].name=local' \
  --set 'clusters[0].backend=in-cluster' \
  --set 'clusterRBAC.sharedRoleName=' \
  | grep -c "name: periscope-shared$"                       # ⇒ 0

# G: schema rejects unknown adminTier subkey
helm template test . --set 'clusterRBAC.adminTier.bogus=true' # ⇒ fail

# H-J: same for agent chart
cd ../periscope-agent
helm template test . \
  --set 'agent.serverURL=wss://x/api/agents/connect' \
  --set 'agent.clusterName=x' \
  | grep -c "name: cluster-admin"                           # ⇒ 0

# K: kind quickstart end-to-end → 0 cluster-admin
cd ../periscope
helm template test . --values ../../../examples/values-kind.yaml \
  | grep -c "name: cluster-admin"                           # ⇒ 0
```

Manual smoke (against a kind cluster):

- [ ] `kind create cluster` + `helm install ... --values examples/values-kind.yaml` + port-forward → SPA OverviewPage renders without crash (no 403s in pod logs)
- [ ] Apply / scale flows work (kind quickstart binds to `edit`, not `view`)
- [ ] Upgrade existing v1.0.x tier+admin release without setting `adminTier.enabled` → `helm upgrade` errors out with the migration recipe

## Notes for reviewers

1. **Why one PR, not two:** both edits land on the same `templates/cluster-rbac.yaml`, share the `clusterRBAC.*` value tree, and tell the same default-install-posture story. Splitting them creates needless merge conflicts on overlapping lines. The CHANGELOG entry mirrors this — two bullets under one Unreleased section.

2. **Migration guard is a `fail`, not a `warning`.** Issue #84 left this open. Silent misconfiguration is what got us into the CIS findings in the first place; a loud `helm template`-time error with the exact group name and the one-line recipe is the right contract. Verified in test D above.

3. **`adminTier.clusterRoleName` defaults to `cluster-admin`.** If the operator opts in (`adminTier.enabled=true`) with no other change, they get the v1.0.x behaviour exactly. Operators who want a tighter posture (e.g. `cluster-admin-no-rbac` they ship out-of-band) can repoint via the value.

4. **`sharedRoleName=""` suppresses the auto-binding** instead of defaulting to an opt-in flag. Rationale: shared mode without RBAC is the broken state we're fixing; making it opt-out adds a footgun. Operators who manage RBAC out-of-band just set the value to empty.

5. **The agent chart doesn't get `sharedRoleName`** — it's not in the shared-mode codepath. The agent's own ClusterRole grants `*` reads + impersonate (separate concern, see `templates/clusterrole.yaml`).

6. **SPA defensive `null`-handling on `OverviewPage`** (mentioned in #142 as "independent of the chart fix") is parked. The chart fix removes the underlying cause of the crash from any default install; a regression-guard PR on the SPA side can come later as its own small change. Doesn't gate this merge.

7. **The `examples/values-kind.yaml` flip is a behavior change for the laptop quickstart.** Before this PR it ran the dev user as cluster-admin (via the tier workaround); after, it runs them as `edit` (namespaced admin, no cluster RBAC mutation). Sufficient for evaluating apply / scale / rollout flows; not sufficient if someone was using it as a literal cluster-admin shell. Worth flagging in release notes if anyone's depending on the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
