### PR TITLE
chore(ci): pin all actions + base images by SHA/digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Dependabot — auto-PRs for vulnerable / outdated dependencies across
-# the three ecosystems Periscope cares about. Weekly cadence keeps PR
+# the four ecosystems Periscope cares about. Weekly cadence keeps PR
 # noise low while still catching CVEs within a reasonable window.
 #
 # Grouping: minor + patch updates land in a single PR per ecosystem so
@@ -47,8 +47,9 @@ updates:
         update-types:
           - version-update:semver-patch
 
-  # GitHub Actions — pinned to major versions across our workflows.
-  # Dependabot bumps the major when a new one ships so we don't lag.
+  # GitHub Actions — every `uses:` is pinned by full commit SHA with a
+  # trailing `# vX.Y.Z` comment. Dependabot bumps both the SHA and the
+  # comment when a new release ships so the pins don't rot.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -59,5 +60,21 @@ updates:
     open-pull-requests-limit: 5
     groups:
       actions-all:
+        patterns:
+          - "*"
+
+  # Container base images — Dockerfile + Dockerfile.agent. The FROM
+  # lines are digest-pinned (@sha256:...); without this ecosystem the
+  # pins silently rot on an old base with unpatched CVEs.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    groups:
+      docker-all:
         patterns:
           - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,12 @@ jobs:
     name: Backend lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
 
@@ -30,8 +30,8 @@ jobs:
     name: Backend test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -43,7 +43,7 @@ jobs:
       # findings show in the run UI but do not fail the build.
       - name: Govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
         continue-on-error: true
 
@@ -54,8 +54,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -64,7 +64,7 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: web-dist
           path: web/dist
@@ -75,8 +75,8 @@ jobs:
     name: Helm lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: latest
       - run: helm lint deploy/helm/periscope
@@ -92,17 +92,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend-test, web]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: web-dist
           path: internal/spa/dist
       - run: go build -tags embed -trimpath -o bin/periscope ./cmd/periscope
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: periscope-binary
           path: bin/periscope

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           # security-and-quality picks up more issues than the default
@@ -58,9 +58,9 @@ jobs:
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       id-token: write       # cosign keyless signing + GH Attestations
       attestations: write   # actions/attest-build-provenance
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Need full history so the release-notes generator can
           # diff against the previous tag.
@@ -49,11 +49,11 @@ jobs:
 
       # ── Container image ─────────────────────────────────────────
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Log in to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract image metadata (tags + labels)
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tags applied:
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -94,7 +94,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       # Keyless signing — cosign uses the GH Actions OIDC token to
       # request a short-lived cert from Sigstore's Fulcio CA. No
@@ -120,7 +120,7 @@ jobs:
       # picks up GitHub Attestations on recent versions.
       - name: Attest server image provenance
         id: attest_server_image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -128,7 +128,7 @@ jobs:
 
       # ── SBOM ───────────────────────────────────────────────────
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json
@@ -149,7 +149,7 @@ jobs:
 
       # ── Helm chart ─────────────────────────────────────────────
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: latest
 
@@ -193,7 +193,7 @@ jobs:
 
       - name: Attest server chart provenance
         id: attest_server_chart
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope
           subject-digest: ${{ steps.helm_push.outputs.digest }}
@@ -207,7 +207,7 @@ jobs:
       # server image above.
       - name: Extract agent image metadata
         id: meta_agent
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-agent
           tags: |
@@ -223,7 +223,7 @@ jobs:
 
       - name: Build and push agent image
         id: build_agent
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile.agent
@@ -248,7 +248,7 @@ jobs:
 
       - name: Attest agent image provenance
         id: attest_agent_image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}-agent
           subject-digest: ${{ steps.build_agent.outputs.digest }}
@@ -284,7 +284,7 @@ jobs:
 
       - name: Attest agent chart provenance
         id: attest_agent_chart
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.CHART_REPO }}/periscope-agent
           subject-digest: ${{ steps.helm_push_agent.outputs.digest }}
@@ -365,7 +365,7 @@ jobs:
 
       # ── GitHub Release ─────────────────────────────────────────
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,10 @@
 # to track posture over time and to surface a public badge enterprise
 # evaluators recognise.
 #
-# Pinning: most actions in this repo use major-version pins
-# (@v3, @v6, etc.). ossf/scorecard-action does NOT publish a
-# rolling major tag — only point releases — so this workflow
-# pins to the latest point version. Bump on each scorecard-action
-# release. Scorecard itself dings us on Pinned-Dependencies for
-# the rest of the repo's actions; accepting that lower score
-# in exchange for not rotating SHAs across every workflow.
+# Pinning: every action across this repo's workflows is pinned by
+# full commit SHA with a `# vX.Y.Z` trailing comment (satisfies
+# Scorecard's Pinned-Dependencies check). Dependabot's github-actions
+# ecosystem bumps both the SHA and the comment on new releases.
 
 name: OpenSSF Scorecard
 
