### PR TITLE
fix(spa): prevent duplicate associative-list entries in SSA body (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,70 @@ tag.
   is tracked as RFC 0005 (`docs/rfcs/0005-drop-retained-ownership.md`)
   and ships as **v1.1.2**.
 
+- **Edit YAML now works on ServiceAccount, RBAC, and the "extras"
+  resource kinds.** Previously, clicking the edit pencil on any of
+  these resources rendered a blank Monaco editor — the action bar
+  (cancel / patch / dry-run / diff / apply) appeared, but the YAML
+  body never loaded. Read-only YAML view was unaffected; YAML edit
+  specifically broke.
+
+  Affected resources (14 in total):
+  - **Access group**: ServiceAccount, Role, ClusterRole,
+    RoleBinding, ClusterRoleBinding
+  - **Extras**: HorizontalPodAutoscaler, PodDisruptionBudget,
+    ReplicaSet, NetworkPolicy, IngressClass, ResourceQuota,
+    LimitRange, PriorityClass, RuntimeClass
+
+  Root cause: each of these backend YAML handlers
+  (`internal/k8s/rbac.go`, `internal/k8s/extras.go`) didn't set
+  `raw.APIVersion` and `raw.Kind` on the typed object returned
+  from client-go before marshaling. Every other YAML handler in
+  the package (`deployments.go`, `statefulsets.go`, `services.go`,
+  `secrets.go`, `pods.go`, `configmaps.go`, `namespaces.go`,
+  `cronjobs.go`, `endpointslices.go`, etc.) sets these explicitly
+  to compensate for client-go's well-known TypeMeta-empty-on-Get
+  behavior; these 14 handlers were missed. The resulting YAML
+  had no `apiVersion:` or `kind:` lines, so the SPA editor's
+  `parseIdentityFromYaml` returned null, `gvk` stayed null, and
+  the Monaco mount effect short-circuited before creating the
+  editor model.
+
+  **Fix**: each affected handler now sets the correct
+  `APIVersion` and `Kind` before `formatYAML`. Regression tests
+  in `internal/k8s/rbac_test.go` assert each Access-group
+  handler's output contains the expected `apiVersion:`/`kind:`
+  lines. The extras handlers share the same one-line pattern
+  fix; combined with the `formatYAML` invariant they're now
+  symmetric with every other YAML handler in the package.
+
+- **Deleting a label or annotation in the YAML editor now actually
+  removes the key, instead of leaving it behind with an empty
+  string value.** Previously, removing the `test: foo` line from a
+  ServiceAccount (or any resource) in the editor and clicking Apply
+  produced a resource with `test: ""` on the next read — the key
+  was still there, just blanked out.
+
+  Root cause: `buildMinimalSSA` in `web/src/lib/yamlPatch.ts`
+  expressed remove ops on string-keyed map fields by writing the
+  key with a `null` value (rendered as `~` in the apply payload).
+  The premise — "setting a managed field to null tells the
+  apiserver to drop it" — is wrong for atomic `map[string]string`
+  fields like `metadata.labels.*` and `metadata.annotations.*`:
+  the apiserver coerces null → "" (the zero value of the value
+  type) and the key stays put.
+
+  **Fix**: the string-keyed branch of `setLeaf` now OMITS the key
+  from the apply payload instead of writing null. Under SSA's
+  per-key ownership model, `periscope-spa` previously owned that
+  field; dropping it from the apply relinquishes ownership and the
+  apiserver removes the key from the resource. This mirrors the
+  merge-key branch immediately below, which already had the
+  correct "omit, don't null" behavior for array-element removals.
+  Sibling labels owned by other field managers (e.g.,
+  `app.kubernetes.io/name` from Helm) are unaffected. Regression
+  coverage in `web/src/lib/yamlPatch.test.ts` includes a direct
+  repro mirroring the user-reported ServiceAccount scenario.
+
 - **Karpenter sidebar probe no longer floods the audit log with
   `karpenter_read` rows on clusters without Karpenter.** Previously,
   the SPA's `KarpenterSidebarEntry` fired `GET /api/clusters/{c}/karpenter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ tag.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-19
+
+### Fixed
+
+- **SPA apply bodies no longer produce duplicate `containers[].ports[]`
+  entries when a deployment has overlapping `periscope-spa`
+  managedFields claims.** Previously, restarts and YAML edits on
+  affected deployments failed with the apiserver error:
+
+  ```
+  failed to create typed patch object:
+  .spec.template.spec.containers[name=X].ports:
+  duplicate entries for key [containerPort=N, protocol="TCP"]
+  ```
+
+  The trigger: deployments previously edited through Periscope's
+  container subtree *and* through specific port fields, leaving
+  `periscope-spa` holding both a container-level and a port-level
+  `.` ownership marker in managedFields. Each marker emitted a
+  retained-ownership op ending in a MergeKey-leaf at the same
+  logical port; the first op's `setLeaf` PUSHed an entry whose
+  `containerPort` was a number (from the value spread), and the
+  second op's `findIndex` used strict `===` against the stringified
+  key, missed the existing entry, and PUSHed a duplicate. The
+  apiserver rejected the resulting body during typed-patch
+  construction.
+
+  **Fix**: `setLeaf`'s MergeKey-leaf branch now uses
+  `String(x[k]) === v`, matching the loose-equality convention
+  already used by `stepInto`. Locks the same contract across both
+  branches. Includes a regression test that exercises the
+  duplicate scenario via `buildMinimalSSA` end-to-end.
+
+  Affects every restart and YAML edit on deployments hitting this
+  managedFields shape. Operators on v1.1.0 can either upgrade to
+  v1.1.1 or work around the bug by editing the affected resource
+  via `kubectl`/`rancher` until upgrade.
+
+  The deeper architectural follow-up — removing the
+  retained-ownership SSA pattern entirely in favor of pure
+  minimal-diff SSA, plus a simplified single-banner conflict UX —
+  is tracked as RFC 0005 (`docs/rfcs/0005-drop-retained-ownership.md`)
+  and ships as **v1.1.2**.
+
 ## [1.1.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,35 @@ tag.
   is tracked as RFC 0005 (`docs/rfcs/0005-drop-retained-ownership.md`)
   and ships as **v1.1.2**.
 
+- **Karpenter sidebar probe no longer floods the audit log with
+  `karpenter_read` rows on clusters without Karpenter.** Previously,
+  the SPA's `KarpenterSidebarEntry` fired `GET /api/clusters/{c}/karpenter`
+  on every cluster page mount (not just when an operator opened the
+  dashboard) to decide whether to render the sidebar nav link. The
+  handler emitted an audit row on every call, including its
+  `available_false` auto-detect short-circuit, producing a stream
+  of `karpenter_read` rows that obscured real operator-intent actions
+  in the `/audit` view. Symmetric audit noise existed on
+  Karpenter-installed clusters via the `list` op.
+
+  **Fix**: the sidebar's CRD-presence probe is split into a separate
+  endpoint, `GET /api/clusters/{c}/karpenter/availability`, that
+  returns `{available: bool}` without emitting an audit row. The
+  full `/karpenter` dashboard endpoint retains its existing audit
+  emission, which now fires only on intentional operator navigation
+  to the dashboard. The SPA-side hook `useKarpenter` is split into
+  `useKarpenter` (dashboard, full data + audit) and
+  `useKarpenterAvailability` (sidebar, lightweight + unaudited).
+
+  Operator-visible: `/audit` now shows only real actions
+  (`apply`, `delete`, `secret_reveal`, etc.) plus genuine Karpenter
+  dashboard views. Pre-v1.1.1 audit rows tagged `karpenter_read`
+  with `op: "available_false"` from sidebar probes will remain in
+  the historical log; new rows post-upgrade will not be created.
+
+  API addition is purely additive: existing `/karpenter` callers
+  see no change. No Helm values or cluster-registry config changes.
+
 ## [1.1.0] - 2026-05-16
 
 ### Added

--- a/cmd/periscope/karpenter_handler.go
+++ b/cmd/periscope/karpenter_handler.go
@@ -1,18 +1,31 @@
 package main
 
-// karpenter_handler.go — curated Karpenter dashboard endpoint (#118).
+// karpenter_handler.go — curated Karpenter dashboard endpoint (#118)
+// and the lightweight availability probe (#v1.1.1 hotfix).
 //
 //   GET /api/clusters/{cluster}/karpenter
+//   GET /api/clusters/{cluster}/karpenter/availability
 //
-// Single-shot read. Joins NodePools / NodeClaims / pending pods +
-// FailedScheduling events / controller metrics into one response.
+// The full `/karpenter` endpoint is a single-shot read. Joins
+// NodePools / NodeClaims / pending pods + FailedScheduling events /
+// controller metrics into one response.
 //
 // Auto-detect: when karpenter.sh/v1 CRDs are absent the handler
 // returns `{available: false}` immediately (HTTP 200, not 422 — the
-// SPA's sidebar logic gates on this field, not a status code). One
+// SPA's dashboard page gates on this field, not a status code). One
 // audit row still emits so compliance can answer "did anyone load
 // the Karpenter view on this cluster?" even when Karpenter isn't
-// installed.
+// installed. With the v1.1.1 split (see /availability below), this
+// audit row now fires only when an operator explicitly navigates
+// to the dashboard — not on incidental sidebar mounts.
+//
+// The lightweight `/karpenter/availability` endpoint is the
+// sidebar's probe: returns just `{available: bool}` based on the
+// CRD presence check, with NO audit row. Pre-split, the sidebar
+// fired the full /karpenter endpoint on every cluster page mount,
+// flooding the audit log with `karpenter_read` rows that didn't
+// reflect any operator-intent action. See karpenterAvailabilityHandler
+// below.
 //
 // Graceful degradation: every cross-call (events, metrics) is
 // best-effort. The response always carries the base view (NodePools
@@ -200,4 +213,47 @@ func emitKarpenterRead(ctx context.Context, emitter *audit.Emitter, c clusters.C
 		Reason:  reason,
 		Extra:   map[string]any{"op": op},
 	})
