### PR TITLE
fix: drop dead ref.Cluster assignment in customResourceEventsHandler

### DIFF
--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -220,8 +220,8 @@ func main() {
 	var cveMgr *cve.Manager
 	if parseBoolEnv("PERISCOPE_INSPECTOR_ENABLED", false) {
 		cveCfg := cve.Config{
-			RefreshInterval: parseDurationEnv("PERISCOPE_INSPECTOR_REFRESH_INTERVAL", 6*time.Hour),
-			EvictAfter:      parseDurationEnv("PERISCOPE_INSPECTOR_EVICT_AFTER", 24*time.Hour),
+			RefreshInterval:  parseDurationEnv("PERISCOPE_INSPECTOR_REFRESH_INTERVAL", 6*time.Hour),
+			EvictAfter:       parseDurationEnv("PERISCOPE_INSPECTOR_EVICT_AFTER", 24*time.Hour),
 			HydrateBatchSize: parseIntEnv("PERISCOPE_INSPECTOR_HYDRATE_BATCH_SIZE", awsinspector.BatchSize),
 		}
 		inspectorClient := awsinspector.New(factory.AWSConfig())
@@ -303,7 +303,6 @@ func main() {
 		helmHistoryHandler(registry)))
 	router.Get("/api/clusters/{cluster}/helm/releases/{ns}/{name}/diff", credentials.Wrap(factory,
 		helmDiffHandler(registry)))
-
 
 	// Chart fetch (#73). Two endpoints: GET /versions for the picker,
 	// POST /values for the audited install-dialog open. Caches are
@@ -780,7 +779,6 @@ func main() {
 			func(ctx context.Context, p credentials.Provider, c clusters.Cluster, ns, name string) (k8s.CronJobDetail, error) {
 				return k8s.GetCronJob(ctx, p, k8s.GetCronJobArgs{Cluster: c, Namespace: ns, Name: name})
 			})))
-
 
 	router.Post("/api/clusters/{cluster}/cronjobs/{ns}/{name}/trigger",
 		credentials.Wrap(factory, triggerCronJobHandler(registry, auditEmitter)))
@@ -2012,36 +2010,36 @@ func bulkDownloadAuditHandler(reg *clusters.Registry, auditer *audit.Emitter) cr
 // prefix since their plural varies per CRD.
 var bulkDownloadableKinds = map[string]struct{}{
 	// namespaced (have /{ns}/{name}/yaml)
-	"configmaps":              {},
-	"cronjobs":                {},
-	"daemonsets":              {},
-	"deployments":             {},
-	"endpointslices":          {},
+	"configmaps":               {},
+	"cronjobs":                 {},
+	"daemonsets":               {},
+	"deployments":              {},
+	"endpointslices":           {},
 	"horizontalpodautoscalers": {},
-	"ingresses":               {},
-	"jobs":                    {},
-	"limitranges":             {},
-	"networkpolicies":         {},
-	"poddisruptionbudgets":    {},
-	"pods":                    {},
-	"pvcs":                    {},
-	"replicasets":             {},
-	"resourcequotas":          {},
-	"rolebindings":            {},
-	"roles":                   {},
-	"secrets":                 {},
-	"serviceaccounts":         {},
-	"services":                {},
-	"statefulsets":            {},
+	"ingresses":                {},
+	"jobs":                     {},
+	"limitranges":              {},
+	"networkpolicies":          {},
+	"poddisruptionbudgets":     {},
+	"pods":                     {},
+	"pvcs":                     {},
+	"replicasets":              {},
+	"resourcequotas":           {},
+	"rolebindings":             {},
+	"roles":                    {},
+	"secrets":                  {},
+	"serviceaccounts":          {},
+	"services":                 {},
+	"statefulsets":             {},
 	// cluster-scoped (have /{name}/yaml)
-	"clusterrolebindings":     {},
-	"clusterroles":            {},
-	"ingressclasses":          {},
-	"namespaces":              {},
-	"priorityclasses":         {},
-	"pvs":                     {},
-	"runtimeclasses":          {},
-	"storageclasses":          {},
+	"clusterrolebindings": {},
+	"clusterroles":        {},
+	"ingressclasses":      {},
+	"namespaces":          {},
+	"priorityclasses":     {},
+	"pvs":                 {},
+	"runtimeclasses":      {},
+	"storageclasses":      {},
 }
 
 // isKnownBulkDownloadKind validates the SPA-supplied kind label.
@@ -2501,7 +2499,6 @@ func customResourceEventsHandler(reg *clusters.Registry) credentials.Handler {
 			return
 		}
 		ref := crdRefFromRequest(r, true)
-		ref.Cluster = c
 		// Look up the CRD's Kind so we can filter events by
 		// involvedObject.kind. Caching the lookup would shave a
 		// round-trip but the CRD list call is fast and the events tab


### PR DESCRIPTION
## Summary

Removes the dead `ref.Cluster = c` assignment in `customResourceEventsHandler` (`cmd/periscope/main.go`). CodeQL flagged it as `go/useless-assignment-to-field` (alert #5): the handler reads `ref.Group` / `ref.Version` / `ref.Plural` and passes the cluster `c` directly to `FindCRDByPlural` / `ListObjectEvents` — `ref.Cluster` is never read. The two sibling CRD handlers *do* read `ref.Cluster`; this one was copy-pasted and the assignment was left dangling.

Also includes incidental `gofmt` alignment cleanup in the same file (struct-literal + map-literal alignment, two stray blank lines) — whitespace only, no behavior change. That's why the diff is larger than the one-line functional fix.

## Effect

Resolves the open CodeQL alert `go/useless-assignment-to-field`. No `Closes #` keyword — it's a code-scanning alert, not a tracked issue; it auto-resolves on the next CodeQL run once this lands on `main`.

## Test plan

- [x] Functional change is a single-line deletion of a provably-unread field assignment
- [ ] CI green (Backend lint/test, Web, CodeQL, Build embedded binary)