### PR TITLE
docs: cut v1.1.5 changelog + NodePort troubleshooting entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,21 @@ tag.
 
 ## [Unreleased]
 
-### Changed
+## [1.1.5] - 2026-06-08
 
-- **Cluster-shell audit now covers `helm` invocations alongside
-  `kubectl`.** The in-pod wrapper (`periscope-audit-kubectl`) has been
-  generalized to `periscope-audit-exec`, keys off `argv[0]` to dispatch,
-  and both `/usr/local/bin/kubectl` and `/usr/local/bin/helm` symlink
-  to it. The `commands: [...]` slice on `cluster_shell_close` audit
-  rows now includes helm command lines that previously only showed up
-  as aggregate `bytes_in` / `bytes_out`. Wire-shape note for downstream
-  audit consumers: entries with `argv[0]` ending in `helm` will now
-  appear; filters keyed on kubectl-only need updating.
-- **`KUBE_EDITOR=nano` pinned in the shell image** so `kubectl edit`
-  works without operators having to export the env var themselves
-  (the image only ships nano; vi/vim are not installed).
+Operator daily-driver milestone landing the headline v1.2-cycle
+feature one minor early: an in-browser cluster-wide kubectl REPL
+([#104](https://github.com/gnana997/periscope/issues/104)) backed
+by a per-session ephemeral pod, tier-narrow impersonation, and a
+single audit log that joins to the apiserver's own audit via a
+shared session UUID. Plus the audit wrapper now covers `helm` next
+to `kubectl`, a new operator-facing troubleshooting page indexes
+common gotchas across every feature, and the Go toolchain is bumped
+to 1.26.4 to clear three stdlib CVE rows from container scanners.
+
+Validated end-to-end across rc1 → rc2 → rc3 against both in-cluster
+and agent backends. Helm chart values are backward-compatible; the
+new `clusterShell.*` block is opt-in (default off).
 
 ### Added
 
@@ -56,6 +57,49 @@ tag.
   disabled). The SPA reads these to gate the shell button. The shape is
   per-cluster from day one so a future per-cluster override won't change the
   wire format.
+- **Operator-facing troubleshooting page**
+  ([`docs/setup/troubleshooting.md`](docs/setup/troubleshooting.md)) —
+  symptom-keyed quick-lookup table indexing every feature doc's troubleshooting
+  section, plus cross-cutting entries for issues that don't fit a single
+  feature (chart-versions OOM at the default 512Mi limit, cluster-shell pod
+  image-pull behind an outbound proxy, Artifact Hub scanner severity vs
+  upstream Go-team triage gap, agent tunnel reconnect churn on LB rotation,
+  local-microk8s TLS cert mismatch on network change, NodePort re-allocation
+  on full reinstall). Every feature doc gets a one-line backlink to the
+  cross-cutting page.
+- **Release pipeline builds + signs the cluster-shell pod image**
+  (`ghcr.io/gnana997/periscope-shell:<version>`) in parallel with the server
+  and agent images, with cosign + SLSA attestation, multi-arch (amd64 +
+  arm64), and the attestation bundle attached to the GitHub Release. Mirrors
+  the agent-image pattern.
+
+### Changed
+
+- **Cluster-shell audit now covers `helm` invocations alongside
+  `kubectl`.** The in-pod wrapper (`periscope-audit-kubectl`) has been
+  generalized to `periscope-audit-exec`, keys off `argv[0]` to dispatch,
+  and both `/usr/local/bin/kubectl` and `/usr/local/bin/helm` symlink
+  to it. The `commands: [...]` slice on `cluster_shell_close` audit
+  rows now includes helm command lines that previously only showed up
+  as aggregate `bytes_in` / `bytes_out`. Wire-shape note for downstream
+  audit consumers: entries with `argv[0]` ending in `helm` will now
+  appear; filters keyed on kubectl-only need updating.
+- **`KUBE_EDITOR=nano` pinned in the shell image** so `kubectl edit`
+  works without operators having to export the env var themselves
+  (the image only ships nano; vi/vim are not installed).
+
+### Security
+
+- **Go toolchain bumped from 1.26.3 to 1.26.4.** Clears three stdlib
+  CVE rows from Artifact Hub / Amazon Inspector aggregators:
+  CVE-2026-42504 (`mime/WordDecoder` quadratic parse), CVE-2026-27145
+  (`crypto/x509` hostname-parsing DoS), CVE-2026-42507 (`net/textproto`
+  error-string escaping). All three are LOW per the Go security team's
+  own triage; scanners that key off NVD CVSS base scores rate them
+  higher. None are reachable on Periscope's request path in practice;
+  bumping clears the scanner badges before this minor's GA. Patch-only
+  bump per upstream release notes — no behavior changes in `crypto/tls`,
+  `crypto/x509`, or any package Periscope uses.
 
 ## [1.1.4] - 2026-05-26
 

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -47,6 +47,7 @@ gets a structured line, and every request carries an
 | Artifact Hub flags HIGH/MEDIUM CVE on a clean image | [below](#artifact-hub-shows-highmedium-cve-that-upstream-rates-low) |
 | Agent tunnel reconnect churn after the central LB changes IP | [below](#agent-tunnel-reconnect-churn-after-the-central-lb-rotates-ip) |
 | Local microk8s: TLS cert error after switching networks | [below](#microk8s-apiserver-tls-cert-mismatch-after-switching-networks) |
+| Agent can't connect after a full reinstall (`connection refused`) | [below](#agent-cant-reach-the-central-server-after-a-full-reinstall-on-local-nodeport) |
 
 ---
 
@@ -184,6 +185,76 @@ detail (DNS resolution, TCP error, TLS handshake) — see
 ---
 
 ## Local-development gotchas
+
+### Agent can't reach the central server after a full reinstall on local NodePort
+
+**Symptom**: After uninstalling the central Periscope helm release and
+reinstalling it (e.g. testing a fresh-install flow on local microk8s or
+kind), the agent on a managed cluster crashloops with:
+
+```
+"err":"state: registration: POST register:
+  Post \"http://192.168.0.6:31429/api/agents/register\":
+  dial tcp 192.168.0.6:31429: connect: connection refused"
+```
+
+The IP looks right but the port doesn't answer.
+
+**Cause**: when the central Periscope service is exposed as
+`service.type: NodePort` (typical for local-dev rigs), Kubernetes
+**allocates a new random NodePort on every fresh install**. The
+agent's saved `serverURL` / `registrationURL` point at the *old*
+NodePorts, which the new service doesn't bind. TCP gets refused.
+
+In-place `helm upgrade --reuse-values` preserves NodePorts because
+the Service object isn't recreated. Only full uninstall → install
+triggers re-allocation.
+
+**Fix**:
+
+```bash
+# 1. Look up the new NodePorts
+microk8s kubectl -n periscope get svc periscope -o yaml \
+  | grep -A2 'nodePort:'
+# Example output:
+#     nodePort: 30733   (port 8080 — HTTP / registration)
+#     nodePort: 32167   (port 8443 — tunnel)
+
+# 2. Update the agent values
+sed -i \
+  -e 's|registrationURL: http://.*|registrationURL: http://<host>:30733|' \
+  -e 's|serverURL: wss://.*|serverURL: wss://<host>:32167|' \
+  kind-agent-values.yaml
+
+# 3. Helm upgrade the agent — agent reconnects on the new URL
+helm upgrade periscope-agent \
+  oci://ghcr.io/gnana997/charts/periscope-agent --version 1.1.5 \
+  -n periscope -f kind-agent-values.yaml
+```
+
+If the agent had not yet completed registration (TCP refused at the
+register step), the bootstrap token is still unused — you can keep
+it. If registration succeeded against the old install before the
+reinstall, the new central server doesn't have the agent's cert in
+its registry, so mint a fresh token from
+`POST /api/agents/tokens` and re-register.
+
+**To avoid**: for local-dev rigs that you might re-install repeatedly,
+pin the NodePort by patching the Service after install:
+
+```bash
+microk8s kubectl -n periscope patch svc periscope --type=json -p='[
+  {"op":"replace","path":"/spec/ports/0/nodePort","value":31429},
+  {"op":"replace","path":"/spec/ports/1/nodePort","value":31410}
+]'
+```
+
+The chart doesn't currently expose `service.nodePorts.*` overrides
+(values issue on the backlog). For production, use a LoadBalancer or
+Ingress — NodePorts would be cluster-internal only and not referenced
+from the agent values, so this issue doesn't apply.
+
+---
 
 ### microk8s apiserver TLS cert mismatch after switching networks
 


### PR DESCRIPTION
## Summary

Bundles two docs-only updates for the v1.1.5 release:

1. **`CHANGELOG.md` v1.1.5 cut** — promotes the Unreleased content under `## [1.1.5] - 2026-06-08` with a release-summary paragraph at the top. Adds entries that weren't yet in Unreleased (troubleshooting page, release-pipeline shell image build) and a Security section for the Go 1.26.4 bump from PR #242.
2. **One new troubleshooting entry** — NodePort re-allocation on full reinstall. Operators following `agent-onboarding.md` on a local-NodePort rig hit this when they do uninstall + reinstall (rather than `helm upgrade --reuse-values`), and their saved agent values point at the old (now unbound) ports.

## Related issue / RFC

None — pure documentation for the v1.1.5 release.

## What changes

- `CHANGELOG.md` — `[Unreleased]` content moves under new `[1.1.5] - 2026-06-08` header with summary paragraph + restructured into Added / Changed / Security. Fresh empty `[Unreleased]` left at the top.
- `docs/setup/troubleshooting.md` — new entry under Local-development gotchas; one new row in the quick-lookup table.

## Why no new release tag for the doc

This is the right pattern: docs that land on `main` flow straight to the website (`periscopehq.dev` syncs from `main` on next build) and the GitHub repo. No tag bump needed for documentation-only changes. v1.1.5 GA can be tagged from main once this PR lands.

## How was this tested

- The NodePort entry was discovered + reproduced during the v1.1.5-rc3 clean-slate install test. The Fix recipe in the entry is the exact recovery path that unblocked the agent during testing.
- The CHANGELOG content was assembled from the actual rc1 → rc2 → rc3 release notes (helm wrapper from #245, Go bump + shell image build from #242, cluster shell from #241).

## Surfaces touched

- [ ] HTTP API
- [ ] Helm values
- [ ] OIDC / auth / authz
- [ ] Audit / RBAC
- [ ] Agent backend / tunnel
- [ ] SPA / frontend
- [x] Documentation
- [x] CHANGELOG

## Checklist

- [x] No code change
- [x] No release-notable behavior change
- [x] Document-only — safe to land before v1.1.5 GA tag