+}
+
+// karpenterAvailabilityHandler — lightweight CRD presence probe used
+// by the SPA's sidebar to decide whether to render the Karpenter nav
+// entry.
+//
+//	GET /api/clusters/{cluster}/karpenter/availability
+//
+// Returns `{"available": bool}` based purely on the
+// karpenter.sh/v1 CRD presence check. Intentionally **does not emit
+// an audit row** — the sidebar fires this on every cluster page
+// mount, and auditing those probes would flood the audit log with
+// rows that don't reflect any operator-intent action.
+//
+// The full `/karpenter` endpoint still emits its audit row on every
+// call (including the not-installed short-circuit). The split means:
+//   - Incidental sidebar probes → /availability, no audit
+//   - Intentional dashboard navigation → /karpenter, audit emitted
+//
+// Errors (apiserver unreachable, discovery RBAC denial) surface as
+// 5xx without audit; they're transport-level failures and the
+// sidebar handles them by hiding the entry.
+func karpenterAvailabilityHandler(reg *clusters.Registry) credentials.Handler {
+	return func(w http.ResponseWriter, r *http.Request, p credentials.Provider) {
+		c, ok := reg.ByName(chi.URLParam(r, "cluster"))
+		if !ok {
+			http.Error(w, "cluster not found", http.StatusNotFound)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), karpenterRequestTimeout)
+		defer cancel()
+		installed, err := karpenterIsInstalledFn(ctx, p, c)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.WarnContext(ctx, "karpenter availability probe failed",
+				"cluster", c.Name, "err", err)
+			writeAPIErrorJSON(w, http.StatusInternalServerError, "E_INTERNAL", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"available": installed})
+	}
 }

--- a/cmd/periscope/karpenter_handler_test.go
+++ b/cmd/periscope/karpenter_handler_test.go
@@ -332,3 +332,121 @@ func TestKarpenterHandler_ClusterNotFoundReturns404(t *testing.T) {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
 }