@@ -43,12 +40,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -58,13 +55,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 # syntax=docker/dockerfile:1.7
 
 # ---- web build ----
-FROM --platform=$BUILDPLATFORM node:22-alpine AS web-builder
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS web-builder
 WORKDIR /web
 
-# Copy lockfiles first for layer caching, then install.
-COPY web/package.json web/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+# Copy lockfiles first for layer caching, then install. npm ci installs
+# exactly what package-lock.json pins and fails on any drift.
+COPY web/package.json web/package-lock.json ./
+RUN npm ci --no-audit --no-fund
 
 COPY web ./
 RUN npm run build
 
 # ---- go build ----
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS go-builder
 WORKDIR /src
 
 RUN apk add --no-cache git ca-certificates
@@ -47,7 +48,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
 
 # ---- runtime ----
 # Distroless static — minimal base, no shell, non-root by default.
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1 AS runtime
 COPY --from=go-builder /out/periscope /periscope
 
 # Non-root UID/GID 65532 (provided by distroless:nonroot).

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -12,7 +12,7 @@
 # on the builder stage so go cross-compiles via GOARCH instead of
 # running under QEMU.
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS go-builder
 WORKDIR /src
 
 RUN apk add --no-cache git ca-certificates
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     ./cmd/periscope-agent
 
 # Distroless static — minimal base, no shell, non-root by default.
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1 AS runtime
 COPY --from=go-builder /out/periscope-agent /periscope-agent
 
 USER 65532:65532


### PR DESCRIPTION
## Summary

Clears all **46 open `PinnedDependenciesID` alerts** from OpenSSF Scorecard ahead of the org security review. Every GitHub Action and container base image was referenced by a mutable tag; this pins them to immutable SHAs/digests.

- **40 GitHub Action refs** across `ci.yaml`, `codeql.yml`, `scorecard.yml`, `release.yaml` — `@v6` → `@<40-char-sha> # v6.0.2`. Each SHA is the exact commit the major tag points at today, so **CI runs identical code** — this changes what is *referenced*, not what *executes*.
- **5 container `FROM` lines** — `node:22-alpine`, `golang:1.26-alpine` (×2), `gcr.io/distroless/static-debian12:nonroot` (×2) → digest-pinned. All three digests verified via `docker buildx imagetools inspect` as **multi-arch index digests** (linux/amd64 + arm64 + more), so `--platform=$BUILDPLATFORM` cross-builds are unaffected.
- **`govulncheck@latest` → `@v1.3.0`** in `ci.yaml`.
- **`npm install` → `npm ci`** in `Dockerfile` — installs exactly what `package-lock.json` pins, fails on drift. `npm ci --dry-run` confirms the committed lock is in sync.
- **`dependabot.yml`** gains a `docker` ecosystem entry so the new digest pins stay fresh — without it, SHA-pinned bases silently rot. The `github-actions` ecosystem already bumps SHA + comment.

### Why these aren't false positives

"Not pinned by hash" is factually true — the risk is a compromised action or registry namespace re-pointing a tag at malicious code mid-run (cf. `tj-actions/changed-files`, March 2025). SHA/digest pins are immutable. 44 of the 46 are zero-behavior-change; the one real change (`npm ci`) is stricter, which is the desired property.

## Test plan

- [x] `docker build -f Dockerfile` — green; exercises all 3 digest pins + `npm ci` + SPA build + Go compile + final assembly
- [x] `npm ci --dry-run` in `web/` — green against the committed `package-lock.json`
- [x] Workflow YAML parses clean; no `@vN` / `@latest` / `@main` refs remain in `.github/workflows/`
- [ ] CI (`ci.yaml` + `codeql.yml`) green on this PR
- [ ] After merge: next `scorecard.yml` run on `main` transitions the 46 `PinnedDependenciesID` alerts to **Fixed**

## Notes for reviewers

- `Dockerfile.agent` reuses the same golang + distroless digests the server build already exercised — no separate build needed.
- `scorecard.yml`'s header comment was rewritten: it previously documented *accepting* a lower Pinned-Dependencies score "in exchange for not rotating SHAs" — this PR rotates them, so the old comment would contradict reality.
- `govulncheck@v1.3.0` is the one manual-bump pin — a `go install` in a `run:` block is invisible to every Dependabot ecosystem. Acceptable: that step is report-only (`continue-on-error: true`).
- Dependabot's `docker` updater should pick up both `Dockerfile` and `Dockerfile.agent` (it matches files with "Dockerfile" in the name) — worth confirming on the first Dependabot run.

Out of scope: the 5 CodeQL alerts and 2 Scorecard meta-checks (`Maintained`, `CIIBestPractices`) — not config, handled separately.