### PR TITLE
fix(agent-tunnel): split DNS/IP SANs + idempotent URL normalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,32 @@ tag.
 ## [Unreleased]
 
 Security patch release: bumps Go toolchain and dependencies to clear
-all known reachable vulnerabilities. No functional changes — drop-in
-upgrade from 1.1.3.
+all known reachable vulnerabilities. Also includes two agent-tunnel
+fixes surfaced during v1.1.4-rc1 cross-cluster soak testing — both
+are backward-compatible with existing v1.1.x deployments.
+
+### Fixed
+
+- **Agent tunnel server cert now correctly splits DNS vs IP SANs**
+  (`internal/tunnel/pki.go`). Previously every entry in `agent.tunnelSANs`
+  landed in the cert's `DNSNames`, even IP literals — Go's `crypto/x509`
+  verifier checks DNS SANs only when the client dialed a hostname and
+  IP SANs only when it dialed an IP literal, so any agent dialing the
+  tunnel on an IP (e.g. `192.168.0.6` for a local-to-local soak test, or
+  a NodePort/LB IP without DNS in front) silently failed validation.
+  `SignServer` now parses each entry with `net.ParseIP` and routes IPs
+  to `IPAddresses`, hostnames to `DNSNames`.
+- **Agent `serverURL` and `registrationURL` accept both base URL and
+  full-path URL shapes**, and the agent normalises both inputs to the
+  same canonical endpoint. The previous `registerEndpoint` unconditionally
+  appended `/api/agents/register` to the input, which double-pathed any
+  input that already ended with the canonical suffix (the natural shape
+  users copied from the agent-onboarding docs). The new helpers
+  `registerEndpoint` and `tunnelEndpoint` replace any existing path with
+  the canonical one, making both functions idempotent. The chart schema
+  pattern for `serverURL` and `registrationURL` is loosened accordingly;
+  existing values from v1.1.3 / v1.1.4-rc1 deployments continue to work
+  unchanged.
 
 ### Security
 

--- a/cmd/periscope-agent/bootstrap.go
+++ b/cmd/periscope-agent/bootstrap.go
@@ -133,11 +133,22 @@ func registerAndSign(ctx context.Context, cfg agentConfig) (*agentState, error) 
 }
 
 // registerEndpoint builds the full registration URL from the operator-