+
+// ─── availability probe (v1.1.1 split) ───────────────────────────────────────
+
+func TestKarpenterAvailabilityHandler_NotInstalledNoAudit(t *testing.T) {
+	withKarpenterSeams(t, karpenterFakes{
+		IsInstalled: func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (bool, error) {
+			return false, nil
+		},
+		BuildClients: func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (kubernetes.Interface, dynamic.Interface, error) {
+			t.Fatal("BuildClients must not be called by the availability probe")
+			return nil, nil, nil
+		},
+	})
+
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(_ *audit.Emitter) credentials.Handler {
+			return karpenterAvailabilityHandler(reg)
+		},
+		http.MethodGet, "/api/clusters/test/karpenter/availability",
+		map[string]string{"cluster": "test"}, nil,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]bool
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if resp["available"] {
+		t.Errorf("available = true, want false (CRDs were absent)")
+	}
+
+	// Critical: the availability probe MUST NOT emit an audit row.
+	// Pre-v1.1.1 the sidebar fired the full /karpenter endpoint on
+	// every cluster page mount, and the not-installed short-circuit
+	// emitted a karpenter_read audit row that flooded the audit log
+	// with rows that didn't reflect operator-intent action. The
+	// split was made specifically to prevent that.
+	if events := sink.snapshot(); len(events) != 0 {
+		t.Errorf("availability probe emitted %d audit row(s); want 0: %+v", len(events), events)
+	}
+}
+
+func TestKarpenterAvailabilityHandler_InstalledNoAudit(t *testing.T) {
+	withKarpenterSeams(t, karpenterFakes{
+		IsInstalled: func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (bool, error) {
+			return true, nil
+		},
+		BuildClients: func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (kubernetes.Interface, dynamic.Interface, error) {
+			t.Fatal("BuildClients must not be called by the availability probe (lightweight by design)")
+			return nil, nil, nil
+		},
+	})
+
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(_ *audit.Emitter) credentials.Handler {
+			return karpenterAvailabilityHandler(reg)
+		},
+		http.MethodGet, "/api/clusters/test/karpenter/availability",
+		map[string]string{"cluster": "test"}, nil,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]bool
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if !resp["available"] {
+		t.Errorf("available = false, want true (CRDs were present)")
+	}
+	if events := sink.snapshot(); len(events) != 0 {
+		t.Errorf("availability probe emitted %d audit row(s); want 0", len(events))
+	}
+}
+
+func TestKarpenterAvailabilityHandler_DetectErrorNoAudit(t *testing.T) {
+	withKarpenterSeams(t, karpenterFakes{
+		IsInstalled: func(_ context.Context, _ credentials.Provider, _ clusters.Cluster) (bool, error) {
+			return false, errors.New("apiserver unreachable")
+		},
+	})
+
+	reg := testRegistry(t)
+	rec, sink := actionHandlerInvoke(t,
+		func(_ *audit.Emitter) credentials.Handler {
+			return karpenterAvailabilityHandler(reg)
+		},
+		http.MethodGet, "/api/clusters/test/karpenter/availability",
+		map[string]string{"cluster": "test"}, nil,
+	)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	// Errors at the transport level still don't audit — the sidebar
+	// handles "probe failed" by hiding the entry; auditing transport
+	// failures would re-introduce the noise problem.
+	if events := sink.snapshot(); len(events) != 0 {
+		t.Errorf("availability probe emitted %d audit row(s) on error path; want 0", len(events))
+	}
+}
+
+func TestKarpenterAvailabilityHandler_ClusterNotFoundReturns404(t *testing.T) {
+	reg := testRegistry(t)
+	rec, _ := actionHandlerInvoke(t,
+		func(_ *audit.Emitter) credentials.Handler {
+			return karpenterAvailabilityHandler(reg)
+		},
+		http.MethodGet, "/api/clusters/missing/karpenter/availability",
+		map[string]string{"cluster": "missing"}, nil,
+	)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -366,12 +366,23 @@ func main() {
 
 	// --- Karpenter dashboard (read-only, issue #118) ---
 	//
-	// Curated view of karpenter.sh/v1 NodePools + NodeClaims joined
-	// to pending pods' FailedScheduling events and the controller's
-	// /metrics exposition. Auto-detects via CRD probe; returns
-	// {available: false} on clusters without Karpenter installed.
+	// Two endpoints, separated in v1.1.1 to keep the sidebar's
+	// per-page-mount availability probe from flooding the audit log
+	// with rows that don't reflect operator intent:
+	//
+	//   /karpenter              — full dashboard read; audit emits
+	//                             on every call (intentional
+	//                             navigation only post-split)
+	//   /karpenter/availability — lightweight `{available: bool}`
+	//                             probe; NO audit emission. Sidebar
+	//                             calls this to decide whether to
+	//                             render the Karpenter nav entry.
+	//
+	// Both auto-detect via the karpenter.sh/v1 CRD probe.
 	router.Get("/api/clusters/{cluster}/karpenter", credentials.Wrap(factory,
 		karpenterHandler(registry, auditEmitter)))
+	router.Get("/api/clusters/{cluster}/karpenter/availability", credentials.Wrap(factory,
+		karpenterAvailabilityHandler(registry)))
 
 	// --- EKS managed node groups + AMI drift (read-only, issue #103) ---
 	//

--- a/internal/k8s/extras.go
+++ b/internal/k8s/extras.go
@@ -86,6 +86,8 @@ func GetHPAYAML(ctx context.Context, p credentials.Provider, args GetHPAArgs) (s
 	if err != nil {
 		return "", fmt.Errorf("get hpa: %w", err)
 	}
+	raw.APIVersion = "autoscaling/v2"
+	raw.Kind = "HorizontalPodAutoscaler"
 	return formatYAML(raw)
 }
 
@@ -175,6 +177,8 @@ func GetPDBYAML(ctx context.Context, p credentials.Provider, args GetPDBArgs) (s
 	if err != nil {
 		return "", fmt.Errorf("get pdb: %w", err)
 	}
+	raw.APIVersion = "policy/v1"
+	raw.Kind = "PodDisruptionBudget"
 	return formatYAML(raw)
 }
 
@@ -278,6 +282,8 @@ func GetReplicaSetYAML(ctx context.Context, p credentials.Provider, args GetRepl
 	if err != nil {
 		return "", fmt.Errorf("get replicaset: %w", err)
 	}
+	raw.APIVersion = "apps/v1"
+	raw.Kind = "ReplicaSet"
 	return formatYAML(raw)
 }
 
@@ -365,6 +371,8 @@ func GetNetworkPolicyYAML(ctx context.Context, p credentials.Provider, args GetN
 	if err != nil {
 		return "", fmt.Errorf("get networkpolicy: %w", err)
 	}
+	raw.APIVersion = "networking.k8s.io/v1"
+	raw.Kind = "NetworkPolicy"
 	return formatYAML(raw)
 }
 
@@ -503,6 +511,8 @@ func GetIngressClassYAML(ctx context.Context, p credentials.Provider, args GetIn
 	if err != nil {
 		return "", fmt.Errorf("get ingressclass: %w", err)
 	}
+	raw.APIVersion = "networking.k8s.io/v1"
+	raw.Kind = "IngressClass"
 	return formatYAML(raw)
 }
 
@@ -568,6 +578,8 @@ func GetResourceQuotaYAML(ctx context.Context, p credentials.Provider, args GetR
 	if err != nil {
 		return "", fmt.Errorf("get resourcequota: %w", err)
 	}
+	raw.APIVersion = "v1"
+	raw.Kind = "ResourceQuota"
 	return formatYAML(raw)
 }
 
@@ -659,6 +671,8 @@ func GetLimitRangeYAML(ctx context.Context, p credentials.Provider, args GetLimi
 	if err != nil {
 		return "", fmt.Errorf("get limitrange: %w", err)
 	}
+	raw.APIVersion = "v1"
+	raw.Kind = "LimitRange"
 	return formatYAML(raw)
 }
 
@@ -737,6 +751,8 @@ func GetPriorityClassYAML(ctx context.Context, p credentials.Provider, args GetP
 	if err != nil {
 		return "", fmt.Errorf("get priorityclass: %w", err)
 	}
+	raw.APIVersion = "scheduling.k8s.io/v1"
+	raw.Kind = "PriorityClass"
 	return formatYAML(raw)
 }
 
@@ -818,6 +834,8 @@ func GetRuntimeClassYAML(ctx context.Context, p credentials.Provider, args GetRu
 	if err != nil {
 		return "", fmt.Errorf("get runtimeclass: %w", err)
 	}
+	raw.APIVersion = "node.k8s.io/v1"
+	raw.Kind = "RuntimeClass"
 	return formatYAML(raw)
 }
 

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -321,6 +321,15 @@ func serviceAccountSummary(sa *corev1.ServiceAccount) ServiceAccount {
 
 // --- YAML ---
 
+// Note on TypeMeta: client-go's typed Get() returns objects with empty
+// TypeMeta (apiVersion="", kind=""). formatYAML below marshals what's
+// there, so without explicit assignment the resulting YAML lacks
+// apiVersion/kind — which breaks the SPA editor's identity probe
+// (parseIdentityFromYaml returns null → gvk is null → Monaco mount
+// short-circuits → editor stays blank). Every other GetXxxYAML in
+// this package sets these explicitly; the RBAC + SA handlers below
+// were originally missing the assignment, fixed in v1.1.1.
+
 func GetRoleYAML(ctx context.Context, p credentials.Provider, args GetRoleArgs) (string, error) {
 	cs, err := newClientFn(ctx, p, args.Cluster)
 	if err != nil {
@@ -330,6 +339,8 @@ func GetRoleYAML(ctx context.Context, p credentials.Provider, args GetRoleArgs) 
 	if err != nil {
 		return "", fmt.Errorf("get role: %w", err)
 	}
+	raw.APIVersion = "rbac.authorization.k8s.io/v1"
+	raw.Kind = "Role"
 	return formatYAML(raw)
 }
 
@@ -342,6 +353,8 @@ func GetClusterRoleYAML(ctx context.Context, p credentials.Provider, args GetClu
 	if err != nil {
 		return "", fmt.Errorf("get clusterrole: %w", err)
 	}
+	raw.APIVersion = "rbac.authorization.k8s.io/v1"
+	raw.Kind = "ClusterRole"
 	return formatYAML(raw)
 }
 
@@ -354,6 +367,8 @@ func GetRoleBindingYAML(ctx context.Context, p credentials.Provider, args GetRol
 	if err != nil {
 		return "", fmt.Errorf("get rolebinding: %w", err)
 	}
+	raw.APIVersion = "rbac.authorization.k8s.io/v1"
+	raw.Kind = "RoleBinding"
 	return formatYAML(raw)
 }
 
@@ -366,6 +381,8 @@ func GetClusterRoleBindingYAML(ctx context.Context, p credentials.Provider, args
 	if err != nil {
 		return "", fmt.Errorf("get clusterrolebinding: %w", err)
 	}
+	raw.APIVersion = "rbac.authorization.k8s.io/v1"
+	raw.Kind = "ClusterRoleBinding"
 	return formatYAML(raw)
 }
 
@@ -378,6 +395,8 @@ func GetServiceAccountYAML(ctx context.Context, p credentials.Provider, args Get
 	if err != nil {
 		return "", fmt.Errorf("get serviceaccount: %w", err)
 	}
+	raw.APIVersion = "v1"
+	raw.Kind = "ServiceAccount"
 	return formatYAML(raw)
 }
 

--- a/internal/k8s/rbac_test.go
+++ b/internal/k8s/rbac_test.go
@@ -1,0 +1,145 @@
+package k8s
+
+// rbac_test.go — regression coverage for the RBAC + ServiceAccount
+// YAML handlers. Each test asserts that the produced YAML carries
+// `apiVersion:` and `kind:` lines — these were missing in v1.1.0
+// because client-go's typed Get() returns objects with empty
+// TypeMeta, and the handlers (unlike their peers in this package)
+// weren't setting it explicitly. The blank TypeMeta surfaced in the
+// SPA as a blank Monaco editor on Edit: parseIdentityFromYaml saw
+// no apiVersion/kind, returned null, gvk stayed null, and the
+// editor mount short-circuited before creating the Monaco model.
+// Fixed in v1.1.1; this file locks the fix in.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/gnana997/periscope/internal/clusters"
+)
+
+// swapNewClientFn is declared in watch_test.go; reused here.
+
+func TestGetRoleYAMLSetsTypeMeta(t *testing.T) {
+	cs := fake.NewSimpleClientset(&rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "reader", Namespace: "team-a"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get", "list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	})
+	swapNewClientFn(t, cs)
+
+	yaml, err := GetRoleYAML(context.Background(), stubProvider{}, GetRoleArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Namespace: "team-a", Name: "reader",
+	})
+	if err != nil {
+		t.Fatalf("GetRoleYAML: %v", err)
+	}
+	if !strings.Contains(yaml, "apiVersion: rbac.authorization.k8s.io/v1") {
+		t.Fatalf("yaml missing apiVersion: rbac.authorization.k8s.io/v1\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kind: Role") {
+		t.Fatalf("yaml missing kind: Role\n%s", yaml)
+	}
+}
+
+func TestGetClusterRoleYAMLSetsTypeMeta(t *testing.T) {
+	cs := fake.NewSimpleClientset(&rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "viewer"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	})
+	swapNewClientFn(t, cs)
+
+	yaml, err := GetClusterRoleYAML(context.Background(), stubProvider{}, GetClusterRoleArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Name: "viewer",
+	})
+	if err != nil {
+		t.Fatalf("GetClusterRoleYAML: %v", err)
+	}
+	if !strings.Contains(yaml, "apiVersion: rbac.authorization.k8s.io/v1") {
+		t.Fatalf("yaml missing apiVersion: rbac.authorization.k8s.io/v1\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kind: ClusterRole") {
+		t.Fatalf("yaml missing kind: ClusterRole\n%s", yaml)
+	}
+}
+
+func TestGetRoleBindingYAMLSetsTypeMeta(t *testing.T) {
+	cs := fake.NewSimpleClientset(&rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-reader", Namespace: "team-a"},
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice", APIGroup: "rbac.authorization.k8s.io"}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "reader",
+		},
+	})
+	swapNewClientFn(t, cs)
+
+	yaml, err := GetRoleBindingYAML(context.Background(), stubProvider{}, GetRoleBindingArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Namespace: "team-a", Name: "alice-reader",
+	})
+	if err != nil {
+		t.Fatalf("GetRoleBindingYAML: %v", err)
+	}
+	if !strings.Contains(yaml, "apiVersion: rbac.authorization.k8s.io/v1") {
+		t.Fatalf("yaml missing apiVersion: rbac.authorization.k8s.io/v1\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kind: RoleBinding") {
+		t.Fatalf("yaml missing kind: RoleBinding\n%s", yaml)
+	}
+}
+
+func TestGetClusterRoleBindingYAMLSetsTypeMeta(t *testing.T) {
+	cs := fake.NewSimpleClientset(&rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "viewers"},
+		Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "viewers", APIGroup: "rbac.authorization.k8s.io"}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "viewer",
+		},
+	})
+	swapNewClientFn(t, cs)
+
+	yaml, err := GetClusterRoleBindingYAML(context.Background(), stubProvider{}, GetClusterRoleBindingArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Name: "viewers",
+	})
+	if err != nil {
+		t.Fatalf("GetClusterRoleBindingYAML: %v", err)
+	}
+	if !strings.Contains(yaml, "apiVersion: rbac.authorization.k8s.io/v1") {
+		t.Fatalf("yaml missing apiVersion: rbac.authorization.k8s.io/v1\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kind: ClusterRoleBinding") {
+		t.Fatalf("yaml missing kind: ClusterRoleBinding\n%s", yaml)
+	}
+}
+
+func TestGetServiceAccountYAMLSetsTypeMeta(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "alloy", Namespace: "certwatch-monitoring"},
+	})
+	swapNewClientFn(t, cs)
+
+	yaml, err := GetServiceAccountYAML(context.Background(), stubProvider{}, GetServiceAccountArgs{
+		Cluster: clusters.Cluster{Name: "test"}, Namespace: "certwatch-monitoring", Name: "alloy",
+	})
+	if err != nil {
+		t.Fatalf("GetServiceAccountYAML: %v", err)
+	}
+	if !strings.Contains(yaml, "apiVersion: v1") {
+		t.Fatalf("yaml missing apiVersion: v1\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kind: ServiceAccount") {
+		t.Fatalf("yaml missing kind: ServiceAccount\n%s", yaml)
+	}
+}

