### PR TITLE
feat(cluster-shell): audit helm alongside kubectl + pin KUBE_EDITOR=nano

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ tag.
 
 ## [Unreleased]
 
+### Changed
+
+- **Cluster-shell audit now covers `helm` invocations alongside
+  `kubectl`.** The in-pod wrapper (`periscope-audit-kubectl`) has been
+  generalized to `periscope-audit-exec`, keys off `argv[0]` to dispatch,
+  and both `/usr/local/bin/kubectl` and `/usr/local/bin/helm` symlink
+  to it. The `commands: [...]` slice on `cluster_shell_close` audit
+  rows now includes helm command lines that previously only showed up
+  as aggregate `bytes_in` / `bytes_out`. Wire-shape note for downstream
+  audit consumers: entries with `argv[0]` ending in `helm` will now
+  appear; filters keyed on kubectl-only need updating.
+- **`KUBE_EDITOR=nano` pinned in the shell image** so `kubectl edit`
+  works without operators having to export the env var themselves
+  (the image only ships nano; vi/vim are not installed).
+
 ### Added
 
 - **In-browser cluster shell ([#104](https://github.com/gnana997/periscope/issues/104)).**

--- a/Dockerfile.shell
+++ b/Dockerfile.shell
@@ -46,7 +46,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
-    -o /out/periscope-audit-kubectl \
+    -o /out/periscope-audit-exec \
     ./cmd/periscope-shell/wrapper
 
 # ---- tool fetch ----
@@ -121,32 +121,43 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --gid 1000 periscope \
     && useradd --uid 1000 --gid 1000 --shell /bin/bash --create-home periscope
 
-# Tools — real kubectl at /opt/periscope/bin/kubectl-real; the
-# /usr/local/bin/kubectl symlink below points at the audit wrapper so
-# every shell-session kubectl invocation flows through it. helm has
-# no wrapper in this PR (per-command audit for helm is a follow-up).
+# Tools — real binaries land in /opt/periscope/bin/<name>-real; the
+# /usr/local/bin/<name> symlinks below all point at the same audit
+# wrapper, which keys off its own argv[0] to dispatch. Every
+# kubectl + helm invocation in the operator's session flows through
+# the wrapper and gets a JSON line in $PERISCOPE_SHELL_AUDIT_FILE.
+# Operators who deliberately want to bypass audit can call the
+# *-real binaries directly — that's the documented best-effort
+# contract for bash mode. The kubectl-only REPL in a follow-up PR
+# enforces audit in a way bash mode cannot.
 COPY --from=tool-fetch /tmp/tools/kubectl /opt/periscope/bin/kubectl-real
-COPY --from=tool-fetch /tmp/tools/helm    /opt/periscope/bin/helm
+COPY --from=tool-fetch /tmp/tools/helm    /opt/periscope/bin/helm-real
 
 # Periscope binaries.
-COPY --from=go-builder /out/periscope-shell          /periscope-shell
-COPY --from=go-builder /out/periscope-audit-kubectl  /opt/periscope/bin/periscope-audit-kubectl
+COPY --from=go-builder /out/periscope-shell        /periscope-shell
+COPY --from=go-builder /out/periscope-audit-exec   /opt/periscope/bin/periscope-audit-exec
 
-# Wire the wrapper into PATH at /usr/local/bin/kubectl. Bash sessions
-# resolve /usr/local/bin before /opt/periscope/bin, so any "kubectl"
-# invocation in the operator's session hits the wrapper. Operators
-# who deliberately want to bypass audit can call
-# /opt/periscope/bin/kubectl-real directly — that's the documented
-# best-effort contract for bash mode. The kubectl-only REPL in a
-# follow-up PR enforces audit in a way bash mode cannot.
-RUN ln -s /opt/periscope/bin/periscope-audit-kubectl /usr/local/bin/kubectl \
-    && ln -s /opt/periscope/bin/helm /usr/local/bin/helm \
+# Wire the wrapper into PATH at /usr/local/bin/{kubectl,helm}. Bash
+# sessions resolve /usr/local/bin before /opt/periscope/bin, so any
+# kubectl or helm invocation hits the wrapper first. Adding a new
+# wrapped tool is one more `ln -s` here plus matching entries in
+# wrappedCommands (cmd/periscope-shell/wrapper/main.go) and the
+# COPY above.
+RUN ln -s /opt/periscope/bin/periscope-audit-exec /usr/local/bin/kubectl \
+    && ln -s /opt/periscope/bin/periscope-audit-exec /usr/local/bin/helm \
     && mkdir -p /tmp/periscope-shell \
     && chown periscope:periscope /tmp/periscope-shell
+
+# kubectl edit (and other editor-using kubectl subcommands) default
+# to vi when KUBE_EDITOR / EDITOR aren't set. The shell image only
+# ships nano — pin the default here so operators don't hit a "vi:
+# command not found" footgun the first time they type
+# `kubectl edit deploy …`.
+ENV KUBE_EDITOR=nano
 
 USER 1000:1000
 
 # The session's KUBECONFIG, PERISCOPE_SHELL_* env, and other per-pod
 # config are set by Periscope on the pod spec — this image stays
-# config-free at build time.
+# config-free at build time apart from KUBE_EDITOR above.
 ENTRYPOINT ["/periscope-shell"]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The [What makes it different](#what-makes-it-different) section above is the sho
 - [Apply YAML dialog](docs/setup/apply-yaml.md) — paste/drop multi-doc YAML with per-doc RBAC pre-flight
 - [Multi-cluster onboarding (agent)](docs/setup/agent-onboarding.md) — register a managed cluster via the periscope-agent tunnel
 - [EKS upgrade readiness](docs/setup/eks-upgrade-readiness.md) — Upgrade Insights + managed node group AMI drift
+- [Troubleshooting](docs/setup/troubleshooting.md) — symptom-keyed index across every feature, plus cross-cutting gotchas (chart-versions OOM, scanner false-positives, local-dev TLS)
 
 **Usage**
 - [Karpenter dashboard](docs/usage/karpenter-view.md) — NodePool/$/hr/Drift/pending-pods walkthrough + cost-RBAC sample

--- a/cmd/periscope-shell/wrapper/main.go
+++ b/cmd/periscope-shell/wrapper/main.go
@@ -1,21 +1,24 @@
-// periscope-audit-kubectl — kubectl wrapper that ships in the
+// periscope-audit-exec — generic audit wrapper that ships in the
 // cluster-shell pod image (issue #104).
 //
-// The image symlinks /usr/local/bin/kubectl to this binary so any
-// kubectl invocation in a bash session transparently routes through
-// it. For each call we:
+// The image symlinks /usr/local/bin/kubectl AND /usr/local/bin/helm
+// (and future tools) at this one binary; the symlink name dictates
+// which real binary gets exec'd. For each call we:
 //
-//  1. Append a single JSON line to $PERISCOPE_SHELL_AUDIT_FILE
+//  1. Resolve which command the operator invoked from os.Args[0]:
+//     the symlink name (e.g. "kubectl" or "helm") is allow-listed
+//     against the table below and mapped to a real binary path under
+//     /opt/periscope/bin/<name>-real. Anything not on the allow-list
+//     errors with exit 127.
+//
+//  2. Append a single JSON line to $PERISCOPE_SHELL_AUDIT_FILE
 //     capturing timestamp, pid, and argv. Best-effort: failures to
 //     write the audit line are logged to stderr but NEVER block the
-//     operator's command. The operator typing "kubectl get pods"
-//     should never have their workflow break because Periscope
-//     couldn't persist an audit line.
+//     operator's command.
 //
-//  2. syscall.Exec into the real kubectl at
-//     /opt/periscope/bin/kubectl-real with the same argv and env.
-//     The wrapper process is replaced, so exit code, stdin, stdout,
-//     and stderr all pass through unchanged.
+//  3. syscall.Exec into the resolved real binary with the same argv
+//     and env. The wrapper process is replaced, so exit code, stdin,
+//     stdout, and stderr all pass through unchanged.
 //
 // Best-effort attribution means an operator who deliberately bypasses
 // the wrapper (e.g. by calling /opt/periscope/bin/kubectl-real
@@ -42,8 +45,19 @@ import (
 
 const (
 	envAuditFile = "PERISCOPE_SHELL_AUDIT_FILE"
-	realKubectl  = "/opt/periscope/bin/kubectl-real"
+	realBinDir   = "/opt/periscope/bin"
 )
+
+// wrappedCommands is the closed allow-list of commands this binary
+// audits. Adding a new wrapped tool is a one-line addition here PLUS
+// a matching `/opt/periscope/bin/<name>-real` install in
+// Dockerfile.shell PLUS a `/usr/local/bin/<name>` symlink at this
+// binary. Allow-list (not lenient-fallback) keeps the surface
+// auditable in a review.
+var wrappedCommands = map[string]string{
+	"kubectl": filepath.Join(realBinDir, "kubectl-real"),
+	"helm":    filepath.Join(realBinDir, "helm-real"),
+}
 
 // auditLine is the JSON shape appended per invocation. Field names
 // stay short — these lines are read by Periscope on every session
@@ -56,36 +70,79 @@ type auditLine struct {
 }
 
 func main() {
-	// Step 1: best-effort audit append. Stderr-only logging here —
-	// we deliberately do NOT use slog so we don't introduce a
-	// startup config dependency that could fail in a way the
-	// operator can't bypass. A single fprintf is enough.
-	if err := appendAudit(); err != nil {
-		fmt.Fprintf(os.Stderr, "periscope-audit-kubectl: audit append failed (continuing): %v\n", err)
+	// Step 1: resolve the real binary from the symlink name. Exit
+	// non-zero before touching the audit file if we can't map the
+	// invocation — a writer that doesn't know what to exec shouldn't
+	// pretend to audit it.
+	realBinary, err := resolveRealBinary(os.Args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "periscope-audit-exec: %v\n", err)
+		os.Exit(127) // POSIX "command not found"
 	}
 
-	// Step 2: exec the real kubectl. argv[0] is conventionally the
-	// program name; we pass the wrapper's argv[0] through so
-	// kubectl's own usage strings still print "kubectl" (and not
-	// "/opt/periscope/bin/kubectl-real") if the user runs
-	// "kubectl --help".
+	// Step 2: best-effort audit append. Stderr-only logging here —
+	// we deliberately do NOT use slog so we don't introduce a
+	// startup config dependency that could fail in a way the
+	// operator can't bypass.
+	if err := appendAudit(); err != nil {
+		fmt.Fprintf(os.Stderr, "periscope-audit-exec: audit append failed (continuing): %v\n", err)
+	}
+
+	// Step 3: exec the real binary. argv[0] is conventionally the
+	// program name; we pass the wrapper's argv[0] through so the
+	// real binary's own usage strings still print the symlink name
+	// (e.g. "kubectl" and not "/opt/periscope/bin/kubectl-real") if
+	// the user runs "kubectl --help".
 	args := append([]string{os.Args[0]}, os.Args[1:]...)
-	if err := syscall.Exec(realKubectl, args, os.Environ()); err != nil {
+	if err := syscall.Exec(realBinary, args, os.Environ()); err != nil {
 		// exec failure is fatal — the operator's command must run.
 		// Exit 126 follows the POSIX shell convention for "command
 		// found but not executable" so any wrapper-aware tooling
-		// can tell this apart from a non-zero kubectl exit.
-		fmt.Fprintf(os.Stderr, "periscope-audit-kubectl: exec %s failed: %v\n", realKubectl, err)
+		// can tell this apart from a non-zero exit from the real binary.
+		fmt.Fprintf(os.Stderr, "periscope-audit-exec: exec %s failed: %v\n", realBinary, err)
 		os.Exit(126)
 	}
+}
+
+// resolveRealBinary maps an invocation path (typically os.Args[0])
+// to the absolute path of the real binary to exec. Returns an error
+// when the basename isn't on the allow-list — caller handles exit.
+// Factored out so it's testable without subprocess plumbing.
+func resolveRealBinary(invocation string) (string, error) {
+	cmdName := filepath.Base(invocation)
+	realBinary, ok := wrappedCommands[cmdName]
+	if !ok {
+		return "", fmt.Errorf("unknown wrapped command %q (allow-list: %s)",
+			cmdName, allowListNames())
+	}
+	return realBinary, nil
+}
+
+// allowListNames returns the wrapped-command names sorted for stable
+// error output. Tiny helper used only by the unrecognized-name path.
+func allowListNames() string {
+	names := make([]string, 0, len(wrappedCommands))
+	for name := range wrappedCommands {
+		names = append(names, name)
+	}
+	// 2 entries today — a manual bubble sort would do, but this keeps
+	// the helper future-proof.
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[j] < names[i] {
+				names[i], names[j] = names[j], names[i]
+			}
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 func appendAudit() (retErr error) {
 	path := strings.TrimSpace(os.Getenv(envAuditFile))
 	if path == "" {
 		// No audit file configured → silently skip. This makes the
-		// binary usable as a transparent kubectl wrapper outside of
-		// the cluster-shell pod (e.g. in tests, local invocations)
+		// binary usable as a transparent wrapper outside of the
+		// cluster-shell pod (e.g. in tests, local invocations)
 		// without it failing on a missing env var.
 		return nil
 	}
@@ -100,7 +157,7 @@ func appendAudit() (retErr error) {
 	line := auditLine{
 		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 		PID:       os.Getpid(),
-		Argv:      os.Args, // argv[0] preserved for forensic context — usually "/usr/local/bin/kubectl"
+		Argv:      os.Args, // argv[0] preserved for forensic context — usually "/usr/local/bin/<name>"
 	}
 	buf, err := json.Marshal(line)
 	if err != nil {
@@ -110,7 +167,7 @@ func appendAudit() (retErr error) {
 	// O_APPEND on POSIX guarantees atomic writes up to PIPE_BUF
 	// (4096 bytes on Linux). A single auditLine — even with a
 	// pathological argv — is comfortably under that, so concurrent
-	// kubectl invocations from a backgrounded shell pipeline can't
+	// invocations from a backgrounded shell pipeline can't
 	// interleave bytes.
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {

--- a/cmd/periscope-shell/wrapper/main_test.go
+++ b/cmd/periscope-shell/wrapper/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRealBinary(t *testing.T) {
+	tests := []struct {
+		name        string
+		invocation  string
+		wantPath    string
+		wantErrFrag string
+	}{
+		{
+			name:       "kubectl via symlink in /usr/local/bin",
+			invocation: "/usr/local/bin/kubectl",
+			wantPath:   "/opt/periscope/bin/kubectl-real",
+		},
+		{
+			name:       "helm via symlink in /usr/local/bin",
+			invocation: "/usr/local/bin/helm",
+			wantPath:   "/opt/periscope/bin/helm-real",
+		},
+		{
+			name:       "kubectl via bare name (PATH lookup)",
+			invocation: "kubectl",
+			wantPath:   "/opt/periscope/bin/kubectl-real",
+		},
+		{
+			name:        "unknown basename returns error with allow-list",
+			invocation:  "/usr/local/bin/kustomize",
+			wantErrFrag: `unknown wrapped command "kustomize"`,
+		},
+		{
+			name:        "direct invocation by binary basename errors",
+			invocation:  "/opt/periscope/bin/periscope-audit-exec",
+			wantErrFrag: `unknown wrapped command "periscope-audit-exec"`,
+		},
+		{
+			name:        "empty invocation errors",
+			invocation:  "",
+			wantErrFrag: `unknown wrapped command "."`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRealBinary(tt.invocation)
+			if tt.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (path=%s)", tt.wantErrFrag, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrFrag) {
+					t.Fatalf("error %q does not contain expected fragment %q", err.Error(), tt.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantPath {
+				t.Errorf("path mismatch: got %s, want %s", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestAllowListNamesSorted(t *testing.T) {
+	got := allowListNames()
+	// Both expected entries must be present and ordered alphabetically.
+	// This is what the unrecognized-name error surface shows operators,
+	// so stable ordering matters for grep-by-error-text.
+	want := "helm, kubectl"
+	if got != want {
+		t.Errorf("allowListNames() = %q, want %q", got, want)
+	}
+}
+
+func TestAppendAudit_WritesNDJSON(t *testing.T) {
+	dir := t.TempDir()
+	auditPath := filepath.Join(dir, "subdir", "audit.jsonl")
+	t.Setenv(envAuditFile, auditPath)
+
+	// First invocation should create the file + parent directory.
+	if err := appendAudit(); err != nil {
+		t.Fatalf("first appendAudit: %v", err)
+	}
+	// Second invocation should append, not truncate.
+	if err := appendAudit(); err != nil {
+		t.Fatalf("second appendAudit: %v", err)
+	}
+
+	f, err := os.Open(auditPath)
+	if err != nil {
+		t.Fatalf("open audit file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	var lines []auditLine
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line auditLine
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("parse line %q: %v", scanner.Text(), err)
+		}
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit lines, got %d", len(lines))
+	}
+	for i, line := range lines {
+		if line.Timestamp == "" {
+			t.Errorf("line %d: empty timestamp", i)
+		}
+		if line.PID == 0 {
+			t.Errorf("line %d: zero PID", i)
+		}
+		if len(line.Argv) == 0 {
+			t.Errorf("line %d: empty argv", i)
+		}
+	}
+}
+
+func TestAppendAudit_NoEnvIsSilentNoop(t *testing.T) {
+	// Explicitly unset (Setenv to "") simulates the binary being run
+	// outside of a cluster-shell pod (e.g. from a developer's laptop).
+	t.Setenv(envAuditFile, "")
+	if err := appendAudit(); err != nil {
+		t.Errorf("expected nil error when env var unset, got %v", err)
+	}
+}
+
+func TestAppendAudit_WhitespaceEnvTreatedAsUnset(t *testing.T) {
+	t.Setenv(envAuditFile, "   ")
+	if err := appendAudit(); err != nil {
+		t.Errorf("expected nil error when env var whitespace-only, got %v", err)
+	}
+}

--- a/docs/setup/agent-onboarding.md
+++ b/docs/setup/agent-onboarding.md
@@ -290,6 +290,8 @@ with the correct value.
 
 ## Troubleshooting
 
+> Cross-cutting issues (production gotchas, scanner false-positives, local-dev TLS) live in [troubleshooting.md](troubleshooting.md). This section covers agent-registration and tunnel-specific failure modes.
+
 ### Turn on debug logging on the agent
 
 When something goes wrong between agent registration and the cluster

--- a/docs/setup/audit.md
+++ b/docs/setup/audit.md
@@ -336,6 +336,8 @@ curl -s -i http://localhost:8088/api/audit | grep X-Audit-Scope
 
 ## Troubleshooting
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers the audit pipeline (SQLite sink, retention, identity scope).
+
 **`/api/audit` returns 404**
 → `audit.enabled=false` in your values, OR the SQLite sink failed to
 open. Check pod logs for `audit: sqlite disabled (open failed)`.

--- a/docs/setup/auth0.md
+++ b/docs/setup/auth0.md
@@ -204,6 +204,8 @@ Login flow (it's an easy step to skip).
 
 ## Common pitfalls
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers Auth0-specific OIDC mistakes.
+
 - **`groups` claim missing.** The Action wasn't added to the Login
   flow, or the namespaced claim name in `auth.yaml: groupsClaim`
   doesn't match the one in the Action code.

--- a/docs/setup/cluster-rbac.md
+++ b/docs/setup/cluster-rbac.md
@@ -406,6 +406,8 @@ but the rest of the deployment is unchanged.
 
 ## Common pitfalls
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers tier-mode RBAC mistakes specifically.
+
 - **Tier mode user gets 403 on everything.** Either `defaultTier: ""`
   is denying them (they're in no listed group), or the chart's
   `cluster-rbac.yaml` was never applied to the cluster they're hitting.

--- a/docs/setup/cluster-shell.md
+++ b/docs/setup/cluster-shell.md
@@ -331,6 +331,8 @@ The full RBAC posture writeup is in
 
 ## 9. Troubleshooting
 
+> Cross-cutting issues (chart-versions OOM, scanner false-positives, local-dev TLS, image-pull behind a corporate proxy) live in [troubleshooting.md](troubleshooting.md).
+
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | **Shell button missing on the cluster header** | Backend says `clusterShellEnabled=false` on this cluster | Check `/api/clusters` response; confirm `clusterShell.enabled=true` on the server helm release |

--- a/docs/setup/cluster-shell.md
+++ b/docs/setup/cluster-shell.md
@@ -221,11 +221,19 @@ Each session creates one ephemeral pod in `clusterShell.namespace`
   `PERISCOPE_SHELL_SESSION_ID` / `PERISCOPE_SHELL_MODE` /
   `PERISCOPE_SHELL_AUDIT_FILE`, then `syscall.Exec`s into
   `/bin/bash --login` with `KUBECONFIG=/etc/periscope/kubeconfig`.
-- **kubectl wrapper:** `/usr/local/bin/kubectl` is a symlink to
-  `periscope-audit-kubectl`, a tiny Go wrapper that appends a JSON
-  audit line for the command + argv before `syscall.Exec`-ing into
-  the real kubectl at `/opt/periscope/bin/kubectl-real`. Best-effort
-  — audit write failure does NOT block the kubectl invocation.
+- **Audit wrapper:** `/usr/local/bin/kubectl` AND `/usr/local/bin/helm`
+  are both symlinks to `periscope-audit-exec`, a tiny Go wrapper that
+  keys off its own `argv[0]` to figure out which real binary to invoke
+  (`kubectl-real` / `helm-real` under `/opt/periscope/bin/`). For every
+  call it appends a `{ts, pid, argv}` JSON line to the in-pod audit
+  file before `syscall.Exec`-ing the real binary. Best-effort — audit
+  write failure does NOT block the command. Adding a new wrapped tool
+  is a one-line allow-list entry in the wrapper plus a matching
+  symlink in `Dockerfile.shell`.
+- **`KUBE_EDITOR=nano` pinned in the image** so `kubectl edit` (and
+  other editor-using subcommands) work without operators having to
+  set the variable themselves. The image only ships `nano`; vi/vim
+  are not installed.
 
 The pod is deleted on session close (clean `exit` / Ctrl-D / WS close
 / idle-timeout). Pod + Secret cleanup is idempotent and runs even on
@@ -283,9 +291,16 @@ that joins the SPA-side audit row to the apiserver's own audit log is
 
 The `commands` slice on `cluster_shell_close` is read from the
 in-pod audit file (`PERISCOPE_SHELL_AUDIT_FILE`) via a final exec
-stream during teardown. Best-effort: a pod that died before the
-readback completes loses its command log, but the open / close
-envelopes are durable.
+stream during teardown. It captures every `kubectl` and `helm`
+invocation made through the session (both wrapped by the
+`periscope-audit-exec` binary). Other commands (`cat`, `jq`,
+`grep`, bash builtins) don't write per-invocation rows here — they
+still contribute to the `bytes_in` / `bytes_out` counters, and any
+K8s API calls they trigger show up in the apiserver audit log
+keyed by the session UUID.
+
+Best-effort: a pod that died before the readback completes loses
+its command log, but the open / close envelopes are durable.
 
 ---
 

--- a/docs/setup/eks-upgrade-readiness.md
+++ b/docs/setup/eks-upgrade-readiness.md
@@ -143,6 +143,8 @@ These are the first **read verbs** in Periscope's audit taxonomy — every other
 
 ## Troubleshooting
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers EKS-specific failure modes.
+
 **"Drift not computed" on every AWS-managed node group.** Almost certainly an IAM issue. Check the periscope pod's logs for `eks ami catalog: ssm lookup failed` — the wrapped error names the missing permission. The 30-minute sticky-error cache means a fresh permission grant takes up to half an hour to take effect; restart the pod to apply immediately.
 
 **"Drift not computed" on Windows or FIPS node groups.** Expected. The catalog does not cover those variants in v1; see *What is NOT in the surface* above.

--- a/docs/setup/okta.md
+++ b/docs/setup/okta.md
@@ -174,6 +174,8 @@ permissive enough).
 
 ## Common pitfalls
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers Okta-specific OIDC mistakes.
+
 - **`groups` claim is empty in the ID token.** Either the claim isn't
   configured (5) or the user isn't a member of any group that
   matches the claim filter. Fix by widening the filter to `.*` while

--- a/docs/setup/pod-exec.md
+++ b/docs/setup/pod-exec.md
@@ -278,6 +278,8 @@ audit persistence is on; see [`audit.md`](./audit.md)).
 
 ## 8. Troubleshooting
 
+> For cross-cutting issues that aren't pod-exec specific (chart-versions OOM, scanner false-positives, local-dev TLS, etc.) see [troubleshooting.md](troubleshooting.md).
+
 ### "Open Shell" button is missing
 
 Pod is on a cluster with `exec.enabled: false`, **or** the user lacks

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -1,0 +1,292 @@
+# Troubleshooting
+
+A symptom-keyed index for things that surface during Periscope
+installs, upgrades, and day-2 operation. Most feature-specific
+issues are documented inline with the feature — this page indexes
+them so an operator can grep by what they saw, plus adds
+cross-cutting items (chart-versions OOM, network changes, scanner
+false-positives) that don't fit a single feature doc.
+
+If you don't find your symptom here, the most diagnostic single
+file is the Periscope pod's slog stream — every privileged action
+gets a structured line, and every request carries an
+`X-Request-Id` that grep-joins to the matching audit row.
+
+---
+
+## Quick lookup
+
+| Symptom | Where |
+|---|---|
+| "Open Shell" button missing on a pod page | [pod-exec.md §8](pod-exec.md#troubleshooting) |
+| Shell button missing on a cluster page header | [cluster-shell.md §9](cluster-shell.md#9-troubleshooting) |
+| WebSocket upgrade fails / instant disconnect | [pod-exec.md](pod-exec.md#websocket-upgrade-fails-instant-disconnect) |
+| `E_FORBIDDEN` on cluster-shell click | [cluster-shell.md §9](cluster-shell.md#9-troubleshooting) |
+| Shell session pod stays `Pending` >30s | [cluster-shell.md §9](cluster-shell.md#9-troubleshooting) — also see [below](#cluster-shell-pod-stuck-pending-behind-an-outbound-proxy) |
+| Helm command not in `cluster_shell_close.commands[]` | Upgraded? On v1.1.5+ helm is audited; pre-v1.1.5 it isn't ([CHANGELOG](../../CHANGELOG.md)) |
+| Tier user gets 403 on everything | [cluster-rbac.md](cluster-rbac.md#common-pitfalls) |
+| `groups` claim missing / empty | [okta.md](okta.md#common-pitfalls) / [auth0.md](auth0.md#common-pitfalls) |
+| Login bounces to IdP forever | [okta.md](okta.md#common-pitfalls) / [auth0.md](auth0.md#common-pitfalls) |
+| Refresh fails after N hours | [okta.md](okta.md#common-pitfalls) / [auth0.md](auth0.md#common-pitfalls) |
+| `Callback URL mismatch` / `Sign-in redirect URI mismatch` | [okta.md](okta.md#common-pitfalls) / [auth0.md](auth0.md#common-pitfalls) |
+| Audit page shows nothing / `auditEnabled: false` | [audit.md](audit.md#troubleshooting) |
+| `X-Audit-Scope: self` for an admin user | [audit.md](audit.md#troubleshooting) |
+| Audit DB grows past `maxSizeMB` | [audit.md](audit.md#troubleshooting) |
+| SSE drops every ~60 seconds | [watch-streams.md §7](watch-streams.md#7-troubleshooting) |
+| Watch stream returns 404 immediately | [watch-streams.md §7](watch-streams.md#7-troubleshooting) |
+| Watch stream cap reached | [watch-streams.md §7](watch-streams.md#7-troubleshooting) |
+| Page updates feel polled, not live | [watch-streams.md §7](watch-streams.md#7-troubleshooting) |
+| EKS "Drift not computed" | [eks-upgrade-readiness.md](eks-upgrade-readiness.md#troubleshooting) |
+| EKS Upgrade Insights "load failed" | [eks-upgrade-readiness.md](eks-upgrade-readiness.md#troubleshooting) |
+| Agent registration `tls: certificate required` | [agent-onboarding.md](agent-onboarding.md#troubleshooting) |
+| Agent registration `SPKI pin mismatch` | [agent-onboarding.md](agent-onboarding.md#troubleshooting) |
+| Agent registration `registration rejected` (HTTP 401) | [agent-onboarding.md](agent-onboarding.md#troubleshooting) |
+| Agent connects, then drops every few seconds | [agent-onboarding.md](agent-onboarding.md#troubleshooting) |
+| Cluster card stuck "unreachable" | [agent-onboarding.md](agent-onboarding.md#troubleshooting) |
+| Periscope pod OOMKilled when listing chart versions | [below](#periscope-pod-oomkilled-when-listing-helm-chart-versions) |
+| Artifact Hub flags HIGH/MEDIUM CVE on a clean image | [below](#artifact-hub-shows-highmedium-cve-that-upstream-rates-low) |
+| Agent tunnel reconnect churn after the central LB changes IP | [below](#agent-tunnel-reconnect-churn-after-the-central-lb-rotates-ip) |
+| Local microk8s: TLS cert error after switching networks | [below](#microk8s-apiserver-tls-cert-mismatch-after-switching-networks) |
+
+---
+
+## Production gotchas
+
+### Periscope pod OOMKilled when listing helm chart versions
+
+**Symptom**: SPA fetches `/api/clusters/{c}/helm/chart/versions`
+against a public helm repo with a large `index.yaml`
+(`prometheus-community`, `bitnami`, `ingress-nginx`, etc.) and
+the Periscope pod restarts. `kubectl describe` shows
+`Last State: Terminated, Reason: OOMKilled, Exit Code: 137`.
+
+**Cause**: the handler reads the entire `index.yaml` into memory
+and `yaml.Unmarshal`s it in one shot. For `prometheus-community`
+(5–10 MB index.yaml), the burst hits ~600–700 MiB RSS — well past
+the chart default `resources.limits.memory: 512Mi`. The pod is
+OOM-killed mid-request; ingress-nginx surfaces this as a 503.
+
+**Fix**: bump the memory limit while a streaming-parse follow-up
+lands. 1Gi is comfortable headroom for every public helm repo we've
+benchmarked:
+
+```yaml
+# values.yaml
+resources:
+  requests:
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+```
+
+Apply with `helm upgrade periscope ... --reuse-values --set resources.limits.memory=1Gi`.
+
+**Notes**:
+
+- The 5-minute `chartVersionsCache` only helps the *second* request —
+  first fetch after pod start still pays the full burst.
+- Affects all backends equally (in-cluster, agent, eks, kubeconfig).
+- Steady-state Periscope RSS is ~200 MiB; the bump is for the chart-
+  versions burst alone.
+- The streaming-parse fix tracks under the helm-chart-versions
+  endpoint refactor — once it lands, the 1Gi bump can revert.
+
+---
+
+### Cluster-shell pod stuck Pending behind an outbound proxy
+
+**Symptom**: Operator clicks the **shell** button. The drawer opens,
+the WebSocket connects, but the terminal sits at "starting…" for
+>30 seconds. `kubectl -n periscope-system describe pod periscope-shell-*`
+shows `Failed: ErrImagePull` / `ImagePullBackOff` against
+`ghcr.io/gnana997/periscope-shell:<version>`.
+
+**Cause**: the cluster's container runtime can't reach `ghcr.io` —
+typically because the cluster is air-gapped, the egress runs through
+a corporate proxy that doesn't allow `ghcr.io`, or the proxy needs
+auth not configured on the kubelet.
+
+**Fix**: mirror the shell image into the registry the cluster *can*
+reach, then point the chart at it:
+
+```yaml
+# Server chart (values.yaml)
+clusterShell:
+  enabled: true
+  image:
+    repository: registry.internal.acme.com/periscope/periscope-shell
+    tag: v1.1.5  # match your installed periscope version
+    pullPolicy: IfNotPresent
+
+# Agent chart (per managed cluster) — only needed if you use the
+# agent backend and the kubelet on managed clusters also can't reach
+# ghcr.io. Same value, applied separately because the agent and
+# server can be sized for different network postures.
+```
+
+The shell image is opt-in (default `clusterShell.enabled: false`),
+so operators who don't use cluster shell never pull it. Once
+mirrored, operators on locked-down clusters get the same in-browser
+experience without punching a hole through their egress policy.
+
+**Notes**:
+
+- The `clusterShell.podStartTimeoutSeconds` (default 30s) determines
+  how long Periscope waits before returning `E_SHELL_POD_TIMEOUT` —
+  bump it if your mirror is slow on first pull, but the underlying
+  issue is registry reachability, not timeout tuning.
+- The shell image is multi-arch (linux/amd64 + linux/arm64), so a
+  one-time `crane copy` or equivalent into your mirror works for both.
+
+---
+
+### Agent tunnel reconnect churn after the central LB rotates IP
+
+**Symptom**: The agent log on a managed cluster shows a steady cadence
+of:
+
+```
+agent.dial_attempt   server=wss://...:8443/api/agents/connect
+agent.dial_failed    err=...
+agent.reconnect_in   seconds=8
+```
+
+The central server's cluster registry shows the cluster as
+"unreachable" or flickering between connected/unreachable.
+
+**Cause**: the agent's `serverURL` was set at install time. If the
+LB / Ingress IP behind that URL changes — e.g. AWS NLB rotates a
+node IP, a hostname-based serverURL DNS-cache TTL expires and resolves
+new, or the central Periscope LB was reprovisioned — there's a brief
+window where the agent's cached DNS / TCP connection is wrong.
+
+**Why it usually self-heals**: the agent's reconnect supervisor
+(`internal/tunnel`) backs off `[0, 1s, 3s, 8s]` with a max 30s
+ceiling and re-dials from scratch each cycle. DNS re-resolves on
+each dial. A 1-2 minute window of churn is the typical signature of
+an LB rotation; longer means something else broke.
+
+**When to act**:
+
+- **Hostname-based `serverURL`**: usually nothing to do; DNS TTL
+  expires and reconnect succeeds. If your DNS TTL is unusually long
+  (>5 min), consider lowering it on the Periscope server's record
+  to shorten the churn window.
+- **IP-based `serverURL`** (rare in production — typically dev rigs
+  or temporary topologies): you'll need to `helm upgrade` the agent
+  with the new IP. After upgrade the agent reads the new value from
+  the rendered env, reconnects on the next dial.
+
+**Diagnostic**: turn on agent debug logging to see the per-attempt
+detail (DNS resolution, TCP error, TLS handshake) — see
+[agent-onboarding.md → Turn on debug logging on the agent](agent-onboarding.md#turn-on-debug-logging-on-the-agent).
+
+---
+
+## Local-development gotchas
+
+### microk8s apiserver TLS cert mismatch after switching networks
+
+**Symptom**: After moving your laptop between networks (wifi → hotspot,
+office → home, etc.), `kubectl port-forward` against a local microk8s
+cluster fails with:
+
+```
+error: error upgrading connection: error dialing backend: tls: failed
+to verify certificate: x509: certificate is valid for 192.168.0.6,
+172.17.0.1, 172.18.0.1, ..., not 172.20.10.3
+```
+
+The new IP (`172.20.10.3` here) is wherever your laptop landed after
+the network swap.
+
+**Cause**: this is a **snap-microk8s + mobile-laptop interaction, not
+a Periscope issue.** Three ingredients combine to produce it:
+
+1. microk8s's apiserver binds to `0.0.0.0` (every interface, including
+   ones that come and go with your network).
+2. The apiserver TLS cert was minted at install time with the host's
+   IPs *at that moment* — your wifi IP became a SAN, but your hotspot
+   IP didn't exist yet.
+3. microk8s runs an interface-watcher daemon that **rewrites your
+   kubeconfig's `server:` line** when it sees a new primary IP. So
+   kubectl now dials the new IP, the apiserver answers, and Go's
+   x509 verifier rejects the cert.
+
+Production clusters don't combine these three. Cloud-managed K8s
+(EKS, GKE, AKS) reach apiserver via stable DNS, cert covers the DNS
+name. kind binds to localhost only, never touches your host IPs.
+k3s defaults to localhost-only kubeconfig. **Only snap-microk8s
+combined with a moving laptop trips all three.**
+
+**Fix (non-destructive, ~30 seconds of apiserver downtime, no workload
+disruption)**:
+
+```bash
+sudo microk8s refresh-certs -e server.crt
+```
+
+This regenerates the apiserver cert with current host IPs in the SAN
+list. Pods keep running through the brief apiserver restart; kubelets
+reconnect; in-flight `kubectl` calls retry transparently.
+
+**Durable fix (one-time setup, ~10 minutes)**: pin the apiserver to a
+stable hostname your network state can't change:
+
+1. Add a hosts entry: `echo "127.0.0.1 periscope-dev.local" | sudo tee -a /etc/hosts`
+2. Edit `/var/snap/microk8s/current/certs/csr.conf.template`, add `DNS.5 = periscope-dev.local`
+3. `sudo microk8s refresh-certs -e server.crt`
+4. Update kubeconfig's `server:` line to `https://periscope-dev.local:16443`
+5. For Periscope-agent installs, set `agent.serverURL=wss://periscope-dev.local:31410` (or whatever your tunnel port is)
+
+After this, you can swap networks freely without breaking kubectl,
+helm, or the agent tunnel.
+
+**Note for cluster operators**: the durable fix is what production
+clusters do anyway (stable hostname, cert pinned to the hostname).
+A laptop dev rig is the only place this gets tricky.
+
+**See also**: [local-dev.md](local-dev.md) if it exists, otherwise this
+entry is the canonical place.
+
+---
+
+## Periscope-binary-side: making slog the diagnostic surface
+
+Almost every entry on this page can be confirmed (or ruled out) by
+grepping the Periscope pod's slog stream for matching keys. The
+binary writes structured JSON; relevant fields per scenario:
+
+| Scenario | What to grep |
+|---|---|
+| OOM during chart-versions | `helm chart versions` (handler name) + check pod `RestartCount` |
+| Cluster-shell pod won't start | `cluster_shell.pod_create`, `cluster_shell.pod_wait_ready` |
+| Agent tunnel issues | `tunnel.*`, `agent.session_event`, `agent.dial_*` |
+| OIDC / auth issues | `auth.*`, look for `groups` field on the line |
+| Watch streams | `watch.stream_open`, `watch.stream_close` |
+| Audit pipeline | `audit:`, especially around startup |
+
+All log lines carry an `X-Request-Id` that the audit pipeline also
+records on the corresponding audit row — one ID grepped across the
+two surfaces gives a complete end-to-end trace.
+
+For agent-backed clusters, the same request_id appears in **both**
+the central server's stdout AND the agent's stdout (when
+`agent.logLevel: debug`), so an end-to-end trace across three logs
+is one `grep` of the same UUID.
+
+---
+
+## See also
+
+| File | What's there |
+|---|---|
+| [pod-exec.md](pod-exec.md) §8 | Pod exec session troubleshooting (4 entries) |
+| [cluster-shell.md](cluster-shell.md) §9 | Cluster shell troubleshooting (8 entries) |
+| [agent-onboarding.md](agent-onboarding.md#troubleshooting) | Agent registration + tunnel troubleshooting |
+| [audit.md](audit.md#troubleshooting) | Audit pipeline issues |
+| [watch-streams.md](watch-streams.md#7-troubleshooting) | SSE watch stream issues |
+| [eks-upgrade-readiness.md](eks-upgrade-readiness.md#troubleshooting) | EKS Upgrade Insights / AMI drift |
+| [cluster-rbac.md](cluster-rbac.md#common-pitfalls) | Tier mode / RBAC binding mistakes |
+| [okta.md](okta.md#common-pitfalls) | Okta-specific OIDC mistakes |
+| [auth0.md](auth0.md#common-pitfalls) | Auth0-specific OIDC mistakes |

--- a/docs/setup/watch-streams.md
+++ b/docs/setup/watch-streams.md
@@ -189,6 +189,8 @@ kubectl -n periscope logs deploy/periscope | grep "watch streams"
 
 ## 7. Troubleshooting
 
+> Cross-cutting Periscope-pod issues live in [troubleshooting.md](troubleshooting.md). This section covers the SSE watch-stream surface specifically.
+
 ### SSE connections drop every ~minute
 
 Your proxy is killing idle connections faster than Periscope's

--- a/docs/usage/cluster-shell.md
+++ b/docs/usage/cluster-shell.md
@@ -44,10 +44,14 @@ to `clusterShell.tiers` or grant you a tier that is on the list.
 The shell pod's image is a thin debian-slim runtime carrying:
 
 - `kubectl` — pinned to a tested version (typically the latest
-  patch of the most recent minor)
-- `helm`
+  patch of the most recent minor). **Audited per-invocation.**
+- `helm` — pinned similarly. **Audited per-invocation** (since v1.1.5
+  every command line shows up in `cluster_shell_close.commands`).
 - `bash` with login profile + readline
-- `nano`, `jq`, `curl`, `coreutils`
+- `nano`, `jq`, `less`, `coreutils`
+- `KUBE_EDITOR=nano` pinned in the image, so `kubectl edit` works
+  out of the box without you setting the env var (vi/vim are not
+  installed)
 
 Your prompt looks like `root@periscope-shell-<uuid>:/$`. **You are
 running as root inside the pod**, but every kubectl call you make

--- a/internal/clustershell/audit_kubectl.go
+++ b/internal/clustershell/audit_kubectl.go
@@ -15,10 +15,14 @@ import (
 )
 
 // CommandLine is one record from the shell pod's audit.jsonl file —
-// emitted by the periscope-audit-kubectl wrapper, one per kubectl
-// invocation in bash mode. The JSON shape mirrors auditLine in
-// cmd/periscope-shell/wrapper/main.go; changing field names there
-// requires updating tag-matching here.
+// emitted by the periscope-audit-exec wrapper, one per wrapped-command
+// invocation (kubectl, helm) in bash mode. The JSON shape mirrors
+// auditLine in cmd/periscope-shell/wrapper/main.go; changing field
+// names there requires updating tag-matching here.
+//
+// Argv[0] preserved as-written, typically "/usr/local/bin/kubectl" or
+// "/usr/local/bin/helm" — use filepath.Base on it if you only want
+// the command name (the SPA does this for display).
 type CommandLine struct {
 	Timestamp string   `json:"ts"`
 	PID       int      `json:"pid"`
@@ -27,9 +31,10 @@ type CommandLine struct {
 
 // ReadCommandLog opens a fresh exec stream against the shell pod and
 // `cat`s the wrapper's audit.jsonl, returning the parsed records.
-// Bulk-on-close is the bash-mode attribution strategy for v1.2 — the
-// kubectl-only REPL in a follow-up PR replaces this with guaranteed
-// real-time per-command emission.
+// Covers all commands routed through periscope-audit-exec — currently
+// kubectl + helm. Bulk-on-close is the bash-mode attribution strategy
+// for v1.2; the kubectl-only REPL in a follow-up PR replaces this
+// with guaranteed real-time per-command emission.
 //
 // Best-effort: ANY error path returns an empty slice rather than
 // bubbling, because the pod is on its way to deletion and a


### PR DESCRIPTION
## Summary

Closes the audit gap surfaced from v1.1.5-rc2 e2e testing: `helm` invocations in the cluster shell ran fine but didn't land in the `cluster_shell_close.commands[]` slice — only `kubectl` was wrapped. This PR generalizes the in-pod wrapper, audits both, and pins `KUBE_EDITOR=nano` so `kubectl edit` works without operators having to set the env var themselves.

## Related issue / RFC

Follow-up to [#104](https://github.com/gnana997/periscope/issues/104). No new tracked issue — internal-audit cleanup.

## Why

The cluster-shell PR shipped `kubectl` as the only wrapped command, with a code comment saying helm was a follow-up. With the feature now in operator hands at v1.1.5-rc2, that gap shows up immediately when someone runs `helm get values`, `helm history`, etc. — those commands work but disappear from the per-session audit row, only contributing to aggregate `bytes_in` / `bytes_out`. Breaks the "single-log audit" story documented for the feature.

## What changes

- **`cmd/periscope-shell/wrapper/main.go`** — generic wrapper. Reads `argv[0]`, looks up the basename in an allow-list (`{kubectl: kubectl-real, helm: helm-real}`), execs the matching real binary. Unknown basename → exit 127 with the allow-list in the error. Adding a new wrapped tool is a one-line map entry plus a Dockerfile symlink — no code duplication.
- **`cmd/periscope-shell/wrapper/main_test.go`** (NEW, 146 LOC) — covers argv[0] derivation (kubectl, helm, unknown, empty), allow-list sort stability, and audit-append happy path + env-unset noop.
- **`Dockerfile.shell`** — binary output renamed `periscope-audit-kubectl` → `periscope-audit-exec`; helm's real binary moves to `/opt/periscope/bin/helm-real`; second symlink `/usr/local/bin/helm` → wrapper; `ENV KUBE_EDITOR=nano` added.
- **`internal/clustershell/audit_kubectl.go`** — doc-only refresh; the reader was already binary-agnostic so no logic change.
- **`docs/setup/cluster-shell.md`** + **`docs/usage/cluster-shell.md`** — describe the expanded wrapper scope, the KUBE_EDITOR pin, and refine the "what runs inside" list (drop `curl` which isn't actually in the runtime image, add `less`).
- **`CHANGELOG.md`** — Unreleased entry under Changed. Includes a wire-shape note for downstream audit consumers: rows with `argv[0]` ending in `helm` will now appear; consumers that hard-filtered on kubectl-only need updating.

## Surfaces touched

- [ ] HTTP API
- [ ] Helm values
- [ ] OIDC / auth / authz
- [x] Audit (`cluster_shell_close.commands[]` value set grows; schema unchanged)
- [ ] Agent backend / tunnel
- [ ] SPA / frontend
- [x] Documentation

## How was this tested

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./cmd/periscope-shell/wrapper/... -v` — 5 new tests pass
- `go test ./internal/clustershell/... ./cmd/periscope-shell/...` clean
- Multi-arch local `docker build -f Dockerfile.shell` succeeded
- Inside the built image: confirmed both `/usr/local/bin/kubectl` and `/usr/local/bin/helm` symlink to `/opt/periscope/bin/periscope-audit-exec`. Ran `kubectl version --client` + `helm version --short` with `PERISCOPE_SHELL_AUDIT_FILE=/tmp/audit.jsonl`; both invocations produced a JSON line in the audit file with correct argv arrays:

      {"ts":"2026-06-08T08:50:55.027Z","pid":7,"argv":["kubectl","version","--client"]}
      {"ts":"2026-06-08T08:50:55.147Z","pid":29,"argv":["helm","version","--short"]}

- Confirmed `KUBE_EDITOR=nano` set in the runtime environment.

## Wire-shape compatibility

The audit-row schema for `cluster_shell_close.commands[]` is unchanged: `{ts, pid, argv}`. The set of *values* of `argv[0]` grows (no longer kubectl-only). SPA / audit consumers using the existing schema keep working; consumers that hard-filtered on kubectl will see new helm entries.

## Checklist

- [x] CONTRIBUTING.md re-read
- [x] Wrapper change is backward-compat for kubectl (same audit shape)
- [x] Tests added for the new code (allow-list dispatch + audit-append helpers)
- [x] Docs updated (setup + usage + CHANGELOG)