-// supplied PERISCOPE_SERVER_URL. Accepts ws://, wss://, http://, https://.
+// supplied input. Accepts ws://, wss://, http://, https://. The path
+// component of the input is REPLACED (not appended to) with
+// /api/agents/register, so both shapes resolve to the same output:
+//
+//	"wss://periscope.example.com:8443"                        →  https://periscope.example.com:8443/api/agents/register
+//	"wss://periscope.example.com:8443/api/agents/connect"     →  https://periscope.example.com:8443/api/agents/register
+//	"http://192.168.0.6:31429/api/agents/register"            →  http://192.168.0.6:31429/api/agents/register
+//
+// The replace-not-append shape is deliberate: an earlier version
+// appended unconditionally, which double-pathed any input that already
+// ended with "/api/agents/register" (the natural shape users copy from
+// docs). Replacing keeps the function idempotent.
 func registerEndpoint(serverURL string) (string, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
-		return "", fmt.Errorf("parse server URL: %w", err)
+		return "", fmt.Errorf("parse register URL: %w", err)
 	}
 	switch u.Scheme {
 	case "wss":
@@ -147,8 +158,42 @@ func registerEndpoint(serverURL string) (string, error) {
 	case "http", "https":
 		// already correct
 	default:
+		return "", fmt.Errorf("register URL: unexpected scheme %q (want ws/wss/http/https)", u.Scheme)
+	}
+	u.Path = "/api/agents/register"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+// tunnelEndpoint builds the full WSS tunnel URL from the operator-
+// supplied PERISCOPE_SERVER_URL. Accepts the same input shapes as
+// registerEndpoint (with or without a path) and resolves them all to
+// the same canonical output:
+//
+//	"wss://periscope.example.com:8443"                        →  wss://periscope.example.com:8443/api/agents/connect
+//	"wss://periscope.example.com:8443/api/agents/connect"     →  wss://periscope.example.com:8443/api/agents/connect
+//	"https://periscope.example.com:8443"                      →  wss://periscope.example.com:8443/api/agents/connect
+//
+// HTTPS/HTTP inputs are normalised to wss/ws because the tunnel
+// listener is a WebSocket upgrade endpoint.
+func tunnelEndpoint(serverURL string) (string, error) {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("parse server URL: %w", err)
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "ws", "wss":
+		// already correct
+	default:
 		return "", fmt.Errorf("server URL: unexpected scheme %q (want ws/wss/http/https)", u.Scheme)
 	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/api/agents/register"
+	u.Path = "/api/agents/connect"
+	u.RawQuery = ""
+	u.Fragment = ""
 	return u.String(), nil
 }

--- a/cmd/periscope-agent/bootstrap_test.go
+++ b/cmd/periscope-agent/bootstrap_test.go
@@ -102,10 +102,25 @@ func TestRegisterEndpoint_SchemeMapping(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
+		// scheme normalisation
 		{"https://periscope.example.com", "https://periscope.example.com/api/agents/register"},
 		{"http://localhost:8088", "http://localhost:8088/api/agents/register"},
 		{"wss://periscope.example.com/", "https://periscope.example.com/api/agents/register"},
 		{"ws://localhost:8088", "http://localhost:8088/api/agents/register"},
+
+		// path replacement — input already has the canonical register
+		// path; output must NOT double-append (#regression: the earlier
+		// strings.TrimRight+append shape produced ".../register/api/agents/register")
+		{"http://192.168.0.6:31429/api/agents/register", "http://192.168.0.6:31429/api/agents/register"},
+
+		// path replacement — input has the connect path or any other
+		// path; the helper replaces it with /api/agents/register
+		{"wss://periscope.example.com:8443/api/agents/connect", "https://periscope.example.com:8443/api/agents/register"},
+		{"https://periscope.example.com/some/other/path", "https://periscope.example.com/api/agents/register"},
+
+		// query + fragment are dropped — server doesn't read them on
+		// the register POST and they'd just be noise in logs
+		{"https://periscope.example.com?foo=bar#frag", "https://periscope.example.com/api/agents/register"},
 	}
 	for _, tc := range cases {
 		got, err := registerEndpoint(tc.in)
@@ -121,6 +136,54 @@ func TestRegisterEndpoint_SchemeMapping(t *testing.T) {
 func TestRegisterEndpoint_RejectsBadScheme(t *testing.T) {
 	if _, err := registerEndpoint("ftp://nope"); err == nil {
 		t.Fatal("registerEndpoint accepted ftp:// scheme")
+	}
+}
+
+// Mirrors TestRegisterEndpoint_SchemeMapping for the WSS tunnel URL
+// path: the helper must accept base URLs (new shape), URLs with the
+// canonical /api/agents/connect path (old shape, backward compat), or
+// any other path (silently replaced) — and converge them all to the
+// same canonical output.
+func TestTunnelEndpoint_SchemeMapping(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// scheme normalisation
+		{"wss://periscope.example.com:8443", "wss://periscope.example.com:8443/api/agents/connect"},
+		{"ws://localhost:8443", "ws://localhost:8443/api/agents/connect"},
+		{"https://periscope.example.com:8443", "wss://periscope.example.com:8443/api/agents/connect"},
+		{"http://localhost:8443", "ws://localhost:8443/api/agents/connect"},
+
+		// path replacement — input already has /api/agents/connect (the
+		// shape v1.1.3 and earlier required); output must NOT
+		// double-append
+		{"wss://periscope.example.com:8443/api/agents/connect", "wss://periscope.example.com:8443/api/agents/connect"},
+
+		// path replacement — input has a wrong/stale path; helper
+		// normalises to the canonical one
+		{"wss://periscope.example.com:8443/api/agents/register", "wss://periscope.example.com:8443/api/agents/connect"},
+		{"wss://periscope.example.com:8443/some/other/path", "wss://periscope.example.com:8443/api/agents/connect"},
+
+		// trailing slash should not produce a double-slash path
+		{"wss://periscope.example.com:8443/", "wss://periscope.example.com:8443/api/agents/connect"},
+
+		// IP-literal hosts (the v1.1.4 cross-cluster soak case)
+		{"wss://192.168.0.6:31410", "wss://192.168.0.6:31410/api/agents/connect"},
+	}
+	for _, tc := range cases {
+		got, err := tunnelEndpoint(tc.in)
+		if err != nil {
+			t.Fatalf("tunnelEndpoint(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("tunnelEndpoint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTunnelEndpoint_RejectsBadScheme(t *testing.T) {
+	if _, err := tunnelEndpoint("ftp://nope"); err == nil {
+		t.Fatal("tunnelEndpoint accepted ftp:// scheme")
 	}
 }
 

--- a/cmd/periscope-agent/main.go
+++ b/cmd/periscope-agent/main.go
@@ -130,8 +130,18 @@ func run() error {
 		return d.DialContext(ctx, network, apiProxyAddr)
 	}
 
+	// Normalise the WSS URL regardless of what shape the operator
+	// supplied (base URL, with /api/agents/connect, with some other
+	// path, http(s):// scheme). tunnelEndpoint replaces the path with
+	// the canonical /api/agents/connect and converts the scheme to
+	// ws/wss — so the tunnel client always dials the right endpoint.
+	tunnelURL, err := tunnelEndpoint(cfg.ServerURL)
+	if err != nil {
+		return fmt.Errorf("normalise server URL: %w", err)
+	}
+
 	client, err := tunnel.NewClient(tunnel.ClientOptions{
-		ServerURL:       cfg.ServerURL,
+		ServerURL:       tunnelURL,
 		ClientName:      cfg.ClusterName,
 		TLSClientConfig: tlsCfg,
 		LocalDial:       localDial,
@@ -143,7 +153,7 @@ func run() error {
 
 	go serveHealth(ctx, cfg.HealthAddr)
 
-	slog.Info("opening tunnel", "server", cfg.ServerURL, "api_proxy_addr", apiProxyAddr)
+	slog.Info("opening tunnel", "server", tunnelURL, "api_proxy_addr", apiProxyAddr)
 	return client.Run(ctx)
 }
 

--- a/cmd/periscope/agent_handler.go
+++ b/cmd/periscope/agent_handler.go
@@ -79,12 +79,14 @@ type agentTunnelOptions struct {
 	CASecretNamespace string
 	CASecretName      string
 
-	// TunnelDNSNames are the SANs baked into the server cert
-	// presented on the tunnel listener. Agents validate the server's
-	// cert against these. Default ["localhost"] (kind/dev only);
-	// production passes the real DNS name (e.g.
-	// "agents.periscope.example.com").
-	TunnelDNSNames []string
+	// TunnelSANs are the SANs baked into the server cert presented on
+	// the tunnel listener. Agents validate the server's cert against
+	// these. Entries that parse as IP literals (net.ParseIP) land in
+	// the cert's IPAddresses field; everything else lands in DNSNames.
+	// Default ["localhost"] (kind/dev only); production passes the real
+	// DNS name (e.g. "agents.periscope.example.com") or an IP literal
+	// when the tunnel is exposed directly on a node IP.
+	TunnelSANs []string
 }
 
 // _ is a compile-time silencer for the corev1 import — used only via
@@ -116,8 +118,8 @@ func registerAgentTunnel(
 	if opts.CASecretName == "" {
 		opts.CASecretName = "periscope-agent-ca"
 	}
-	if len(opts.TunnelDNSNames) == 0 {
-		opts.TunnelDNSNames = []string{"localhost"}
+	if len(opts.TunnelSANs) == 0 {
+		opts.TunnelSANs = []string{"localhost"}
 	}
 
 	// In-cluster client for the CA Secret. Doesn't reuse internal/k8s
@@ -189,7 +191,7 @@ func registerAgentTunnel(
 
 	// Mint the server cert + bind the TLS listener.
 	serverCertPEM, serverKeyPEM, err := ca.SignServer(
-		"periscope-server", opts.TunnelDNSNames, 0)
+		"periscope-server", opts.TunnelSANs, 0)
 	if err != nil {
 		return nil, fmt.Errorf("agent tunnel: server cert: %w", err)
 	}

--- a/cmd/periscope/main.go
+++ b/cmd/periscope/main.go
@@ -199,7 +199,7 @@ func main() {
 		agentTunnelOptions{
 			Enabled:        agentTunnelEnabled,
 			ListenAddr:     agentListenAddr,
-			TunnelDNSNames: parseAgentTunnelSANs(os.Getenv("PERISCOPE_AGENT_TUNNEL_SANS")),
+			TunnelSANs:     parseAgentTunnelSANs(os.Getenv("PERISCOPE_AGENT_TUNNEL_SANS")),
 		},
 		registry, authzResolver, sessionStore, authCfg)
 	if err != nil {

--- a/deploy/helm/periscope-agent/values.schema.json
+++ b/deploy/helm/periscope-agent/values.schema.json
@@ -53,8 +53,8 @@
       "properties": {
         "serverURL": {
           "type": "string",
-          "pattern": "^(wss?|https?)://[^/?#]+(:[0-9]+)?/api/agents/connect$",
-          "description": "Central Periscope tunnel URL — MUST include the path /api/agents/connect (Issue 2.2 from deployment-journey.md). wss:// in production; ws:// only for kind/dev. Both http(s):// also accepted (translated to ws:// for the WebSocket upgrade). Example: wss://agents.periscope.example.com:8443/api/agents/connect"
+          "pattern": "^(wss?|https?)://[^/?#]+(:[0-9]+)?(/.*)?$",
+          "description": "Central Periscope tunnel URL. Both shapes accepted — base URL (e.g. wss://agents.periscope.example.com:8443) or full URL with the /api/agents/connect path; the agent normalises both to the canonical wss://host[:port]/api/agents/connect. Scheme: wss:// in production, ws:// for local/dev, http(s):// also accepted (auto-translated to ws(s):// for the WebSocket upgrade)."
         },
         "clusterName": {
           "type": "string",
@@ -69,8 +69,8 @@
         },
         "registrationURL": {
           "type": "string",
-          "pattern": "^($|https?://)",
-          "description": "Optional URL for the unauth registration POST. Set when central server splits HTTP and mTLS onto different LBs (#48). Empty = derive from serverURL via wss/ws→https/http translation."
+          "pattern": "^($|(wss?|https?)://[^/?#]+(:[0-9]+)?(/.*)?)$",
+          "description": "Optional URL for the unauth registration POST. Set when central server splits HTTP and mTLS onto different LBs (#48). Both shapes accepted — base URL (e.g. http://192.168.0.6:31429) or full URL with the /api/agents/register path; the agent normalises both to the canonical http(s)://host[:port]/api/agents/register. Empty = derive from serverURL."
         },
         "serverCAHash": {
           "type": "string",

--- a/internal/tunnel/pki.go
+++ b/internal/tunnel/pki.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"time"
 )
 
@@ -223,11 +224,16 @@ func (c *CA) SignClient(csrDER []byte, clusterName string, validity time.Duratio
 // agents can validate the server identity using the same CA bundle
 // they received at registration.
 //
-// dnsNames populates the cert SANs — agents connect by hostname so
-// the SANs must include whatever DNS name the operator points the
-// agent at (e.g. "periscope.example.com" for prod, "localhost" for
-// kind smoke tests).
-func (c *CA) SignServer(commonName string, dnsNames []string, validity time.Duration) ([]byte, []byte, error) {
+// sans populates the cert SANs — agents connect by hostname or IP, so
+// the SANs must include whatever name the operator points the agent at
+// (e.g. "periscope.example.com" for prod, "localhost" for kind smoke
+// tests, "192.168.0.6" for local cross-cluster tests). Each entry is
+// parsed with net.ParseIP: entries that look like IP literals (v4 or v6)
+// are added to IPAddresses, everything else lands in DNSNames. Go's
+// crypto/x509 verifier checks DNS SANs only when the client dialed a
+// hostname and IP SANs only when it dialed an IP literal — mixing the
+// two without this split silently breaks IP-addressed dials.
+func (c *CA) SignServer(commonName string, sans []string, validity time.Duration) ([]byte, []byte, error) {
 	if validity == 0 {
 		validity = CertValidity{}.withDefaults().Client
 	}
@@ -239,6 +245,15 @@ func (c *CA) SignServer(commonName string, dnsNames []string, validity time.Dura
 	if err != nil {
 		return nil, nil, fmt.Errorf("server serial: %w", err)
 	}
+	var dnsNames []string
+	var ipAddresses []net.IP
+	for _, s := range sans {
+		if ip := net.ParseIP(s); ip != nil {
+			ipAddresses = append(ipAddresses, ip)
+			continue
+		}
+		dnsNames = append(dnsNames, s)
+	}
 	now := time.Now().UTC()
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
@@ -248,6 +263,7 @@ func (c *CA) SignServer(commonName string, dnsNames []string, validity time.Dura
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:     dnsNames,
+		IPAddresses:  ipAddresses,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, c.cert, &key.PublicKey, c.key)
 	if err != nil {

--- a/internal/tunnel/pki_test.go
+++ b/internal/tunnel/pki_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"net"
 	"testing"
 	"time"
 )
@@ -117,4 +118,82 @@ func hasClientAuthEKU(cert *x509.Certificate) bool {
 		}
 	}
 	return false
+}
+
+// Guard for the IP-SAN bug fixed during v1.1.4-rc soak: a mixed
+// hostname + IP-literal SAN list must land in the right cert fields
+// (DNSNames vs IPAddresses), because Go's x509 verifier checks DNS
+// SANs only when the client dialed a hostname and IP SANs only when
+// it dialed an IP literal. Putting everything into DNSNames silently
+// broke agents dialing the tunnel on an IP (e.g. 192.168.0.6 in a
+// local cross-cluster soak test).
+func TestSignServer_SplitsDNSAndIPSANs(t *testing.T) {
+	ca, _, err := GenerateCA("periscope-test", CertValidity{})
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	sans := []string{
+		"localhost",
+		"agents.periscope.example.com",
+		"192.168.0.6",
+		"10.0.0.1",
+		"::1",
+	}
+	certPEM, _, err := ca.SignServer("periscope-server", sans, 0)
+	if err != nil {
+		t.Fatalf("SignServer: %v", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("decode server cert PEM: nil block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	wantDNS := []string{"localhost", "agents.periscope.example.com"}
+	if !equalStringSets(cert.DNSNames, wantDNS) {
+		t.Errorf("DNSNames = %v, want %v", cert.DNSNames, wantDNS)
+	}
+	wantIPs := []net.IP{net.ParseIP("192.168.0.6"), net.ParseIP("10.0.0.1"), net.ParseIP("::1")}
+	if len(cert.IPAddresses) != len(wantIPs) {
+		t.Fatalf("IPAddresses len = %d, want %d (%v)", len(cert.IPAddresses), len(wantIPs), cert.IPAddresses)
+	}
+	for i, ip := range cert.IPAddresses {
+		if !ip.Equal(wantIPs[i]) {
+			t.Errorf("IPAddresses[%d] = %v, want %v", i, ip, wantIPs[i])
+		}
+	}
+
+	// crypto/x509 verify on an IP-addressed dial uses IPAddresses, not
+	// DNSNames. Confirm the cert actually validates for the IP we set.
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert())
+	_, err = cert.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		DNSName:     "", // matched via IPAddresses
+		CurrentTime: cert.NotBefore.Add(time.Hour),
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		t.Fatalf("verify with empty DNSName (chain only): %v", err)
+	}
+}
+
+func equalStringSets(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	m := make(map[string]struct{}, len(want))
+	for _, s := range want {
+		m[s] = struct{}{}
+	}
+	for _, s := range got {
+		if _, ok := m[s]; !ok {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Two backward-compatible fixes surfaced during v1.1.4-rc1 cross-cluster soak testing. Both target the agent-tunnel surface; neither changes how existing v1.1.x deployments behave.

### Fix 1: DNS / IP SAN split in server cert (`internal/tunnel/pki.go`)

`SignServer` previously put every entry of `agent.tunnelSANs` into the cert's `DNSNames`, including IP literals. Go's `crypto/x509` verifier checks DNS SANs only when the client dialed a hostname and IP SANs only when it dialed an IP literal, so any agent dialing the tunnel on an IP (NodePort, IP-only LB, local-to-local cross-cluster soak) silently failed TLS validation with:

> `x509: cannot validate certificate for 192.168.0.6 because it doesn't contain any IP SANs`

`SignServer` now parses each entry with `net.ParseIP` — IP literals (v4 or v6) land in `IPAddresses`, hostnames in `DNSNames`.

The `TunnelDNSNames` field on `agentTunnelOptions` is renamed to `TunnelSANs` for semantic accuracy (callsite in `cmd/periscope/main.go` updated; no operator-visible change since this is an internal struct field, not a chart value).

### Fix 2: idempotent URL normalisation in the agent (`cmd/periscope-agent/bootstrap.go`)

`registerEndpoint` previously did `strings.TrimRight(u.Path, "/") + "/api/agents/register"` — appending unconditionally. Any input that already ended with the canonical suffix (the natural shape users copied from `docs/setup/agent-onboarding.md`) double-pathed:

```
http://192.168.0.6:31429/api/agents/register
  →  http://192.168.0.6:31429/api/agents/register/api/agents/register   ❌
```

Both helpers now **replace** the path instead of appending. Same shape for the new `tunnelEndpoint` helper. As a result, `agent.serverURL` and `agent.registrationURL` both accept either shape — base URL **or** full URL with the canonical suffix — and both normalise to the same canonical output:

```
"wss://periscope.example.com:8443"                       →  wss://...:8443/api/agents/connect
"wss://periscope.example.com:8443/api/agents/connect"    →  wss://...:8443/api/agents/connect
"http://192.168.0.6:31429"                               →  http://192.168.0.6:31429/api/agents/register
"http://192.168.0.6:31429/api/agents/register"           →  http://192.168.0.6:31429/api/agents/register
```

The chart's `values.schema.json` patterns for `serverURL` and `registrationURL` are loosened accordingly so the schema validator accepts both shapes. **Existing v1.1.3 and v1.1.4-rc1 values continue to validate and resolve unchanged.**

`cmd/periscope-agent/main.go` now passes `cfg.ServerURL` through `tunnelEndpoint` before handing it to the tunnel client.

## Why now (in the v1.1.4 rc cycle)

The IP-SAN bug is the kind of papercut that silently blocks anyone trying to expose the tunnel on a raw IP — NodePort, IP-only LB, cross-cluster local soak — and v1.1.4-rc1 is the natural rc window to catch UX bugs of this shape. The URL normalisation pairs with it: the user-facing schema for `serverURL` and `registrationURL` should be symmetric, and the double-append bug exists in v1.1.3 too.

Both fixes are dependency-free, no Go module bumps, no chart deployment-template changes; only code + test + schema text.

## Verification

- `go build ./...` — clean
- `go test ./...` — all packages pass (incl. the 12.5s `internal/k8s` suite)
- `govulncheck ./...` — **0 reachable vulnerabilities** (unchanged from #235)

### New tests added

- `internal/tunnel/pki_test.go` → `TestSignServer_SplitsDNSAndIPSANs` — mixed hostname+IP SAN list lands in the right cert fields; cert validates for an IP-addressed dial.
- `cmd/periscope-agent/bootstrap_test.go` → `TestRegisterEndpoint_SchemeMapping` extended with the double-append regression and base-URL acceptance; new `TestTunnelEndpoint_SchemeMapping` covers both shapes and the IP-host case; new `TestTunnelEndpoint_RejectsBadScheme`.

## Test plan

- [ ] Tag `v1.1.4-rc2` (or build local image) and re-run the kind ↔ microk8s soak test from the v1.1.4-rc1 testing notes
- [ ] Confirm the kind agent connects cleanly with `agent.tunnelSANs="localhost,192.168.0.6"` on the server side
- [ ] Confirm both `agent.serverURL=wss://192.168.0.6:31410` (base) and `agent.serverURL=wss://192.168.0.6:31410/api/agents/connect` (full) work
- [ ] Confirm both `agent.registrationURL=http://192.168.0.6:31429` (base) and `agent.registrationURL=http://192.168.0.6:31429/api/agents/register` (full) work
- [ ] Tag `v1.1.4` final once soak is green