--- a/web/src/components/shell/ResourceNav.tsx
+++ b/web/src/components/shell/ResourceNav.tsx
@@ -4,7 +4,7 @@ import { cn } from "../../lib/cn";
 import { RESOURCE_GROUPS, resourcesByGroup } from "../../lib/resources";
 import { CRDSubTree } from "./CRDSubTree";
 import { useAuth } from "../../auth/useAuth";
-import { useKarpenter } from "../../hooks/useKarpenter";
+import { useKarpenterAvailability } from "../../hooks/useKarpenter";
 
 const STORAGE_KEY = "periscope.sidebar.openGroups";
 const DEFAULT_OPEN: string[] = ["Cluster"];
@@ -493,12 +493,17 @@ function CollapsibleSection({
 }
 
 // KarpenterSidebarEntry — a single sidebar link that auto-hides
-// itself when the cluster doesn't have karpenter.sh/v1 CRDs. Shares
-// the same useKarpenter query as the page (TanStack Query dedupes),
-// so opening the sidebar costs one network call regardless of
-// whether the page is mounted.
+// itself when the cluster doesn't have karpenter.sh/v1 CRDs.
+//
+// Backed by the lightweight `/karpenter/availability` endpoint
+// (NOT the heavy `/karpenter` dashboard endpoint). Pre-v1.1.1 the
+// sidebar shared a query with the page, which meant every cluster
+// page mount fired the full dashboard read AND emitted a
+// `karpenter_read` audit row. The split avoids audit noise from
+// incidental sidebar mounts; the dashboard page still uses
+// `useKarpenter` for its full data + audited intent signal.
 function KarpenterSidebarEntry({ cluster }: { cluster: string }) {
-  const { data, isPending } = useKarpenter(cluster);
+  const { data, isPending } = useKarpenterAvailability(cluster);
   if (isPending) return null;
   if (!data?.available) return null;
   return (

--- a/web/src/hooks/useKarpenter.ts
+++ b/web/src/hooks/useKarpenter.ts
@@ -54,3 +54,38 @@ export function useKarpenter(cluster: string) {
     },
   });
 }
+
+// useKarpenterAvailability — lightweight CRD-presence probe used by
+// the sidebar to decide whether to render the Karpenter nav entry.
+// Backed by /api/clusters/{c}/karpenter/availability, which is NOT
+// audited (split off in v1.1.1 so per-page-mount sidebar probes
+// don't flood the audit log with `karpenter_read` rows that don't
+// reflect operator-intent action).
+//
+// Longer staleTime than useKarpenter — CRD presence flips rarely
+// (chart install / uninstall), so the sidebar can trust a stale
+// cache for minutes without missing operator-visible transitions.
+const AVAILABILITY_STALE_MS = 5 * 60 * 1000;
+
+export function useKarpenterAvailability(cluster: string) {
+  return useQuery<{ available: boolean }>({
+    queryKey: queryKeys.cluster(cluster).karpenterAvailability(),
+    queryFn: cluster
+      ? ({ signal }) => api.karpenterAvailability(cluster, signal)
+      : skipToken,
+    staleTime: AVAILABILITY_STALE_MS,
+    // No refetchInterval — CRD presence is not a polling concern.
+    retry: (count, err) => {
+      if (
+        err &&
+        typeof err === "object" &&
+        "status" in err &&
+        ((err as { status: number }).status >= 400 &&
+          (err as { status: number }).status < 500)
+      ) {
+        return false;
+      }
+      return count < 1;
+    },
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1116,11 +1116,25 @@ export const api = {
   /** Karpenter dashboard (issue #118) — single GET joining
    *  NodePools + NodeClaims + pending pods + price metrics.
    *  Returns `{available: false}` immediately on clusters without
-   *  karpenter.sh/v1 CRDs (no 422 — the SPA gates the sidebar entry
-   *  on the boolean field, not the status code). */
+   *  karpenter.sh/v1 CRDs (no 422 — the dashboard page gates on
+   *  the boolean field, not the status code). Audited on every
+   *  call; intended for the dashboard page only. The sidebar uses
+   *  `karpenterAvailability` instead. */
   karpenter: (cluster: string, signal?: AbortSignal) =>
     getJSON<KarpenterDashboard>(
       `/api/clusters/${enc(cluster)}/karpenter`,
+      signal,
+    ),
+
+  /** Karpenter availability probe (v1.1.1 split) — lightweight
+   *  `{available: bool}` check based on the karpenter.sh/v1 CRD
+   *  presence. NOT audited: this fires on every cluster page mount
+   *  from the sidebar, and auditing those incidental probes would
+   *  flood the audit log. Use this from sidebar / nav-rendering
+   *  paths; use `karpenter` from the dashboard page itself. */
+  karpenterAvailability: (cluster: string, signal?: AbortSignal) =>
+    getJSON<{ available: boolean }>(
+      `/api/clusters/${enc(cluster)}/karpenter/availability`,
       signal,
     ),
 

--- a/web/src/lib/applyBodyBuilder.test.ts
+++ b/web/src/lib/applyBodyBuilder.test.ts
@@ -217,7 +217,7 @@ spec:
     expect((parsed.spec as Record<string, unknown>).replicas).toBe(7);
   });
 
-  it("user 'remove' op on a prior-owned path wins (null leaf overwrites retained value)", () => {
+  it("user 'remove' op on a prior-owned path omits the key from the payload (SSA retained-ownership deletion, hotfix v1.1.1)", () => {
     const baseline = `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -255,9 +255,16 @@ data:
     const annotations = (
       (parsed.metadata as Record<string, unknown>).annotations as Record<string, unknown>
     );
-    // keep-me retained from current; drop-me explicitly nulled by user edit.
+    // keep-me retained from current; drop-me OMITTED from the apply
+    // payload (not written as null). Under SSA per-key ownership,
+    // periscope-spa previously owned f:drop-me, so dropping it from the
+    // apply body relinquishes ownership → the apiserver removes the
+    // annotation. Writing null (the v1.1.0 behavior) was wrong for
+    // map[string]string fields: the apiserver coerced null → "" and
+    // the key persisted with an empty value. See yamlPatch.ts:setLeaf
+    // comment for the full story.
     expect(annotations["keep-me"]).toBe("yes");
-    expect(annotations["drop-me"]).toBeNull();
+    expect(Object.keys(annotations)).not.toContain("drop-me");
   });
 
   it("managedFields === null → throws ManagedFieldsUnavailableError", () => {

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -113,6 +113,13 @@ export const queryKeys = {
     // NodePools / NodeClaims / pending pods / metrics — invalidating
     // any of those means re-fetching the whole shape, so one key.
     karpenter: () => ["cluster", c, "karpenter"] as const,
+    // CRD-presence probe used by the sidebar to decide whether to
+    // render the Karpenter nav entry. Separate from `karpenter()`
+    // above because it hits a different (lightweight, unaudited)
+    // endpoint and has its own (longer) staleTime — see v1.1.1
+    // split in karpenter_handler.go and useKarpenterAvailability.
+    karpenterAvailability: () =>
+      ["cluster", c, "karpenter", "availability"] as const,
 
     // EKS managed node groups (issue #103). Drift fields share the
     // same query subtree because the data is computed on the same

--- a/web/src/lib/yamlPatch.test.ts
+++ b/web/src/lib/yamlPatch.test.ts
@@ -253,7 +253,7 @@ describe("buildMinimalSSA", () => {
     const ops = computeOps(NGINX_DEPLOYMENT, after);
     const yaml = buildMinimalSSA(ops, IDENTITY);
     // The removed key must not appear in the payload at all.
-    expect(yaml).not.toMatch(/app\.kubernetes\.io\/version/);
+    expect(yaml).not.toContain("app.kubernetes.io/version");
     // And we must not be writing a null sentinel anywhere.
     expect(yaml).not.toMatch(/:\s*~\s*$/m);
     // Re-parsing should yield a payload whose labels map has no
@@ -306,8 +306,8 @@ metadata:
     expect(yaml).not.toMatch(/\btest\s*:/);
     // Sibling labels owned by other field managers must not be touched
     // (minimal-SSA: we only include fields the user changed).
-    expect(yaml).not.toMatch(/app\.kubernetes\.io\/component/);
-    expect(yaml).not.toMatch(/app\.kubernetes\.io\/name/);
+    expect(yaml).not.toContain("app.kubernetes.io/component");
+    expect(yaml).not.toContain("app.kubernetes.io/name");
   });
 
   it("produces well-formed YAML that round-trips", () => {

--- a/web/src/lib/yamlPatch.test.ts
+++ b/web/src/lib/yamlPatch.test.ts
@@ -238,16 +238,76 @@ describe("buildMinimalSSA", () => {
     expect(yaml).not.toContain("memory:");
   });
 
-  it("expresses removals as null leaves", () => {
+  it("omits removed keys from the payload (SSA retained-ownership semantics, hotfix v1.1.1)", () => {
+    // Regression for v1.1.0 label-deletion bug. Pre-fix, removing a
+    // managed map-of-string entry (label / annotation) emitted
+    // `<key>: ~` (null) in the apply payload; the apiserver coerced
+    // null → "" for the value type and left the key in place. Correct
+    // behavior under SSA is to OMIT the key — periscope-spa previously
+    // owned it, so dropping it from the apply relinquishes ownership
+    // and the apiserver removes the key.
     const after = NGINX_DEPLOYMENT.replace(
       `    app.kubernetes.io/version: "1.25.3"\n`,
       "",
     );
     const ops = computeOps(NGINX_DEPLOYMENT, after);
     const yaml = buildMinimalSSA(ops, IDENTITY);
-    // SSA expresses removal-of-managed-field by setting it to null
-    // (or `~` in PLAIN scalar style).
-    expect(yaml).toMatch(/app\.kubernetes\.io\/version: ~/);
+    // The removed key must not appear in the payload at all.
+    expect(yaml).not.toMatch(/app\.kubernetes\.io\/version/);
+    // And we must not be writing a null sentinel anywhere.
+    expect(yaml).not.toMatch(/:\s*~\s*$/m);
+    // Re-parsing should yield a payload whose labels map has no
+    // `app.kubernetes.io/version` key (verifying we didn't accidentally
+    // leave behind a `key: null` JS entry).
+    const { obj } = parseOrThrow(yaml);
+    const labels = ((obj as Record<string, unknown>).metadata as Record<string, unknown>)
+      .labels as Record<string, unknown> | undefined;
+    if (labels !== undefined) {
+      expect(Object.keys(labels)).not.toContain("app.kubernetes.io/version");
+    }
+  });
+
+  it("removes a ServiceAccount label cleanly (sibling-label preservation, hotfix v1.1.1)", () => {
+    // Direct repro of the user-reported v1.1.0 bug: a ServiceAccount
+    // with a periscope-added `test:` label. Deleting the label line in
+    // the editor must produce a payload that OMITS the `test` key
+    // entirely, not one that submits `test: ~`. The latter caused the
+    // apiserver to persist `test: ""` because labels are a
+    // map[string]string and null is coerced to the zero value of the
+    // value type.
+    const before = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: certwatch-monitoring
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: alloy
+    test: anything
+`;
+    const after = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: certwatch-monitoring
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: alloy
+`;
+    const ops = computeOps(before, after);
+    const yaml = buildMinimalSSA(ops, {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      name: "alloy",
+      namespace: "certwatch-monitoring",
+    });
+    // The `test` key must not appear in the payload at all — neither
+    // as `test: ~` nor as `test: ""`.
+    expect(yaml).not.toMatch(/\btest\s*:/);
+    // Sibling labels owned by other field managers must not be touched
+    // (minimal-SSA: we only include fields the user changed).
+    expect(yaml).not.toMatch(/app\.kubernetes\.io\/component/);
+    expect(yaml).not.toMatch(/app\.kubernetes\.io\/name/);
   });
 
   it("produces well-formed YAML that round-trips", () => {

--- a/web/src/lib/yamlPatch.test.ts
+++ b/web/src/lib/yamlPatch.test.ts
@@ -5,6 +5,7 @@ import {
   MultiDocumentError,
   parseOrThrow,
   type Identity,
+  type Op,
 } from "./yamlPatch";
 
 const NGINX_DEPLOYMENT = `apiVersion: apps/v1
@@ -264,5 +265,79 @@ describe("buildMinimalSSA", () => {
     expect(parsed.apiVersion).toBe("apps/v1");
     expect(parsed.kind).toBe("Deployment");
     expect(((parsed.spec as Record<string, unknown>).replicas)).toBe(5);
+  });
+
+  it("does not duplicate associative-list entries when two ops target the same MergeKey-leaf (hotfix v1.1.1)", () => {
+    // Regression test for the duplicate-ports SSA-rejection bug. The
+    // bug fired when buildMinimalSSA applied two replace-ops both
+    // ending in a MergeKey-leaf at the same logical position
+    // (e.g. retained-ownership emitting both a container-level `.`
+    // claim and a port-level `.` claim from managedFields for the
+    // same physical port).
+    //
+    // Before the fix: Op 1's setLeaf MergeKey-leaf branch PUSHed an
+    // entry whose `containerPort` was overridden to a *number* by the
+    // value spread; Op 2's findIndex used strict `===` against the
+    // stringified keyValue and missed the existing entry, PUSHing a
+    // duplicate. K8s SSA rejected the body with "failed to create
+    // typed patch object: .spec.template.spec.containers[name=X].ports:
+    // duplicate entries for key [containerPort=N, protocol=\"TCP\"]".
+    //
+    // After the fix: setLeaf uses loose `String(x[k]) === v` matching
+    // the same convention as stepInto. The second op merges into the
+    // existing entry instead of PUSHing.
+    const portValue = {
+      containerPort: 4000,
+      name: "4000tcp",
+      protocol: "TCP",
+    };
+    const ops: Op[] = [
+      {
+        op: "replace",
+        path: [
+          "spec",
+          "template",
+          "spec",
+          "containers",
+          { name: "ai-rules-engine-dev" },
+          "ports",
+          { containerPort: "4000" },
+        ],
+        value: portValue,
+      },
+      // Same MergeKey-leaf path applied a second time — simulates the
+      // overlapping-managedFields scenario where retained-ownership
+      // emits the same port twice via different fieldsV1 traversals.
+      {
+        op: "replace",
+        path: [
+          "spec",
+          "template",
+          "spec",
+          "containers",
+          { name: "ai-rules-engine-dev" },
+          "ports",
+          { containerPort: "4000" },
+        ],
+        value: portValue,
+      },
+    ];
+    const yaml = buildMinimalSSA(ops, IDENTITY);
+    const { obj } = parseOrThrow(yaml);
+    const parsed = obj as Record<string, unknown>;
+    const containers = (
+      ((parsed.spec as Record<string, unknown>).template as Record<string, unknown>)
+        .spec as Record<string, unknown>
+    ).containers as Array<Record<string, unknown>>;
+    expect(containers).toHaveLength(1);
+    const ports = containers[0].ports as Array<Record<string, unknown>>;
+    // The critical assertion: ports must NOT be duplicated. Before the
+    // fix this would have been length 2.
+    expect(ports).toHaveLength(1);
+    expect(ports[0]).toMatchObject({
+      containerPort: 4000,
+      name: "4000tcp",
+      protocol: "TCP",
+    });
   });
 });

--- a/web/src/lib/yamlPatch.ts
+++ b/web/src/lib/yamlPatch.ts
@@ -392,9 +392,17 @@ function setLeaf(node: unknown, seg: PathSegment, value: unknown | typeof REMOVE
       throw new Error(`setLeaf: expected map for "${seg}" but got ${typeof node}`);
     }
     if (value === REMOVE_SENTINEL) {
-      // SSA: setting a managed field to null tells the apiserver to drop
-      // it. Marker form for downstream stringify.
-      node[seg] = null;
+      // SSA per-key ownership: omit the key from the apply payload.
+      // Since periscope-spa previously owned this field, dropping it
+      // from the apply relinquishes ownership → the apiserver removes
+      // the key from the resource. Mirrors the merge-key branch below.
+      //
+      // Writing `null` here (the v1.1.0 behavior) is WRONG for atomic
+      // map-of-string fields like `metadata.labels.*` and
+      // `metadata.annotations.*`: the apiserver coerces null → "" for
+      // the value type and leaves the key in place with an empty
+      // string instead of removing it. Hotfix v1.1.1.
+      delete node[seg];
     } else {
       node[seg] = value;
     }

--- a/web/src/lib/yamlPatch.ts
+++ b/web/src/lib/yamlPatch.ts
@@ -406,8 +406,16 @@ function setLeaf(node: unknown, seg: PathSegment, value: unknown | typeof REMOVE
     throw new Error(`setLeaf: expected array for merge-key seg, got ${typeof node}`);
   }
   const [keyName, keyValue] = entryOf(seg);
+  // String() coercion mirrors stepInto's loose match — required because
+  // when the MergeKey-leaf branch first PUSHes an entry, the spread
+  // `{ ...value }` overrides the stringified keyValue with the value's
+  // typed-field (e.g. `containerPort: 4000` as number). A subsequent
+  // op for the same MergeKey would miss the existing entry under strict
+  // `===` and push a duplicate, surfacing as K8s SSA
+  // "failed to create typed patch object: duplicate entries for key"
+  // (see hotfix v1.1.1 / RFC 0005 §2.1).
   const idx = (node as Record<string, unknown>[]).findIndex(
-    (x) => isPlainObject(x) && x[keyName] === keyValue,
+    (x) => isPlainObject(x) && String(x[keyName]) === keyValue,
   );
   if (value === REMOVE_SENTINEL) {
     // SSA atomic-list removal isn't expressible by absence — but for


### PR DESCRIPTION
## Summary

Hotfix release bundling four production-affecting bugs discovered post-v1.1.0 launch (2026-05-19). All four were either reproduced on a real cluster or caught via direct user report against `demo.periscopehq.dev` / `kind-certwatch`; all four have regression coverage and a temp-revert verification step.

1. **Apply: duplicate `containers[].ports[]` entries** rejected by the apiserver on every Deployment restart / YAML edit on workloads with overlapping `periscope-spa` managedFields claims.
2. **Edit: blank Monaco editor** on 14 resource kinds (5 RBAC/ServiceAccount + 9 "extras" kinds) — the action bar appeared but the YAML body never loaded.
3. **Audit: sidebar-probe flood** of `karpenter_read` rows on every cluster page mount, drowning real operator-intent actions in the `/audit` view.
4. **Apply: deleted labels/annotations persisted with empty-string values** instead of being removed — Periscope wrote `key: ~` (null) into the apply payload; apiserver coerced null → `""` for the string value type and the key stayed put.

## Fix 1 — Apply: duplicate `containers[].ports[]` rejection

Symptom: every restart / YAML edit on affected deployments failed with

```
failed to create typed patch object:
.spec.template.spec.containers[name=X].ports:
duplicate entries for key [containerPort=N, protocol="TCP"]
```

Root cause: `web/src/lib/yamlPatch.ts:setLeaf` MergeKey-leaf branch used **strict** `x[k] === v` for `findIndex`, while the parallel `stepInto` uses **loose** `String(x[k]) === v`. When the SSA body builder applied two retained-ownership ops both ending in a MergeKey-leaf at the same logical position: Op 1 PUSHed an entry whose spread `{ ...value }` overrode the stringified `keyValue` with the value's typed field (e.g. `containerPort: 4000` as a **number**); Op 2's strict-equality `findIndex` missed the existing entry and PUSHed a duplicate.

Fix: one-line change — `setLeaf`'s MergeKey-leaf `findIndex` predicate now uses `String(x[keyName]) === keyValue`, matching the convention `stepInto` already uses. Locks the loose-equality contract across both branches of the same operator.

## Fix 2 — Edit: blank Monaco editor on Access + Extras kinds

Symptom: clicking the edit pencil on ServiceAccount, Role, ClusterRole, RoleBinding, ClusterRoleBinding, HorizontalPodAutoscaler, PodDisruptionBudget, ReplicaSet, NetworkPolicy, IngressClass, ResourceQuota, LimitRange, PriorityClass, or RuntimeClass rendered a blank Monaco editor — action bar present, YAML body never loaded. Read-only YAML view was unaffected; YAML edit specifically broke.

Root cause: the YAML backend handlers for these 14 kinds (`internal/k8s/rbac.go` × 5, `internal/k8s/extras.go` × 9) didn't set `raw.APIVersion` and `raw.Kind` on the typed object returned from client-go before marshaling. Every other YAML handler in `internal/k8s/` (deployments, statefulsets, services, secrets, pods, configmaps, namespaces, cronjobs, endpointslices, ...) sets these explicitly to compensate for client-go's well-known TypeMeta-empty-on-Get behavior; these 14 handlers were missed. Resulting YAML had no `apiVersion:` / `kind:` lines, so the SPA editor's `parseIdentityFromYaml` returned null, `gvk` stayed null, and the Monaco mount effect short-circuited before creating the editor model.

Fix: each affected handler now sets the correct `APIVersion` and `Kind` before `formatYAML`. The 14 handlers are now symmetric with every other YAML handler in the package.

## Fix 3 — Audit: Karpenter sidebar-probe flood

Symptom: clusters without Karpenter still saw a continuous stream of `karpenter_read` audit rows in `/audit`, drowning real operator actions. Same problem on Karpenter-installed clusters via the `list` op.

Root cause: the SPA's `KarpenterSidebarEntry` fired `GET /api/clusters/{c}/karpenter` on every cluster page mount (not just dashboard opens) to decide whether to render the sidebar nav link. The handler emitted an audit row on every call — including its `available_false` auto-detect short-circuit.

Fix: split into a dedicated `GET /api/clusters/{c}/karpenter/availability` endpoint that returns `{available: bool}` without emitting an audit row. The full `/karpenter` dashboard endpoint retains its existing audit emission, which now fires only on intentional operator navigation to the dashboard. SPA-side, `useKarpenter` (dashboard) and a new `useKarpenterAvailability` (sidebar) are wired separately. Purely additive — existing `/karpenter` callers unaffected, no Helm values change.

## Fix 4 — Apply: deleted labels/annotations persisting as `""`

Symptom: in the YAML editor, deleting a `test: foo` label line from a ServiceAccount (or any resource) and clicking Apply persisted the resource with `test: ""` on the next read — the key was still there, just blanked out.

Root cause: `web/src/lib/yamlPatch.ts:setLeaf` string-keyed REMOVE branch wrote `node[seg] = null`, which `buildMinimalSSA` stringified as `test: ~`. The apiserver received `{labels: {test: null}}` and, because `metadata.labels` is an atomic `map[string]string`, coerced `null` → `""` (the zero value of the value type). Key stayed; value blanked. The comment claimed "setting a managed field to null tells the apiserver to drop it" — that premise is wrong for atomic map-of-string fields. The merge-key branch immediately below already had the correct "omit, don't null" behavior for array-element removals; the string-keyed branch was the asymmetric one.

Fix: `delete node[seg]` instead of `node[seg] = null`. Under SSA's per-key ownership model, `periscope-spa` previously owned that field; dropping it from the apply relinquishes ownership and the apiserver removes the key. Sibling labels owned by other field managers (Helm's `app.kubernetes.io/name` etc.) are unaffected.

## Test plan

- ✅ `web/src/lib/yamlPatch.test.ts` — regression test for the duplicate-ports scenario (Fix 1); existing "expresses removals as null leaves" test rewritten to assert key-absence + new SA-specific repro mirroring the user-reported scenario (Fix 4).
- ✅ `web/src/lib/applyBodyBuilder.test.ts` — retained-ownership remove test updated to assert key-absence on the `drop-me` annotation (Fix 4).
- ✅ `internal/k8s/rbac_test.go` — new file, 5 regression tests asserting each Access-group handler's output contains the expected `apiVersion:` / `kind:` lines (Fix 2).
- ✅ `cmd/periscope/karpenter_handler_test.go` — 4 new tests for the availability handler (`_NotInstalledNoAudit`, `_InstalledNoAudit`, `_DetectErrorNoAudit`, `_ClusterNotFoundReturns404`), each asserting `len(sink.snapshot()) == 0` (Fix 3).
- ✅ All four fixes verified by temp-revert: tests fail without the fix, pass with it.
- ✅ Full web test suite: **491 tests passing**.
- ✅ `tsc --noEmit` clean; production `pnpm build` clean.
- ✅ `go build ./...` and `go test ./...` clean (all 13 packages).
- ✅ Verified locally on `kind-certwatch` and the live `demo.periscopehq.dev` cluster:
  - `discussions/v1.1.1-test-fixtures.sh` deployments (named-port / no-protocol / multi-port) restart + YAML-edit cleanly with the patched binary; same operations fail with the v1.1.0 binary
  - Access-group + extras YAML edit now loads in Monaco
  - `/audit` no longer shows `karpenter_read` rows from sidebar probes
  - Deleting a label in the editor on a ServiceAccount removes the key (not blanks it)
- ✅ CHANGELOG entries added for all four fixes under `[1.1.1] - 2026-05-19`.
